### PR TITLE
fix(bus): enforce the reply tool via a turn-end nudge, synthesized net as fallback (#240/#215)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.187",
+      "version": "2.2.188",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.187",
+  "version": "2.2.188",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/discord/__tests__/discord-outbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-outbound.test.ts
@@ -48,6 +48,21 @@ describe("DiscordAdapter — outbound response.text", () => {
     expect(h.rest.sent[0]?.text).toBe("done");
   });
 
+  it("prefixes the synthesized notice on a safety-net delivery (#240)", async () => {
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "raw turn output", intent: "final", synthesized: true },
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(h.rest.sent[0]?.text.startsWith("⚠️")).toBe(true);
+    expect(h.rest.sent[0]?.text).toContain("without sending a reply");
+    expect(h.rest.sent[0]?.text).toContain("raw turn output");
+  });
+
   it("IGNORES the JSONL tailer's observability echo so replies aren't double-posted (#217)", async () => {
     // The silent-drop net (#217) wires the JSONL tailer into the live bus.
     // The tailer re-emits a raw per-block `response.text` for every assistant

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -42,6 +42,7 @@ import {
   type BusOrigin,
   type PermissionRequest,
   isTailerOriginEvent,
+  withSynthesizedNotice,
 } from "../../bus/types";
 import { createDiscordGateway } from "./gateway";
 import { join } from "node:path";
@@ -521,8 +522,11 @@ export class DiscordAdapter {
       const payload = event.payload as { text?: string };
       const text = typeof payload.text === "string" ? payload.text : "";
       if (!text) return;
+      // #240: label a silent-drop safety-net delivery so it is not mistaken for
+      // a curated reply (no-op for normal replies). Full text preserved.
+      const outText = withSynthesizedNotice(text, event.payload);
       for (const channelId of targetChannels) {
-        void this.safeSendMessage(channelId, text);
+        void this.safeSendMessage(channelId, outText);
       }
       return;
     }

--- a/src/adapters/slack/__tests__/slack.test.ts
+++ b/src/adapters/slack/__tests__/slack.test.ts
@@ -552,6 +552,21 @@ describe("SlackAdapter — response.text outbound", () => {
     expect(api.sent[0]?.text).toBe("on it");
   });
 
+  it("prefixes the synthesized notice on a safety-net delivery (#240)", async () => {
+    adapter = await startAdapter();
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "raw turn output", intent: "final", synthesized: true },
+    });
+    await waitFor(() => api.sent.length > 0);
+    expect(api.sent[0]?.text.startsWith("⚠️")).toBe(true);
+    expect(api.sent[0]?.text).toContain("without sending a reply");
+    expect(api.sent[0]?.text).toContain("raw turn output");
+  });
+
   it("ignores response.text for an unrelated agent", async () => {
     adapter = await startAdapter();
     bus.emit({

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -22,6 +22,7 @@ import {
   type BusOrigin,
   type PermissionRequest,
   isTailerOriginEvent,
+  withSynthesizedNotice,
 } from "../../bus/types";
 import { createSlackApi } from "./api";
 import { buildPermissionBlocks } from "./blocks";
@@ -626,8 +627,11 @@ export class SlackAdapter {
       this.logger.warn(`[slack-adapter] no channels for agent ${agentId}; dropping response.text`);
       return;
     }
+    // #240: label a silent-drop safety-net delivery so it is not mistaken for a
+    // curated reply (no-op for normal replies). Full text preserved.
+    const outText = withSynthesizedNotice(text, payload);
     for (const channelId of channels) {
-      await this.safePostMessage({ channel: channelId, text });
+      await this.safePostMessage({ channel: channelId, text: outText });
     }
   }
 

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -670,6 +670,40 @@ describe("TelegramAdapter — response.text outbound", () => {
     expect(edit?.parse_mode).toBe("HTML");
   });
 
+  it("prefixes a synthesized (safety-net) final with the uncurated-output notice (#240)", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "raw turn output", intent: "final", synthesized: true },
+    });
+    await waitFor(() => api.sendMessages.length > 0);
+    const sent = api.sendMessages[0];
+    expect(sent?.text.startsWith("⚠️")).toBe(true);
+    expect(sent?.text).toContain("without sending a reply");
+    // The full uncurated text is preserved (the safety net's whole point).
+    expect(sent?.text).toContain("raw turn output");
+  });
+
+  it("does NOT prefix a normal curated final (#240)", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "curated answer", intent: "final" },
+    });
+    await waitFor(() => api.sendMessages.length > 0);
+    expect(api.sendMessages[0]?.text).toBe("curated answer");
+  });
+
   it("IGNORES the JSONL tailer observability echo so replies are not double-posted (#217)", async () => {
     // The tailer re-emits a raw per-block response.text stamped with
     // _meta.source = "jsonl-tailer"; the real delivery comes from ingestReply

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -704,6 +704,53 @@ describe("TelegramAdapter — response.text outbound", () => {
     expect(api.sendMessages[0]?.text).toBe("curated answer");
   });
 
+  it("prefixes the notice on the edit-in-place path when a turn is live (#240)", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+
+    // Progress reply opens a live turn (fresh message + spinner) so the
+    // following final edits in place instead of sending fresh — the dominant
+    // path for a normal prompted turn, distinct from the send-fresh tests above.
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "working", intent: "progress" },
+    });
+    await waitFor(() => api.sendMessages.length === 1);
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "raw turn output", intent: "final", synthesized: true },
+    });
+    await waitFor(() => api.editMessages.some((e) => e.text.startsWith("⚠️")));
+    const edit = api.editMessages.find((e) => e.text.startsWith("⚠️"));
+    expect(edit?.text).toContain("without sending a reply");
+    expect(edit?.text).toContain("raw turn output");
+  });
+
+  it("does not emit a lone notice for a reaction-only synthesized final (#240)", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+
+    // Text is non-empty but becomes empty after reaction directives are
+    // stripped — the cleanedText.length>0 gate must suppress a bare notice.
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "[react:🪶]", intent: "final", synthesized: true },
+    });
+    await waitFor(() => api.reactions.length > 0);
+    expect(api.sendMessages).toHaveLength(0);
+    expect(api.editMessages).toHaveLength(0);
+  });
+
   it("IGNORES the JSONL tailer observability echo so replies are not double-posted (#217)", async () => {
     // The tailer re-emits a raw per-block response.text stamped with
     // _meta.source = "jsonl-tailer"; the real delivery comes from ingestReply

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -514,6 +514,14 @@ export class TelegramAdapter {
     const intent = (event.payload as { intent?: string })?.intent;
     const isProgress = intent === "progress";
     const FRAMES = TelegramAdapter.SPINNER_FRAMES;
+    // #240: a synthesized (silent-drop safety-net) final carries raw, uncurated
+    // turn output — prefix a notice so it is not mistaken for a curated reply.
+    // Synthesized deliveries are always finals, never progress frames.
+    const synthesized = (event.payload as { synthesized?: boolean })?.synthesized === true;
+    const displayText =
+      synthesized && !isProgress && cleanedText.length > 0
+        ? `${TelegramAdapter.SYNTHESIZED_REPLY_NOTICE}\n\n${cleanedText}`
+        : cleanedText;
     const key = this.convKey(agentId, target.chat_id);
     // Receipt timeout is INACTIVITY-based, not a wall-clock budget: any assistant
     // output for this turn — progress OR final — proves the turn is alive, so
@@ -538,7 +546,7 @@ export class TelegramAdapter {
       // Live turn message exists (placeholder or earlier progress) — edit in place.
       const live = this.lastBotMessage.get(key);
       if (live) {
-        const editText = isProgress ? `${FRAMES[0]} ${cleanedText}` : cleanedText;
+        const editText = isProgress ? `${FRAMES[0]} ${cleanedText}` : displayText;
         try {
           await this.editHtml({
             chat_id: live.chat_id,
@@ -574,7 +582,7 @@ export class TelegramAdapter {
       }
     } else {
       // No live turn (unprompted reply / second final) — send fresh.
-      const sendText = isProgress ? `${FRAMES[0]} ${cleanedText}` : cleanedText;
+      const sendText = isProgress ? `${FRAMES[0]} ${cleanedText}` : displayText;
       try {
         let res: { ok: boolean; result?: { message_id: number } };
         try {
@@ -706,6 +714,17 @@ export class TelegramAdapter {
       this.logger.error(`[telegram-adapter] editMessageText failed`, err);
     }
   }
+
+  /**
+   * Prefix for a silent-drop safety-net delivery (#240). The bus tags these
+   * `synthesized: true` because the agent ended its turn without calling the
+   * `reply` tool, so the text is raw, uncurated turn output rather than a
+   * message the agent chose to send. Label it so the user does not mistake it
+   * for a curated reply; the full text is preserved (the #217 safety net
+   * exists precisely because the user would otherwise get nothing).
+   */
+  private static readonly SYNTHESIZED_REPLY_NOTICE =
+    "⚠️ The agent ended its turn without sending a reply — raw output below:";
 
   /** Braille spinner frames — classic CLI animation. */
   private static readonly SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -16,6 +16,7 @@ import {
   type BusOrigin,
   type PermissionRequest,
   isTailerOriginEvent,
+  withSynthesizedNotice,
 } from "../../bus/types";
 import { createTelegramApi } from "./api";
 import { extractReactionDirectives } from "./directives";
@@ -515,13 +516,10 @@ export class TelegramAdapter {
     const isProgress = intent === "progress";
     const FRAMES = TelegramAdapter.SPINNER_FRAMES;
     // #240: a synthesized (silent-drop safety-net) final carries raw, uncurated
-    // turn output — prefix a notice so it is not mistaken for a curated reply.
-    // Synthesized deliveries are always finals, never progress frames.
-    const synthesized = (event.payload as { synthesized?: boolean })?.synthesized === true;
-    const displayText =
-      synthesized && !isProgress && cleanedText.length > 0
-        ? `${TelegramAdapter.SYNTHESIZED_REPLY_NOTICE}\n\n${cleanedText}`
-        : cleanedText;
+    // turn output — prefix the shared notice so it is not mistaken for a curated
+    // reply. No-op for curated replies and empty text; only the non-progress
+    // arms below use displayText, so progress frames are untouched.
+    const displayText = withSynthesizedNotice(cleanedText, event.payload);
     const key = this.convKey(agentId, target.chat_id);
     // Receipt timeout is INACTIVITY-based, not a wall-clock budget: any assistant
     // output for this turn — progress OR final — proves the turn is alive, so
@@ -714,17 +712,6 @@ export class TelegramAdapter {
       this.logger.error(`[telegram-adapter] editMessageText failed`, err);
     }
   }
-
-  /**
-   * Prefix for a silent-drop safety-net delivery (#240). The bus tags these
-   * `synthesized: true` because the agent ended its turn without calling the
-   * `reply` tool, so the text is raw, uncurated turn output rather than a
-   * message the agent chose to send. Label it so the user does not mistake it
-   * for a curated reply; the full text is preserved (the #217 safety net
-   * exists precisely because the user would otherwise get nothing).
-   */
-  private static readonly SYNTHESIZED_REPLY_NOTICE =
-    "⚠️ The agent ended its turn without sending a reply — raw output below:";
 
   /** Braille spinner frames — classic CLI animation. */
   private static readonly SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -1483,6 +1483,33 @@ describe("BusCore IPC", () => {
       expect(replies.length).toBe(1);
       expect(replies[0].text).toBe("the answer");
     });
+
+    it("synthesizes immediately when the reply nudge reaches no transport (deaf agent) (#261)", async () => {
+      // replyNudge is on by default, but makeBus() wires neither an IPC server
+      // nor a streamPromptHandler, so the nudge reaches nobody. Pre-fix this
+      // stranded the user until the reconciler respawned the agent (one full
+      // cycle of hang); now the bus must fall through and synthesize at once.
+      const b = makeBus();
+      const replies = captureReplies(b, "alpha");
+      await b.sendPrompt({
+        agent_id: "alpha",
+        origin: "webui",
+        origin_id: "deaf-1",
+        user_id: "u1",
+        text: "hi",
+      });
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "recovered answer" },
+      });
+      // Delivered synchronously via synthesis — no waiting for a nudged turn.
+      expect(replies.length).toBe(1);
+      expect(replies[0].text).toBe("recovered answer");
+      expect(replies[0].synthesized).toBe(true);
+    });
   });
 });
 

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -1085,11 +1085,20 @@ describe("BusCore IPC", () => {
     }
 
     function captureReplies(b: BusCore, agentId: string) {
-      const replies: { text: string; origin?: string }[] = [];
+      const replies: { text: string; origin?: string; synthesized?: boolean }[] = [];
       b.subscribe({ agent_id: agentId, topics: ["response.text"] }, (event) => {
-        const payload = event.payload as { text?: string; intent?: string; origin?: string };
+        const payload = event.payload as {
+          text?: string;
+          intent?: string;
+          origin?: string;
+          synthesized?: boolean;
+        };
         if (payload?.intent === "final") {
-          replies.push({ text: payload.text ?? "", origin: payload.origin });
+          replies.push({
+            text: payload.text ?? "",
+            origin: payload.origin,
+            synthesized: payload.synthesized,
+          });
         }
       });
       return replies;
@@ -1119,6 +1128,30 @@ describe("BusCore IPC", () => {
       expect(replies.length).toBe(1);
       expect(replies[0].text).toBe("hi there, this is the silent-dropped text");
       expect(replies[0].origin).toBe("webui");
+    });
+
+    it("tags the synthesized delivery with synthesized:true so surfaces can label it (#240)", async () => {
+      const b = makeBus();
+      const replies = captureReplies(b, "alpha");
+
+      await b.sendPrompt({
+        agent_id: "alpha",
+        origin: "webui",
+        origin_id: "test-240",
+        user_id: "u1",
+        text: "say hi",
+      });
+
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "uncurated working prose" },
+      });
+
+      expect(replies.length).toBe(1);
+      expect(replies[0].synthesized).toBe(true);
     });
 
     it("does NOT synthesize when the agent already called reply with intent: final", async () => {
@@ -1152,6 +1185,8 @@ describe("BusCore IPC", () => {
       // Only the real reply, no duplicate from the safety net.
       expect(replies.length).toBe(1);
       expect(replies[0].text).toBe("hello — delivered properly via reply tool");
+      // A curated reply is NOT tagged synthesized (#240).
+      expect(replies[0].synthesized).toBeUndefined();
     });
 
     it("does NOT synthesize when turn_end text is empty", async () => {

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -1078,9 +1078,19 @@ describe("BusCore IPC", () => {
   });
 
   describe("silent-drop safety net (issue #215)", () => {
-    function makeBus(): BusCore {
+    function makeBus(opts?: { replyNudge?: boolean; nudges?: string[] }): BusCore {
       return createBusCore({
         eventLogAppend: createMockEventLog().append,
+        replyNudge: opts?.replyNudge,
+        // Capture PTY-stdin deliveries so nudge tests can assert the reminder
+        // was injected (no real REPL in tests).
+        streamPromptHandler: opts?.nudges
+          ? async (_agentId: string, wrapped: string) => {
+              // sendPrompt also delivers <channel> prompts over this seam;
+              // capture only the bus-injected reply nudges.
+              if (wrapped.includes("<system-reminder>")) opts.nudges?.push(wrapped);
+            }
+          : undefined,
       });
     }
 
@@ -1105,7 +1115,8 @@ describe("BusCore IPC", () => {
     }
 
     it("synthesizes a final reply when turn_end fires without prior reply call", async () => {
-      const b = makeBus();
+      // replyNudge:false isolates the fallback synthesis path from the nudge.
+      const b = makeBus({ replyNudge: false });
       const replies = captureReplies(b, "alpha");
 
       await b.sendPrompt({
@@ -1131,7 +1142,8 @@ describe("BusCore IPC", () => {
     });
 
     it("tags the synthesized delivery with synthesized:true so surfaces can label it (#240)", async () => {
-      const b = makeBus();
+      // replyNudge:false to reach the synthesis path directly (not via a nudge).
+      const b = makeBus({ replyNudge: false });
       const replies = captureReplies(b, "alpha");
 
       await b.sendPrompt({
@@ -1151,6 +1163,98 @@ describe("BusCore IPC", () => {
       });
 
       expect(replies.length).toBe(1);
+      expect(replies[0].synthesized).toBe(true);
+    });
+
+    /* ───────── reply-tool enforcement: nudge-first (#215/#240) ───────── */
+
+    const turnEnd = (b: BusCore, agentId: string, text: string) =>
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: agentId,
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text },
+      });
+    const promptTg = (b: BusCore, agentId: string) =>
+      b.sendPrompt({
+        agent_id: agentId,
+        origin: "telegram",
+        origin_id: "tg-1",
+        user_id: "u1",
+        text: "hi",
+      });
+    const tick = () => new Promise((r) => setTimeout(r, 5));
+
+    it("nudges the agent to call reply instead of synthesizing on the first miss", async () => {
+      const nudges: string[] = [];
+      const b = makeBus({ nudges });
+      const replies = captureReplies(b, "alpha");
+
+      await promptTg(b, "alpha");
+      turnEnd(b, "alpha", "uncurated scratch");
+      await tick();
+
+      // No synthesized delivery — the agent got a reminder to call reply.
+      expect(replies.length).toBe(0);
+      expect(nudges.length).toBe(1);
+      expect(nudges[0]).toContain("<system-reminder>");
+      expect(nudges[0]).toContain("reply");
+    });
+
+    it("delivers the agent's real reply (not a synthesized dump) when the nudge works", async () => {
+      const nudges: string[] = [];
+      const b = makeBus({ nudges });
+      const replies = captureReplies(b, "alpha");
+
+      await promptTg(b, "alpha");
+      turnEnd(b, "alpha", "scratch"); // → nudge
+      await tick();
+      expect(replies.length).toBe(0);
+
+      // The agent obeys the nudge and calls reply with a curated answer.
+      b.ingestReply({ agent_id: "alpha", text: "Curated answer", intent: "final" });
+      expect(replies.length).toBe(1);
+      expect(replies[0].text).toBe("Curated answer");
+      expect(replies[0].synthesized).toBeUndefined(); // a REAL reply, not synthesized
+
+      // A trailing turn_end for the nudged turn must NOT double-deliver.
+      turnEnd(b, "alpha", "scratch");
+      await tick();
+      expect(replies.length).toBe(1);
+    });
+
+    it("falls back to a labeled synthesized delivery when the nudged turn ALSO skips reply", async () => {
+      const nudges: string[] = [];
+      const b = makeBus({ nudges });
+      const replies = captureReplies(b, "alpha");
+
+      await promptTg(b, "alpha");
+      turnEnd(b, "alpha", "original output"); // first miss → nudge
+      await tick();
+      expect(replies.length).toBe(0);
+      expect(nudges.length).toBe(1);
+
+      turnEnd(b, "alpha", "second output"); // nudged turn ALSO skips reply
+      await tick();
+      expect(replies.length).toBe(1);
+      expect(replies[0].synthesized).toBe(true);
+      expect(nudges.length).toBe(1); // bounded: exactly one nudge per turn
+    });
+
+    it("the fallback preserves the original turn text if the nudged turn produces none", async () => {
+      const nudges: string[] = [];
+      const b = makeBus({ nudges });
+      const replies = captureReplies(b, "alpha");
+
+      await promptTg(b, "alpha");
+      turnEnd(b, "alpha", "the original answer"); // → nudge (text stashed)
+      await tick();
+      turnEnd(b, "alpha", ""); // nudged turn ends empty, still no reply
+      await tick();
+
+      expect(replies.length).toBe(1);
+      expect(replies[0].text).toBe("the original answer");
       expect(replies[0].synthesized).toBe(true);
     });
 
@@ -1256,7 +1360,8 @@ describe("BusCore IPC", () => {
     });
 
     it("resets the per-turn flag on each new prompt (single-flight per prompt)", async () => {
-      const b = makeBus();
+      // replyNudge:false: asserts the synthesis path directly across prompts.
+      const b = makeBus({ replyNudge: false });
       const replies = captureReplies(b, "alpha");
 
       // Prompt 1: agent calls reply → no synthesis.

--- a/src/bus/__tests__/session-manager.test.ts
+++ b/src/bus/__tests__/session-manager.test.ts
@@ -839,7 +839,14 @@ describe("JSONL tailer wiring (issue #215)", () => {
     const enc = encodeCwdForProjectsDir(realpathSync(agentCwd));
     mkdirSync(join(projectsDir, enc), { recursive: true });
     sessionPath = join(projectsDir, enc, `${SID}.jsonl`);
-    bus = createBusCore({ eventLogAppend: (async () => ({})) as never });
+    // replyNudge:false: this suite proves the synthesis runtime wiring; the
+    // nudge-first path (#215/#240) is exercised in core.test.ts. With the nudge
+    // on, a turn_end would inject a reminder to /bin/cat (which never replies)
+    // instead of synthesizing, so the wiring assertion must target the fallback.
+    bus = createBusCore({
+      eventLogAppend: (async () => ({})) as never,
+      replyNudge: false,
+    });
     mgr = new SessionManager({
       commandOverride: "/bin/cat",
       argsOverride: [],

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -1004,6 +1004,7 @@ export class BusCoreImpl implements BusCore {
       intent: string;
       origin?: BusOrigin;
       origin_id?: string;
+      synthesized?: true;
     }> = {
       ts: Date.now(),
       agent_id: req.agent_id,
@@ -1013,6 +1014,11 @@ export class BusCoreImpl implements BusCore {
         text: req.text,
         intent: req.intent,
         ...(origin ? { origin: origin.origin, origin_id: origin.origin_id } : {}),
+        // #240: tag the silent-drop safety-net delivery so surfaces can tell it
+        // apart from a curated `reply` and choose to label, truncate, or
+        // suppress it. The text was never curated through the `reply` tool — it
+        // is the raw concatenated turn output #217 falls back to delivering.
+        ...(opts?.synthetic ? { synthesized: true as const } : {}),
       },
     };
     this.publish(event);

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -194,6 +194,15 @@ export interface BusCoreOptions {
    * the bus — same late-binding pattern as `slashCommandHandler`).
    */
   jobHandler?: AgentJobHandler;
+  /**
+   * Reply-tool enforcement (#215/#240). When an agent ends a channel-driven
+   * turn with text but never calls `reply`, the bus first nudges it to call
+   * `reply` (a curated reply beats a synthesized raw dump), and only synthesizes
+   * the labeled safety-net delivery if the nudged turn ALSO skips `reply`.
+   * Set to `false` to disable the nudge and synthesize immediately (the
+   * pre-nudge #217 behaviour) — a kill switch for the live path. Default true.
+   */
+  replyNudge?: boolean;
 }
 
 /* ───────────────────────────────────────────────────────────────────── */
@@ -421,7 +430,21 @@ export class BusCoreImpl implements BusCore {
    */
   private readonly currentTurnFinalPublished = new Map<string, boolean>();
 
+  /**
+   * Reply-tool enforcement (#215/#240). `replyNudged` records that the agent
+   * was already nudged once for the in-flight turn, so a nudged turn that again
+   * ends without `reply` falls through to the synthesized safety net instead of
+   * nudging forever. `pendingNudgeText` holds the original turn's text so the
+   * fallback can still deliver it if the nudged turn produces no fresh text.
+   * Both are cleared on prompt / final reply / disconnect / cancel / error,
+   * alongside the other per-turn flags.
+   */
+  private readonly replyNudgeEnabled: boolean;
+  private readonly replyNudged = new Map<string, boolean>();
+  private readonly pendingNudgeText = new Map<string, string>();
+
   constructor(opts: BusCoreOptions = {}) {
+    this.replyNudgeEnabled = opts.replyNudge ?? true;
     this.socketPath = opts.socketPath ?? null;
     this.ringbufferCapacity = opts.ringbufferCapacity ?? DEFAULT_RINGBUFFER_CAPACITY;
     this.deliveryBackstopMs = opts.deliveryBackstopMs ?? 4000;
@@ -476,6 +499,10 @@ export class BusCoreImpl implements BusCore {
           this.originAmbiguous.delete(agentId);
           this.currentTurnReplied.delete(agentId);
           this.currentTurnFinalPublished.delete(agentId);
+          // Reply-tool enforcement (#215/#240): drop nudge state with the rest
+          // of the per-turn flags so a dead session can't leave it dangling.
+          this.replyNudged.delete(agentId);
+          this.pendingNudgeText.delete(agentId);
           // The subprocess is gone -- tear down this agent's delivery-gate
           // state too, so a held prompt plus an armed backstop timer can never
           // flush a stale keystroke into a restart that reuses this agent_id.
@@ -605,6 +632,10 @@ export class BusCoreImpl implements BusCore {
     // #217 finding 2: a new turn starts undelivered — clear the
     // cross-transport "final already published" dedup flag.
     this.currentTurnFinalPublished.set(req.agent_id, false);
+    // Reply-tool enforcement (#215/#240): a fresh user turn — drop any nudge
+    // state from the previous turn so this turn gets its own one-shot nudge.
+    this.replyNudged.delete(req.agent_id);
+    this.pendingNudgeText.delete(req.agent_id);
 
     const ipcMsg: IpcPrompt = {
       type: "prompt",
@@ -1050,6 +1081,10 @@ export class BusCoreImpl implements BusCore {
       // the cross-transport race loser (real reply vs synthesized) is
       // suppressed above.
       this.currentTurnFinalPublished.set(req.agent_id, true);
+      // Reply-tool enforcement (#215/#240): a final was delivered (incl. one a
+      // nudge successfully produced) — clear the nudge state for the turn.
+      this.replyNudged.delete(req.agent_id);
+      this.pendingNudgeText.delete(req.agent_id);
     }
   }
 
@@ -1068,7 +1103,13 @@ export class BusCoreImpl implements BusCore {
     // #217 finding 2: if a final already published for this turn (e.g. the
     // real reply IPC landed first), don't synthesize a duplicate.
     if (this.currentTurnFinalPublished.get(agentId) === true) return;
-    if (!text || text.trim().length === 0) return;
+    // Effective text to deliver: this turn's own text, or — on a turn we already
+    // nudged that produced none — the original text stashed when we nudged, so a
+    // nudged-but-still-silent turn never loses the first turn's output (#215).
+    const nudged = this.replyNudged.get(agentId) === true;
+    const ownText = text && text.trim().length > 0 ? text : "";
+    const deliverText = ownText || (nudged ? (this.pendingNudgeText.get(agentId) ?? "") : "");
+    if (deliverText.trim().length === 0) return;
     // RESIDUAL RACE (#217 finding 3 → deferred #239): `lastPromptOrigin` and
     // the per-turn flags are single-slot, keyed by agent_id only, with no
     // prompt/turn identity. The JSONL tailer's `response.turn_end` is
@@ -1102,27 +1143,83 @@ export class BusCoreImpl implements BusCore {
     if (!CHANNEL_DRIVEN_ORIGINS.has(origin.origin)) {
       return;
     }
+    // ROOT-CAUSE FIRST (#215): the agent skipped the `reply` tool. Rather than
+    // immediately shipping the raw, uncurated turn text, give it ONE chance to
+    // deliver properly — inject a system reminder telling it to call `reply`
+    // now. A curated reply is what the user actually wants; the synthesized
+    // dump is a last resort. Bounded to one nudge per turn via `replyNudged`.
+    if (this.replyNudgeEnabled && !nudged) {
+      console.warn(
+        `[bus] silent-drop detected for agent=${agentId} (origin=${origin.origin}, ` +
+          `chars=${deliverText.length}): turn ended with text but no reply tool call — ` +
+          `nudging the agent to call reply. See issue #215.`,
+      );
+      this.replyNudged.set(agentId, true);
+      this.pendingNudgeText.set(agentId, deliverText);
+      this.nudgeForReply(agentId, origin);
+      return;
+    }
+    // FALLBACK (#217/#240): the nudge is disabled or already spent and the turn
+    // STILL ended without a reply — synthesize a labeled delivery so the user
+    // gets something rather than nothing.
     console.warn(
       `[bus] silent-drop recovered for agent=${agentId} (origin=${origin.origin}, ` +
-        `chars=${text.length}): the turn ended with text but the agent did not call the ` +
-        `reply tool — synthesizing ingestReply to deliver. See issue #215.`,
+        `chars=${deliverText.length}): no reply tool call${nudged ? " even after a nudge" : ""} — ` +
+        `synthesizing ingestReply to deliver. See issue #215/#240.`,
     );
     // Mark BEFORE the recursive ingestReply so the synthetic call itself
     // doesn't trigger another safety-net pass (it would no-op anyway
     // because we set the flag here, but the explicit ordering makes the
     // single-fire intent clearer).
     this.currentTurnReplied.set(agentId, true);
+    this.replyNudged.delete(agentId);
+    this.pendingNudgeText.delete(agentId);
     // `synthetic: true` lets this first delivery through the cross-transport
     // dedup (#217 finding 2); it sets `currentTurnFinalPublished`, so a
     // later real `reply` IPC for the same turn is suppressed.
     this.ingestReply(
       {
         agent_id: agentId,
-        text,
+        text: deliverText,
         intent: "final",
       },
       { synthetic: true },
     );
+  }
+
+  /**
+   * Reply-tool enforcement (#215/#240). Inject a one-shot system reminder
+   * telling the agent to call `reply` now, after it ended a channel-driven turn
+   * with text but no reply. Delivered over the same seams as a prompt — IPC for
+   * MCP-connected agents, PTY-stdin for headless ones — but best-effort: a
+   * failed IPC send is swallowed here (it must NOT trip the #222 respawn
+   * reconciler, which is for real prompts), and the synthesized safety net in
+   * `handleTurnEnd` still backs the nudge if it does not yield a reply.
+   *
+   * The nudged turn is a fresh turn that should end in `reply`, so reset the
+   * per-turn delivered/published flags: a real reply then lands cleanly, and if
+   * it doesn't, the next `response.turn_end` falls through to the fallback.
+   */
+  private nudgeForReply(agentId: string, origin: { origin: BusOrigin; origin_id: string }): void {
+    const text =
+      "You ended your turn without calling the `reply` tool, so the user received " +
+      "nothing — your transcript text does not reach them. Call `reply` now with " +
+      "intent:'final' to send your answer for this turn.";
+    this.currentTurnReplied.set(agentId, false);
+    this.currentTurnFinalPublished.set(agentId, false);
+    // IPC path (best-effort, no reconciler): reach an MCP-connected agent.
+    this.ipcServer?.send(agentId, {
+      type: "prompt",
+      agent_id: agentId,
+      origin: origin.origin,
+      origin_id: origin.origin_id,
+      user_id: "system",
+      text,
+      metadata: { nudge: "reply-tool" },
+    });
+    // PTY-stdin path for headless agents. A <system-reminder> wrap signals this
+    // is bus-injected guidance, not a user message from a surface.
+    this.deliverOrQueuePrompt(agentId, `<system-reminder>${escapeXmlText(text)}</system-reminder>`);
   }
 
   ingestSessionEvent(e: BusEvent): void {
@@ -1444,6 +1541,10 @@ export class BusCoreImpl implements BusCore {
         // tracking flag to keep the map bounded.
         this.currentTurnReplied.delete(agentId);
         this.currentTurnFinalPublished.delete(agentId);
+        // Reply-tool enforcement (#215/#240): no turn_end is coming — drop the
+        // nudge state too so it can't leak into a later turn for this agent.
+        this.replyNudged.delete(agentId);
+        this.pendingNudgeText.delete(agentId);
         // A cancelled/errored turn emits no response.turn_end, so the
         // neighbor-turn flag would never clear via the tailer — drop it here
         // too, else flush-verify defers forever for this agent (#252 stack ultra).
@@ -1538,6 +1639,10 @@ export class BusCoreImpl implements BusCore {
         // turn_end either — clear tracking too.
         this.currentTurnReplied.delete(agentId);
         this.currentTurnFinalPublished.delete(agentId);
+        // Reply-tool enforcement (#215/#240): no turn_end is coming — drop the
+        // nudge state too so it can't leak into a later turn for this agent.
+        this.replyNudged.delete(agentId);
+        this.pendingNudgeText.delete(agentId);
         // A cancelled/errored turn emits no response.turn_end, so the
         // neighbor-turn flag would never clear via the tailer — drop it here
         // too, else flush-verify defers forever for this agent (#252 stack ultra).

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -565,6 +565,8 @@ export class BusCoreImpl implements BusCore {
     this.agentTurnActive.clear();
     this.originAmbiguous.clear();
     this.pendingRedelivery.clear();
+    this.replyNudged.clear();
+    this.pendingNudgeText.clear();
   }
 
   /* ─────────────────────────────── prompts ─────────────────────────────── */
@@ -1156,8 +1158,14 @@ export class BusCoreImpl implements BusCore {
       );
       this.replyNudged.set(agentId, true);
       this.pendingNudgeText.set(agentId, deliverText);
-      this.nudgeForReply(agentId, origin);
-      return;
+      if (this.nudgeForReply(agentId, origin)) return;
+      // #261/#222: neither IPC nor PTY received the nudge (deaf agent) — don't
+      // strand the user waiting for a turn that will never start. Fall through to
+      // synthesize immediately (zero-delay, exactly as the pre-#215 path did).
+      console.warn(
+        `[bus] reply nudge undeliverable for agent=${agentId} (no IPC/PTY transport) — ` +
+          `synthesizing immediately instead of waiting. See #261/#222.`,
+      );
     }
     // FALLBACK (#217/#240): the nudge is disabled or already spent and the turn
     // STILL ended without a reply — synthesize a labeled delivery so the user
@@ -1200,7 +1208,10 @@ export class BusCoreImpl implements BusCore {
    * per-turn delivered/published flags: a real reply then lands cleanly, and if
    * it doesn't, the next `response.turn_end` falls through to the fallback.
    */
-  private nudgeForReply(agentId: string, origin: { origin: BusOrigin; origin_id: string }): void {
+  private nudgeForReply(
+    agentId: string,
+    origin: { origin: BusOrigin; origin_id: string },
+  ): boolean {
     const text =
       "You ended your turn without calling the `reply` tool, so the user received " +
       "nothing — your transcript text does not reach them. Call `reply` now with " +
@@ -1208,18 +1219,25 @@ export class BusCoreImpl implements BusCore {
     this.currentTurnReplied.set(agentId, false);
     this.currentTurnFinalPublished.set(agentId, false);
     // IPC path (best-effort, no reconciler): reach an MCP-connected agent.
-    this.ipcServer?.send(agentId, {
-      type: "prompt",
-      agent_id: agentId,
-      origin: origin.origin,
-      origin_id: origin.origin_id,
-      user_id: "system",
-      text,
-      metadata: { nudge: "reply-tool" },
-    });
-    // PTY-stdin path for headless agents. A <system-reminder> wrap signals this
-    // is bus-injected guidance, not a user message from a surface.
+    const ipcDelivered =
+      this.ipcServer?.send(agentId, {
+        type: "prompt",
+        agent_id: agentId,
+        origin: origin.origin,
+        origin_id: origin.origin_id,
+        user_id: "system",
+        text,
+        metadata: { nudge: "reply-tool" },
+      }) === true;
+    // PTY-stdin path for headless agents. A <system-reminder> wrap signals this is
+    // bus-injected guidance, not a user message. deliverOrQueuePrompt no-ops when no
+    // streamPromptHandler is wired, so that is the PTY-availability signal.
+    const ptyAvailable = this.streamPromptHandler !== null;
     this.deliverOrQueuePrompt(agentId, `<system-reminder>${escapeXmlText(text)}</system-reminder>`);
+    // #261/#222: report whether ANY transport actually received the nudge, so a
+    // deaf agent (neither IPC nor PTY) does not leave the caller waiting for a
+    // turn that never starts.
+    return ipcDelivered || ptyAvailable;
   }
 
   ingestSessionEvent(e: BusEvent): void {

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -1219,16 +1219,24 @@ export class BusCoreImpl implements BusCore {
     this.currentTurnReplied.set(agentId, false);
     this.currentTurnFinalPublished.set(agentId, false);
     // IPC path (best-effort, no reconciler): reach an MCP-connected agent.
-    const ipcDelivered =
-      this.ipcServer?.send(agentId, {
-        type: "prompt",
-        agent_id: agentId,
-        origin: origin.origin,
-        origin_id: origin.origin_id,
-        user_id: "system",
-        text,
-        metadata: { nudge: "reply-tool" },
-      }) === true;
+    // Wrapped so a synchronous send() throw can't skip the PTY path below or
+    // propagate to the turn-end handler — the send is best-effort, mirroring
+    // sendPrompt's IPC guard.
+    let ipcDelivered = false;
+    try {
+      ipcDelivered =
+        this.ipcServer?.send(agentId, {
+          type: "prompt",
+          agent_id: agentId,
+          origin: origin.origin,
+          origin_id: origin.origin_id,
+          user_id: "system",
+          text,
+          metadata: { nudge: "reply-tool" },
+        }) === true;
+    } catch {
+      /* best-effort: the PTY path + synthesize fallback still cover delivery */
+    }
     // PTY-stdin path for headless agents. A <system-reminder> wrap signals this is
     // bus-injected guidance, not a user message. deliverOrQueuePrompt no-ops when no
     // streamPromptHandler is wired, so that is the PTY-availability signal.

--- a/src/bus/types.ts
+++ b/src/bus/types.ts
@@ -142,6 +142,28 @@ export function isTailerOriginEvent(event: BusEvent): boolean {
   return meta?.source === TAILER_EVENT_SOURCE;
 }
 
+/**
+ * Prefix shown on a silent-drop safety-net delivery (#240). The bus tags these
+ * `synthesized: true` (see `ingestReply`) because the agent ended its turn
+ * without calling the `reply` tool, so the text is raw, uncurated turn output
+ * rather than a message the agent chose to send. Surfaces prepend this so the
+ * user does not mistake it for a curated reply; the full text is preserved (the
+ * #217 safety net exists precisely because the user would otherwise get nothing).
+ */
+export const SYNTHESIZED_REPLY_NOTICE =
+  "⚠️ The agent ended its turn without sending a reply — raw output below:";
+
+/**
+ * Prepend {@link SYNTHESIZED_REPLY_NOTICE} when `payload.synthesized` is set
+ * (#240). No-op for curated replies and for empty text. Centralised so every
+ * channel adapter renders the same wording and gate, with no drift.
+ */
+export function withSynthesizedNotice(text: string, payload: unknown): string {
+  const synthesized = (payload as { synthesized?: boolean } | undefined)?.synthesized === true;
+  if (!synthesized || text.length === 0) return text;
+  return `${SYNTHESIZED_REPLY_NOTICE}\n\n${text}`;
+}
+
 /* ───────────────────────────────────────────────────────────────────── */
 /* Permission flow (§5.1 v2.2)                                           */
 /* ───────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Problem

When an agent ends a channel-driven turn with text but never calls the `reply` tool, the user gets nothing — its transcript text is not visible to them (issue #215). #217 added a safety net that synthesizes a delivery from the raw turn text, but that text was never curated through `reply`, so working/planning scratch shipped verbatim, masquerading as a curated answer (the altitude follow-up, #240).

## Approach — three layers, each with a distinct role

**1. Root cause first — nudge the reply tool (`bus/core.ts`).**
On the first miss, the bus injects a one-shot `<system-reminder>` telling the agent to call `reply` now, delivered over the same IPC + PTY-stdin seams as a prompt (best-effort — a failed IPC send does **not** trip the #222 respawn reconciler). A curated reply is what the user actually wants; the raw dump is a last resort. Bounded to one nudge per turn (`replyNudged`); the original turn text is stashed (`pendingNudgeText`) so a nudged-but-empty turn never loses the first turn's output. `replyNudge` (default `true`) is a kill switch on `BusCoreOptions`.

**2. Fallback — synthesize + tag (`bus/core.ts`).**
If the nudged turn *also* ends without a reply (or the nudge is disabled), synthesize the delivery and tag the `response.text` payload `synthesized: true` so surfaces can tell it apart from a curated reply.

**3. Presentation — label at the surface (`bus/types.ts` + adapters).**
A shared `withSynthesizedNotice(text, payload)` prefixes a concise notice (`⚠️ The agent ended its turn without sending a reply — raw output below:`), applied in the telegram, slack, and discord adapters (telegram on both the fresh-send and edit-in-place paths). Full text preserved. The bus stays a pure transport that adds metadata; presentation is the surface's call. **webui** (dashboard, different render path) is deferred — the flag is on the payload, adoptable later.

> Note on the nudge: it's an *in-the-moment* correction, not training. The model doesn't learn across sessions, so the nudge and the net are both permanent layers — the nudge isn't a temporary scaffold that "teaches" the model to comply.

## Tests

- core: nudge on first miss (no synthesis, reminder injected); a real reply after a nudge delivers curated text (not `synthesized`) and doesn't double-deliver; fallback synthesizes a tagged delivery when the nudged turn also skips reply; fallback preserves the original text if the nudged turn is empty. Existing synthesis tests pin `replyNudge:false` to target the fallback directly.
- adapters: synthesized delivery is prefixed in telegram (fresh-send **and** edit-in-place — mutation-verified), slack, and discord; reaction-only synthesized final emits no bare notice; a curated reply is unchanged.

596 bus + adapter tests pass, biome clean, no new typecheck errors, no full-suite regressions.

Closes #240. Implements the root-cause fix for #215 (which the #217 net only mitigated).
