### PR TITLE
feat(telemetry): host telemetry over MCP — read-only measurement surface (telemetry__*) [#275 brick 1]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.176",
+      "version": "2.2.177",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.175",
+      "version": "2.2.176",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.176",
+  "version": "2.2.177",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.175",
+  "version": "2.2.176",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/governance/mode-dispatch-journal.ts
+++ b/src/governance/mode-dispatch-journal.ts
@@ -1,0 +1,104 @@
+/**
+ * mode_dispatch instrumentation — the HOST-side producer of the `mode_dispatch`
+ * telemetry stream (OutcomeLoop Phase B).
+ *
+ * ClaudeClaw routes each request to an `agentic.modes` mode by keyword/phrase
+ * matching (`classifyTask`/`selectModel` in `../model-router.ts`, called from
+ * `./model-router.ts`'s `selectModel`). That resolution IS the dispatch event.
+ * This module records one `{ ts, mode, matched_keyword, reclassified }` line per
+ * dispatch to a journal that `ModeDispatchTelemetryProducer` reads.
+ *
+ * Sink indirection (why it's not a bare `appendFileSync`): the classifier runs
+ * inside unit tests and the `tuner` CLI, neither of which should touch the real
+ * home dir. So emission goes through a module-level sink that defaults to a
+ * NO-OP. The live daemon installs the file sink exactly once at router init
+ * (`ensureGovernanceRouter` in `runner.ts`) via `setModeDispatchSink`. Tests
+ * install an in-memory sink (or a temp-file one) explicitly. No env-sniffing,
+ * no accidental writes.
+ *
+ * `reclassified` is the metric the consumer needs (ModelRoutingSubject's
+ * `routing_reclassify_rate = nonzeroRate`). A fresh dispatch is never known to
+ * be a mis-route at emit time, so it is recorded `false` (value 0) — an honest
+ * baseline that activates the stream with a real dispatch count and a
+ * reclassify-rate of 0, never a fabricated nonzero. A later corrector can append
+ * a `reclassified:true` record for the same dispatch when one is detected.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+/** One dispatch record. Field names match the on-disk JSONL + the producer. */
+export interface ModeDispatchEvent {
+  /** ISO-8601 UTC. Filled by `recordModeDispatch` when omitted. */
+  ts: string;
+  /** Resolved agentic mode name (e.g. "coding", "planning"). */
+  mode: string;
+  /** The phrase/keyword that selected the mode ("" on a default/tie fallback). */
+  matched_keyword: string;
+  /** True only when a later signal flags this dispatch a mis-route. */
+  reclassified: boolean;
+}
+
+/** Default journal — alongside the ClaudeClaw operations journal. */
+export const DEFAULT_MODE_DISPATCH_LOG = join(
+  homedir(),
+  ".claudeclaw",
+  "journal",
+  "mode_dispatch.jsonl",
+);
+
+export type ModeDispatchSink = (event: ModeDispatchEvent) => void;
+
+/** No-op default: emission is inert until the host installs a real sink. */
+let sink: ModeDispatchSink = () => {};
+
+/** Install the active sink (daemon → file sink; tests → in-memory/temp). */
+export function setModeDispatchSink(next: ModeDispatchSink): void {
+  sink = next;
+}
+
+/** Restore the inert no-op sink (test teardown). */
+export function resetModeDispatchSink(): void {
+  sink = () => {};
+}
+
+/**
+ * Record one dispatch. `ts` defaults to now and `reclassified` to false, so the
+ * common call site is just `recordModeDispatch({ mode, matched_keyword })`.
+ * Never throws — instrumentation must not break the routing path.
+ */
+export function recordModeDispatch(
+  event: Pick<ModeDispatchEvent, "mode" | "matched_keyword"> & Partial<ModeDispatchEvent>,
+): void {
+  try {
+    sink({
+      ts: event.ts ?? new Date().toISOString(),
+      mode: event.mode,
+      matched_keyword: event.matched_keyword,
+      reclassified: event.reclassified ?? false,
+    });
+  } catch {
+    /* swallow — telemetry is best-effort */
+  }
+}
+
+/**
+ * A sink that appends one JSON line per event to `path` (default
+ * `DEFAULT_MODE_DISPATCH_LOG`). Creates the parent dir on first write. All
+ * filesystem errors are swallowed.
+ */
+export function fileModeDispatchSink(path: string = DEFAULT_MODE_DISPATCH_LOG): ModeDispatchSink {
+  let dirEnsured = false;
+  return (event: ModeDispatchEvent) => {
+    try {
+      if (!dirEnsured) {
+        mkdirSync(dirname(path), { recursive: true });
+        dirEnsured = true;
+      }
+      appendFileSync(path, `${JSON.stringify(event)}\n`);
+    } catch {
+      /* swallow */
+    }
+  };
+}

--- a/src/observability/__tests__/mcp-tool-call-producer.test.ts
+++ b/src/observability/__tests__/mcp-tool-call-producer.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { McpToolCallTelemetryProducer } from "../mcp-tool-call-producer.js";
+import { ToolCallSink } from "../tool-call-sink.js";
+import type { ToolCallEvent } from "../tool-call.js";
+
+const RANGE = {
+  start: new Date("2026-05-25T00:00:00.000Z"),
+  end: new Date("2026-05-26T00:00:00.000Z"),
+};
+
+function seed(logPath: string, events: ToolCallEvent[]): void {
+  const sink = new ToolCallSink({ path: logPath, autoFlush: false });
+  for (const e of events) sink.record(e);
+  sink.flush();
+}
+
+function ev(over: Partial<ToolCallEvent>): ToolCallEvent {
+  return {
+    ts: "2026-05-25T12:00:00.000Z",
+    plugin: "alpha",
+    tool: "echo",
+    agent_id: "pty-1",
+    status: "ok",
+    duration_ms: 10,
+    args_hash: "aaaa",
+    ...over,
+  };
+}
+
+describe("McpToolCallTelemetryProducer", () => {
+  let dir: string;
+  let logPath: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mcp-tc-producer-"));
+    logPath = join(dir, "mcp-tool-calls.jsonl");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("advertises mcp.tool_call unavailable when no log exists", () => {
+    const p = new McpToolCallTelemetryProducer({ logPath });
+    const cap = p.capabilities()[0]!;
+    expect(cap.stream).toBe("mcp.tool_call");
+    expect(cap.available).toBe(false);
+    expect(cap.reason).toMatch(/no mcp\.tool_call log/);
+  });
+
+  it("reads the audited log back as duration-valued samples with full labels", async () => {
+    seed(logPath, [
+      ev({ tool: "echo", status: "ok", duration_ms: 12 }),
+      ev({ tool: "fetch", status: "error", duration_ms: 99, error: "nope" }),
+    ]);
+    const p = new McpToolCallTelemetryProducer({ logPath });
+    expect(p.capabilities()[0]!.available).toBe(true);
+
+    const samples = await p.query("mcp.tool_call", RANGE);
+    expect(samples).toHaveLength(2);
+    expect(samples.map((s) => s.value).sort((a, b) => a - b)).toEqual([12, 99]);
+    const echo = samples.find((s) => s.labels?.tool === "echo")!;
+    expect(echo.labels).toMatchObject({
+      plugin: "alpha",
+      tool: "echo",
+      status: "ok",
+      agent_id: "pty-1",
+      args_hash: "aaaa",
+    });
+  });
+
+  it("returns [] for a stream it does not own", async () => {
+    seed(logPath, [ev({})]);
+    const p = new McpToolCallTelemetryProducer({ logPath });
+    expect(await p.query("session_cost", RANGE)).toEqual([]);
+  });
+
+  it("honours the time window (half-open [start, end))", async () => {
+    seed(logPath, [
+      ev({ ts: "2026-05-25T12:00:00.000Z" }), // in
+      ev({ ts: "2026-05-24T23:59:59.000Z" }), // before
+      ev({ ts: "2026-05-26T00:00:00.000Z" }), // == end → excluded
+    ]);
+    const p = new McpToolCallTelemetryProducer({ logPath });
+    const samples = await p.query("mcp.tool_call", RANGE);
+    expect(samples).toHaveLength(1);
+  });
+
+  it("applies label filters", async () => {
+    seed(logPath, [ev({ plugin: "alpha", tool: "echo" }), ev({ plugin: "beta", tool: "echo" })]);
+    const p = new McpToolCallTelemetryProducer({ logPath });
+    const samples = await p.query("mcp.tool_call", RANGE, { plugin: "beta" });
+    expect(samples).toHaveLength(1);
+    expect(samples[0]!.labels?.plugin).toBe("beta");
+  });
+
+  it("tolerates a malformed trailing line (concurrent partial write)", async () => {
+    seed(logPath, [ev({})]);
+    // Simulate a torn append: a partial JSON line at the tail.
+    const { appendFileSync } = await import("node:fs");
+    appendFileSync(logPath, '{"event":"mcp.tool_call","detail":{"dur');
+    const p = new McpToolCallTelemetryProducer({ logPath });
+    const samples = await p.query("mcp.tool_call", RANGE);
+    expect(samples).toHaveLength(1);
+  });
+});

--- a/src/observability/__tests__/mcp-tool-call-producer.test.ts
+++ b/src/observability/__tests__/mcp-tool-call-producer.test.ts
@@ -25,7 +25,6 @@ function ev(over: Partial<ToolCallEvent>): ToolCallEvent {
     agent_id: "pty-1",
     status: "ok",
     duration_ms: 10,
-    args_hash: "aaaa",
     ...over,
   };
 }
@@ -64,8 +63,9 @@ describe("McpToolCallTelemetryProducer", () => {
       tool: "echo",
       status: "ok",
       agent_id: "pty-1",
-      args_hash: "aaaa",
     });
+    // args_hash is intentionally NOT emitted — args are never captured.
+    expect(echo.labels).not.toHaveProperty("args_hash");
   });
 
   it("returns [] for a stream it does not own", async () => {

--- a/src/observability/mcp-tool-call-producer.ts
+++ b/src/observability/mcp-tool-call-producer.ts
@@ -22,6 +22,7 @@ import {
   type TelemetryStream,
 } from "../skills-tuner/core/telemetry.js";
 import { MCP_TOOL_CALL_STREAM } from "./tool-call.js";
+import { DEFAULT_TOOL_CALL_LOG } from "./tool-call-sink.js";
 
 interface ToolCallRecord {
   event?: string;
@@ -34,7 +35,10 @@ export class McpToolCallTelemetryProducer implements TelemetryProvider {
   private readonly path: string;
 
   constructor(opts: { logPath?: string } = {}) {
-    this.path = (opts.logPath ?? "").replace(/^~/, homedir());
+    // Default to the same log ToolCallSink writes, so the producer is available
+    // out of the box (matching the sink) instead of permanently returning [] when
+    // a caller forgets to pass a path.
+    this.path = (opts.logPath ?? DEFAULT_TOOL_CALL_LOG).replace(/^~/, homedir());
   }
 
   contractVersion(): string {

--- a/src/observability/mcp-tool-call-producer.ts
+++ b/src/observability/mcp-tool-call-producer.ts
@@ -7,8 +7,9 @@
  * parsing line-by-line and skipping a malformed trailing partial write.
  *
  * `value` carries the call's `duration_ms`; everything else (plugin, tool,
- * status, agent_id, args_hash) rides in `labels` so a reader can reconstruct the
- * universal metrics without a second source.
+ * status, agent_id) rides in `labels` so a reader can reconstruct the universal
+ * metrics without a second source. Call args are never captured (not even a
+ * hash — see tool-call.ts), so there is nothing sensitive to surface here.
  */
 
 import { existsSync, readFileSync } from "node:fs";
@@ -89,7 +90,6 @@ export class McpToolCallTelemetryProducer implements TelemetryProvider {
         tool: String(detail.tool ?? ""),
         status: String(detail.status ?? ""),
         agent_id: String(detail.agent_id ?? ""),
-        args_hash: String(detail.args_hash ?? ""),
       };
       if (filters && !Object.entries(filters).every(([k, v]) => labels[k] === v)) continue;
 

--- a/src/observability/mcp-tool-call-producer.ts
+++ b/src/observability/mcp-tool-call-producer.ts
@@ -12,8 +12,9 @@
  * hash — see tool-call.ts), so there is nothing sensitive to surface here.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
+import { forEachLineSync } from "../tuner/wisecron/line-reader.js";
 import {
   type DateRange,
   type MetricSample,
@@ -66,35 +67,54 @@ export class McpToolCallTelemetryProducer implements TelemetryProvider {
     if (stream !== MCP_TOOL_CALL_STREAM) return [];
     if (this.path === "" || !existsSync(this.path)) return [];
 
-    const text = readFileSync(this.path, "utf8");
+    // Stream the append-only audit log line-by-line with a per-file byte cap
+    // rather than slurping the whole file into one string. The log grows
+    // unbounded on a long-running daemon, so a `readFileSync` here could OOM
+    // before the MCP-layer sample cap can act. Same treatment the session /
+    // journal readers already use (see line-reader.ts). Wrapped in try/catch to
+    // tolerate a mid-read failure on one bad file.
     const out: MetricSample[] = [];
-    for (const line of text.split("\n")) {
-      const l = line.trim();
-      if (!l) continue;
-      let rec: ToolCallRecord;
-      try {
-        rec = JSON.parse(l) as ToolCallRecord;
-      } catch {
-        continue; // skip a partial trailing write or a corrupt line
-      }
-      if (rec.event !== MCP_TOOL_CALL_STREAM) continue;
-      const detail = rec.detail ?? {};
-      const tsStr = typeof detail.event_ts === "string" ? detail.event_ts : rec.ts;
-      if (!tsStr) continue;
-      const ts = new Date(tsStr);
-      if (Number.isNaN(ts.getTime())) continue;
-      if (ts < range.start || ts >= range.end) continue;
+    try {
+      forEachLineSync(
+        this.path,
+        (line) => {
+          const l = line.trim();
+          if (!l) return;
+          let rec: ToolCallRecord;
+          try {
+            rec = JSON.parse(l) as ToolCallRecord;
+          } catch {
+            return; // skip a partial trailing write or a corrupt line
+          }
+          if (rec.event !== MCP_TOOL_CALL_STREAM) return;
+          const detail = rec.detail ?? {};
+          const tsStr = typeof detail.event_ts === "string" ? detail.event_ts : rec.ts;
+          if (!tsStr) return;
+          const ts = new Date(tsStr);
+          if (Number.isNaN(ts.getTime())) return;
+          if (ts < range.start || ts >= range.end) return;
 
-      const labels: Record<string, string> = {
-        plugin: String(rec.subject ?? ""),
-        tool: String(detail.tool ?? ""),
-        status: String(detail.status ?? ""),
-        agent_id: String(detail.agent_id ?? ""),
-      };
-      if (filters && !Object.entries(filters).every(([k, v]) => labels[k] === v)) continue;
+          const labels: Record<string, string> = {
+            plugin: String(rec.subject ?? ""),
+            tool: String(detail.tool ?? ""),
+            status: String(detail.status ?? ""),
+            agent_id: String(detail.agent_id ?? ""),
+          };
+          if (filters && !Object.entries(filters).every(([k, v]) => labels[k] === v)) return;
 
-      const duration = Number(detail.duration_ms ?? 0);
-      out.push({ ts, value: Number.isFinite(duration) ? duration : 0, labels });
+          const duration = Number(detail.duration_ms ?? 0);
+          out.push({ ts, value: Number.isFinite(duration) ? duration : 0, labels });
+        },
+        {
+          onTruncate: (bytes) =>
+            console.warn(
+              `[mcp-tool-call] audit log read hit the ${bytes}-byte cap — query result is truncated`,
+            ),
+        },
+      );
+    } catch {
+      // A read failure mid-scan returns whatever was parsed so far, matching the
+      // "tolerate one bad file" contract of the other producers.
     }
     return out;
   }

--- a/src/observability/mcp-tool-call-producer.ts
+++ b/src/observability/mcp-tool-call-producer.ts
@@ -1,0 +1,97 @@
+/**
+ * Reads the hash-chained `mcp.tool_call` audit log back as queryable telemetry.
+ *
+ * This closes the loop: the gateway WRITES the audited chain (least privilege —
+ * it only emits), and this producer READS it (least privilege — read-only, no
+ * lock, no god-mode). Out-of-band: it tolerates a concurrently-appending sink by
+ * parsing line-by-line and skipping a malformed trailing partial write.
+ *
+ * `value` carries the call's `duration_ms`; everything else (plugin, tool,
+ * status, agent_id, args_hash) rides in `labels` so a reader can reconstruct the
+ * universal metrics without a second source.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import {
+  type DateRange,
+  type MetricSample,
+  type TelemetryCapability,
+  TELEMETRY_CONTRACT_VERSION,
+  type TelemetryProvider,
+  type TelemetryStream,
+} from "../skills-tuner/core/telemetry.js";
+import { MCP_TOOL_CALL_STREAM } from "./tool-call.js";
+
+interface ToolCallRecord {
+  event?: string;
+  ts?: string;
+  subject?: string;
+  detail?: Record<string, unknown>;
+}
+
+export class McpToolCallTelemetryProducer implements TelemetryProvider {
+  private readonly path: string;
+
+  constructor(opts: { logPath?: string } = {}) {
+    this.path = (opts.logPath ?? "").replace(/^~/, homedir());
+  }
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  capabilities(): TelemetryCapability[] {
+    const has = this.path !== "" && existsSync(this.path);
+    return [
+      {
+        stream: MCP_TOOL_CALL_STREAM,
+        schemaVersion: TELEMETRY_CONTRACT_VERSION,
+        available: has,
+        ...(has ? {} : { reason: "no mcp.tool_call log on this host" }),
+      },
+    ];
+  }
+
+  async query(
+    stream: TelemetryStream,
+    range: DateRange,
+    filters?: Record<string, string>,
+  ): Promise<MetricSample[]> {
+    if (stream !== MCP_TOOL_CALL_STREAM) return [];
+    if (this.path === "" || !existsSync(this.path)) return [];
+
+    const text = readFileSync(this.path, "utf8");
+    const out: MetricSample[] = [];
+    for (const line of text.split("\n")) {
+      const l = line.trim();
+      if (!l) continue;
+      let rec: ToolCallRecord;
+      try {
+        rec = JSON.parse(l) as ToolCallRecord;
+      } catch {
+        continue; // skip a partial trailing write or a corrupt line
+      }
+      if (rec.event !== MCP_TOOL_CALL_STREAM) continue;
+      const detail = rec.detail ?? {};
+      const tsStr = typeof detail.event_ts === "string" ? detail.event_ts : rec.ts;
+      if (!tsStr) continue;
+      const ts = new Date(tsStr);
+      if (Number.isNaN(ts.getTime())) continue;
+      if (ts < range.start || ts >= range.end) continue;
+
+      const labels: Record<string, string> = {
+        plugin: String(rec.subject ?? ""),
+        tool: String(detail.tool ?? ""),
+        status: String(detail.status ?? ""),
+        agent_id: String(detail.agent_id ?? ""),
+        args_hash: String(detail.args_hash ?? ""),
+      };
+      if (filters && !Object.entries(filters).every(([k, v]) => labels[k] === v)) continue;
+
+      const duration = Number(detail.duration_ms ?? 0);
+      out.push({ ts, value: Number.isFinite(duration) ? duration : 0, labels });
+    }
+    return out;
+  }
+}

--- a/src/observability/tool-call-sink.ts
+++ b/src/observability/tool-call-sink.ts
@@ -1,0 +1,238 @@
+/**
+ * Sink for `mcp.tool_call` telemetry + the mandatory-audit Phase-1 intent gate.
+ *
+ * TWO PHASES, governed by the `AuditPolicy`:
+ *
+ *   Phase 1 — intent. `recordIntent()` runs at the gateway BEFORE a tool
+ *     dispatches. Under `enforce` it is a SYNCHRONOUS local append that THROWS
+ *     on failure so the caller can fail closed ("no log → no action"). Under
+ *     `best-effort` it is a no-op — the result log alone is kept, exactly the
+ *     pre-mandatory-audit behaviour. The intent append is local-only: no
+ *     network, no fsync-storm, at most a sub-ms buffered write on the call path.
+ *
+ *   Phase 2 — result. `record()` is the unchanged fire-and-forget result sink.
+ *     NON-NEGOTIABLE: a hub hiccup can never stall tool I/O (the getUpdates-hang
+ *     lesson). It is O(1), synchronous, never throws, never touches disk, and is
+ *     NEVER awaited — it only buffers and arms a deferred flush that drains into
+ *     a hash-chained `AuditLog` OFF the request path, swallowing every error.
+ *
+ * The dedicated tool-call chain is its OWN file — never the tuner's outcome
+ * audit chain — so high-volume call traffic can't bloat or couple to that
+ * certifiable surface, while still being tamper-evident in its own right. Intent
+ * and result records share that one chain so the audit narrative (attempt →
+ * outcome) is complete and ordered.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { AuditLog, type AuditEntry } from "../skills-tuner/core/audit-log.js";
+import {
+  type AuditPolicy,
+  MCP_AUDIT_POLICY_EVENT,
+  MCP_TOOL_CALL_EVENT,
+  MCP_TOOL_CALL_INTENT_EVENT,
+  type ToolCallEvent,
+  type ToolCallIntent,
+} from "./tool-call.js";
+
+export const DEFAULT_TOOL_CALL_LOG = join(
+  homedir(),
+  ".claudeclaw",
+  "telemetry",
+  "mcp-tool-calls.jsonl",
+);
+
+/** The single method the sink needs from its backing chain. Narrowing to this
+ *  lets tests inject a chain whose `append` throws (to exercise enforce's
+ *  fail-closed path) without standing up a real unwritable file. */
+export interface AuditLogLike {
+  append(entry: AuditEntry): unknown;
+}
+
+export interface ToolCallSinkOptions {
+  /** Backing log path. `null`/`":memory:"` keeps the chain in memory. */
+  path?: string | null;
+  /** Arm a deferred timer flush on record (production). When false, the caller
+   *  drives `flush()` — used by tests for deterministic assertions. Default true. */
+  autoFlush?: boolean;
+  /** Mandatory-audit policy. Default `best-effort` (backward-compatible). */
+  policy?: AuditPolicy;
+  /** Test seam — build the backing chain. Production constructs a real
+   *  `AuditLog`; tests can inject a throwing chain to drive enforce's
+   *  fail-closed refusal. */
+  logFactory?: (path: string | null) => AuditLogLike;
+}
+
+export class ToolCallSink {
+  private enabled = true;
+  private policy: AuditPolicy;
+  private buffer: ToolCallEvent[] = [];
+  private flushArmed = false;
+  private log: AuditLogLike | null = null;
+  private readonly path: string | null;
+  private readonly autoFlush: boolean;
+  private readonly logFactory: (path: string | null) => AuditLogLike;
+  /** Bound the buffer so a wedged flusher can't grow memory without limit;
+   *  past the cap we DROP events rather than block or grow — telemetry is
+   *  best-effort and must never threaten the daemon. */
+  private static readonly MAX_BUFFER = 10_000;
+
+  constructor(opts: ToolCallSinkOptions = {}) {
+    this.path = opts.path === undefined ? DEFAULT_TOOL_CALL_LOG : opts.path;
+    this.autoFlush = opts.autoFlush !== false;
+    this.policy = opts.policy ?? "best-effort";
+    this.logFactory = opts.logFactory ?? ((p) => new AuditLog(p ?? ":memory:"));
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  setPolicy(policy: AuditPolicy): void {
+    this.policy = policy;
+  }
+  getPolicy(): AuditPolicy {
+    return this.policy;
+  }
+
+  /** Lazily materialise the shared backing chain. Both the synchronous intent
+   *  append and the async result flush write to this one instance so the hash
+   *  chain stays consistent (JS is single-threaded — neither can interleave
+   *  mid-append). */
+  private ensureLog(): AuditLogLike {
+    if (!this.log) this.log = this.logFactory(this.path);
+    return this.log;
+  }
+
+  /**
+   * PHASE 1 — intent, run on the call path BEFORE dispatch.
+   *
+   * - `enforce`: a SYNCHRONOUS local append. It deliberately does NOT swallow
+   *   errors — a throw propagates so the gateway refuses the call ("no log → no
+   *   action"). Intentionally independent of `enabled`: enforce is a hard
+   *   auditability guarantee, not a metrics nicety, so the intent is recorded
+   *   even when result-capture is toggled off.
+   * - `best-effort`: a no-op. No synchronous gate; the async result log is the
+   *   only record — exactly the pre-mandatory-audit behaviour, so the call path
+   *   is byte-for-byte unchanged.
+   *
+   * The append is local-only: no network and no awaited I/O on the call path.
+   */
+  recordIntent(intent: ToolCallIntent): void {
+    if (this.policy !== "enforce") return;
+    this.ensureLog().append({
+      event: MCP_TOOL_CALL_INTENT_EVENT,
+      subject: intent.plugin,
+      detail: {
+        tool: intent.tool,
+        agent_id: intent.agent_id,
+        args_hash: intent.args_hash,
+        event_ts: intent.ts,
+      },
+    });
+  }
+
+  /**
+   * Boot provenance — record the active policy once at start. Synchronous local
+   * append, emitted only under `enforce` (best-effort must stay write-free at
+   * boot to preserve the pre-mandatory-audit behaviour). Best-effort about its
+   * OWN failure: a boot record must never crash daemon start, so it swallows.
+   */
+  recordPolicy(): void {
+    if (this.policy !== "enforce") return;
+    try {
+      this.ensureLog().append({
+        event: MCP_AUDIT_POLICY_EVENT,
+        detail: { policy: this.policy, recorded_at: new Date().toISOString() },
+      });
+    } catch {
+      // Provenance is documentation; the per-call gate is what enforces.
+    }
+  }
+
+  /** PHASE 2 — result. HOT PATH. Synchronous, O(1), never throws, never awaited. */
+  record(event: ToolCallEvent): void {
+    if (!this.enabled) return;
+    if (this.buffer.length >= ToolCallSink.MAX_BUFFER) return;
+    this.buffer.push(event);
+    this.armFlush();
+  }
+
+  private armFlush(): void {
+    if (!this.autoFlush) return;
+    if (this.flushArmed) return;
+    this.flushArmed = true;
+    const t = setTimeout(() => {
+      this.flushArmed = false;
+      this.flush();
+    }, 0);
+    // Don't keep the event loop alive for a telemetry flush.
+    if (typeof (t as { unref?: () => void }).unref === "function") {
+      (t as { unref: () => void }).unref();
+    }
+  }
+
+  /**
+   * Drain the buffer into the audited chain. Runs OFF the request path (timer
+   * macrotask in production; callable directly in tests for determinism).
+   */
+  flush(): void {
+    if (this.buffer.length === 0) return;
+    const batch = this.buffer;
+    this.buffer = [];
+    try {
+      const log = this.ensureLog();
+      for (const e of batch) {
+        log.append({
+          event: MCP_TOOL_CALL_EVENT,
+          subject: e.plugin,
+          detail: {
+            tool: e.tool,
+            agent_id: e.agent_id,
+            status: e.status,
+            duration_ms: e.duration_ms,
+            args_hash: e.args_hash,
+            event_ts: e.ts,
+            ...(e.error !== undefined ? { error: e.error } : {}),
+          },
+        });
+      }
+    } catch {
+      // Fire-and-forget: a sink failure must never surface on the call path.
+    }
+  }
+
+  /** Test helper — events buffered but not yet flushed. */
+  pending(): readonly ToolCallEvent[] {
+    return this.buffer;
+  }
+}
+
+let sink: ToolCallSink | null = null;
+
+export function getToolCallSink(): ToolCallSink {
+  if (!sink) sink = new ToolCallSink();
+  return sink;
+}
+
+/** The one Phase-2 call the gateway makes per terminal path. Fire-and-forget. */
+export function recordToolCall(event: ToolCallEvent): void {
+  getToolCallSink().record(event);
+}
+
+/**
+ * The Phase-1 call the gateway makes before dispatch. Under `enforce` this can
+ * THROW — the caller MUST treat a throw as "refuse the call". Under best-effort
+ * it is a no-op and never throws.
+ */
+export function recordToolCallIntent(intent: ToolCallIntent): void {
+  getToolCallSink().recordIntent(intent);
+}
+
+/** Test seam — swap in an isolated sink (e.g. `new ToolCallSink(tmpPath)`). */
+export function __setToolCallSinkForTest(s: ToolCallSink | null): void {
+  sink = s;
+}

--- a/src/observability/tool-call-sink.ts
+++ b/src/observability/tool-call-sink.ts
@@ -76,12 +76,28 @@ export class ToolCallSink {
    *  past the cap we DROP events rather than block or grow — telemetry is
    *  best-effort and must never threaten the daemon. */
   private static readonly MAX_BUFFER = 10_000;
+  /** Bound the in-memory chain window on the high-volume tool-call log so the
+   *  process-lifetime singleton can't leak; reads go through the file producer. */
+  private static readonly MAX_RECORDS = 5_000;
+  /** Rotate the tool-call JSONL past this size so an append-only file can't grow
+   *  without bound and the producer's per-query full-file read stays cheap. */
+  private static readonly ROTATE_BYTES = 32 * 1024 * 1024;
+  /** Cap a captured tool `error` string: error text is not redacted and can be
+   *  arbitrarily large (echoed bodies, paths). Truncate before it is retained on
+   *  disk + in memory. */
+  private static readonly MAX_ERROR_LEN = 2_000;
 
   constructor(opts: ToolCallSinkOptions = {}) {
     this.path = opts.path === undefined ? DEFAULT_TOOL_CALL_LOG : opts.path;
     this.autoFlush = opts.autoFlush !== false;
     this.policy = opts.policy ?? "best-effort";
-    this.logFactory = opts.logFactory ?? ((p) => new AuditLog(p ?? ":memory:"));
+    this.logFactory =
+      opts.logFactory ??
+      ((p) =>
+        new AuditLog(p ?? ":memory:", {
+          maxRecords: ToolCallSink.MAX_RECORDS,
+          rotateBytes: ToolCallSink.ROTATE_BYTES,
+        }));
   }
 
   setEnabled(enabled: boolean): void {
@@ -181,10 +197,18 @@ export class ToolCallSink {
    */
   flush(): void {
     if (this.buffer.length === 0) return;
+    // Materialise the chain BEFORE detaching the batch: if the backing log can't
+    // be built, keep the events buffered (bounded by MAX_BUFFER) for the next
+    // flush rather than silently dropping the batch and wedging telemetry.
+    let log: AuditLogLike;
+    try {
+      log = this.ensureLog();
+    } catch {
+      return;
+    }
     const batch = this.buffer;
     this.buffer = [];
     try {
-      const log = this.ensureLog();
       for (const e of batch) {
         log.append({
           event: MCP_TOOL_CALL_EVENT,
@@ -196,13 +220,21 @@ export class ToolCallSink {
             duration_ms: e.duration_ms,
             args_hash: e.args_hash,
             event_ts: e.ts,
-            ...(e.error !== undefined ? { error: e.error } : {}),
+            ...(e.error !== undefined ? { error: ToolCallSink.clampError(e.error) } : {}),
           },
         });
       }
     } catch {
       // Fire-and-forget: a sink failure must never surface on the call path.
     }
+  }
+
+  /** Bound an unredacted tool-error string before it is persisted + retained. */
+  private static clampError(error: string): string {
+    if (error.length <= ToolCallSink.MAX_ERROR_LEN) return error;
+    return `${error.slice(0, ToolCallSink.MAX_ERROR_LEN)}…[truncated ${
+      error.length - ToolCallSink.MAX_ERROR_LEN
+    } chars]`;
   }
 
   /** Test helper — events buffered but not yet flushed. */

--- a/src/observability/tool-call-sink.ts
+++ b/src/observability/tool-call-sink.ts
@@ -145,7 +145,6 @@ export class ToolCallSink {
       detail: {
         tool: intent.tool,
         agent_id: intent.agent_id,
-        args_hash: intent.args_hash,
         event_ts: intent.ts,
       },
     });
@@ -218,7 +217,6 @@ export class ToolCallSink {
             agent_id: e.agent_id,
             status: e.status,
             duration_ms: e.duration_ms,
-            args_hash: e.args_hash,
             event_ts: e.ts,
             ...(e.error !== undefined ? { error: ToolCallSink.clampError(e.error) } : {}),
           },

--- a/src/observability/tool-call.ts
+++ b/src/observability/tool-call.ts
@@ -1,0 +1,80 @@
+/**
+ * The uniform MCP tool-call event — the atom of the Phase A observability hub.
+ *
+ * The gateway (mcp-multiplexer) emits ONE of these per `tools/call`, for every
+ * plugin, with no per-plugin code. Boundary metrics only: call args are reduced
+ * to a stable, non-reversible hash (`args_hash`) — raw args never leave the call
+ * scope (privacy/audit). External (upstream) traffic is out of scope; this is the
+ * gateway boundary, and depth is plugin-opt-in via the view-manifest.
+ */
+
+import { createHash } from "node:crypto";
+
+/** The telemetry stream id AND the audit event name share this literal. */
+export const MCP_TOOL_CALL_STREAM = "mcp.tool_call" as const;
+export const MCP_TOOL_CALL_EVENT = "mcp.tool_call" as const;
+/** Phase 1 (mandatory-audit) intent record — distinct from the result event so
+ *  the metrics producer never counts an intent as a completed call. */
+export const MCP_TOOL_CALL_INTENT_EVENT = "mcp.tool_call_intent" as const;
+/** Boot-provenance record naming the active mandatory-audit policy. */
+export const MCP_AUDIT_POLICY_EVENT = "mcp.audit_policy" as const;
+
+/**
+ * Mandatory-audit policy for the gateway, resolved from config (`settings.mcp.audit`).
+ *
+ * - `enforce`: an action that cannot be logged is REFUSED (fail-closed). The
+ *   Phase-1 intent append is SYNCHRONOUS and a failure refuses the call —
+ *   "no log → no action". Safe because the append is a cheap LOCAL write.
+ * - `best-effort` (default, backward-compatible): logging is fully async
+ *   fire-and-forget and can never block or fail a call. No synchronous intent
+ *   gate; the result log is the only record (exactly the pre-mandatory-audit
+ *   behaviour).
+ */
+export type AuditPolicy = "enforce" | "best-effort";
+
+export type ToolCallStatus = "ok" | "error";
+
+export interface ToolCallEvent {
+  /** ISO-8601 — the call's own timestamp, not the (possibly later) flush time. */
+  ts: string;
+  /** Upstream MCP server name = the plugin label the hub auto-discovers on. */
+  plugin: string;
+  tool: string;
+  /** PTY/bucket identity the call was dispatched under. */
+  agent_id: string;
+  status: ToolCallStatus;
+  duration_ms: number;
+  args_hash: string;
+  /** Present only on `status: "error"`. */
+  error?: string;
+}
+
+/**
+ * The Phase-1 INTENT atom: what the gateway records BEFORE dispatching a tool
+ * call. No `status`/`duration_ms` — the call hasn't run yet. Under `enforce`
+ * this is written synchronously and a write failure refuses the call.
+ */
+export interface ToolCallIntent {
+  /** ISO-8601 — when the intent was recorded (pre-dispatch). */
+  ts: string;
+  plugin: string;
+  tool: string;
+  /** PTY/bucket identity the call is dispatched under. */
+  agent_id: string;
+  args_hash: string;
+}
+
+/**
+ * Stable, non-reversible digest of call arguments. 16 hex chars is enough to
+ * spot identical-arg repeats without exposing — or being able to reconstruct —
+ * the payload. Never throws (falls back to a string coercion for exotic input).
+ */
+export function hashArgs(args: unknown): string {
+  let serial: string;
+  try {
+    serial = JSON.stringify(args ?? null);
+  } catch {
+    serial = String(args);
+  }
+  return createHash("sha256").update(serial).digest("hex").slice(0, 16);
+}

--- a/src/observability/tool-call.ts
+++ b/src/observability/tool-call.ts
@@ -2,13 +2,14 @@
  * The uniform MCP tool-call event — the atom of the Phase A observability hub.
  *
  * The gateway (mcp-multiplexer) emits ONE of these per `tools/call`, for every
- * plugin, with no per-plugin code. Boundary metrics only: call args are reduced
- * to a stable, non-reversible hash (`args_hash`) — raw args never leave the call
- * scope (privacy/audit). External (upstream) traffic is out of scope; this is the
- * gateway boundary, and depth is plugin-opt-in via the view-manifest.
+ * plugin, with no per-plugin code. Boundary metrics only: tool name + status +
+ * duration are the whole signal. Call ARGS are NOT captured — not even a hash.
+ * A hash of low-entropy args (short filenames, known command names) is
+ * brute-forceable, which would undercut the "nothing sensitive in telemetry"
+ * guarantee, and tool name + status already carry the signal the tuner needs.
+ * External (upstream) traffic is out of scope; this is the gateway boundary, and
+ * depth is plugin-opt-in via the view-manifest.
  */
-
-import { createHash } from "node:crypto";
 
 /** The telemetry stream id AND the audit event name share this literal. */
 export const MCP_TOOL_CALL_STREAM = "mcp.tool_call" as const;
@@ -44,7 +45,6 @@ export interface ToolCallEvent {
   agent_id: string;
   status: ToolCallStatus;
   duration_ms: number;
-  args_hash: string;
   /** Present only on `status: "error"`. */
   error?: string;
 }
@@ -61,20 +61,4 @@ export interface ToolCallIntent {
   tool: string;
   /** PTY/bucket identity the call is dispatched under. */
   agent_id: string;
-  args_hash: string;
-}
-
-/**
- * Stable, non-reversible digest of call arguments. 16 hex chars is enough to
- * spot identical-arg repeats without exposing — or being able to reconstruct —
- * the payload. Never throws (falls back to a string coercion for exotic input).
- */
-export function hashArgs(args: unknown): string {
-  let serial: string;
-  try {
-    serial = JSON.stringify(args ?? null);
-  } catch {
-    serial = String(args);
-  }
-  return createHash("sha256").update(serial).digest("hex").slice(0, 16);
 }

--- a/src/skills-tuner/core/__tests__/scope.test.ts
+++ b/src/skills-tuner/core/__tests__/scope.test.ts
@@ -25,8 +25,8 @@ const RANGE: DateRange = {
   end: new Date("2026-05-31T00:00:00.000Z"),
 };
 
-/** Fixed agent surface rooted at /home/simon/agent (matches defaultAgentSurface). */
-const SURFACE: AgentSurface = defaultAgentSurface("/home/simon");
+/** Fixed agent surface rooted at /home/user/agent (matches defaultAgentSurface). */
+const SURFACE: AgentSurface = defaultAgentSurface("/home/user");
 
 function s(labels: Record<string, string>, value = 1): MetricSample {
   return { ts: new Date("2026-05-10T00:00:00.000Z"), value, labels };
@@ -65,7 +65,7 @@ describe("defaultAgentSurface", () => {
     // A generic cron tag would attribute the whole cron/cost stream to the agent.
     expect(SURFACE.jobMarkers).not.toContain('source="cron"');
     // Only agent-specific markers remain.
-    expect(SURFACE.jobMarkers).toEqual(["bus-scheduler", "/home/simon/agent"]);
+    expect(SURFACE.jobMarkers).toEqual(["bus-scheduler", "/home/user/agent"]);
   });
 });
 
@@ -83,7 +83,7 @@ describe("sampleInAgentScope — cron/cost attribution (fix #1)", () => {
     });
 
     it(`${stream}: a unit anchored under the agent root IS attributed`, () => {
-      const byUnit = s({ unit: "/home/simon/agent/jobs/nightly.service" });
+      const byUnit = s({ unit: "/home/user/agent/jobs/nightly.service" });
       expect(sampleInAgentScope(stream, byUnit, SURFACE)).toBe(true);
     });
 
@@ -97,22 +97,22 @@ describe("sampleInAgentScope — cron/cost attribution (fix #1)", () => {
 describe("sampleInAgentScope — memory_access root boundary (fix #3)", () => {
   it("keeps a file under the agent root", () => {
     expect(
-      sampleInAgentScope("memory_access", s({ file: "/home/simon/agent/memory/x.md" }), SURFACE),
+      sampleInAgentScope("memory_access", s({ file: "/home/user/agent/memory/x.md" }), SURFACE),
     ).toBe(true);
   });
 
   it("keeps the root path itself", () => {
-    expect(sampleInAgentScope("memory_access", s({ file: "/home/simon/agent" }), SURFACE)).toBe(
+    expect(sampleInAgentScope("memory_access", s({ file: "/home/user/agent" }), SURFACE)).toBe(
       true,
     );
   });
 
   it("does NOT match the agent-backup sibling directory", () => {
-    // /home/simon/agent must not prefix-match /home/simon/agent-backup/...
+    // /home/user/agent must not prefix-match /home/user/agent-backup/...
     expect(
       sampleInAgentScope(
         "memory_access",
-        s({ file: "/home/simon/agent-backup/secrets.md" }),
+        s({ file: "/home/user/agent-backup/secrets.md" }),
         SURFACE,
       ),
     ).toBe(false);

--- a/src/skills-tuner/core/__tests__/scope.test.ts
+++ b/src/skills-tuner/core/__tests__/scope.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "bun:test";
+import type {
+  DateRange,
+  MetricSample,
+  TelemetryCapability,
+  TelemetryProvider,
+  TelemetryStream,
+} from "../telemetry.js";
+import {
+  AGENT_SESSION_DIRS_FILTER_KEY,
+  type AgentSurface,
+  DEFAULT_SCOPE,
+  PREDICATE_STREAMS,
+  SCOPE_ACK_LABEL,
+  SCOPE_FILTER_KEY,
+  SOURCE_SCOPED_STREAMS,
+  ScopedTelemetryProvider,
+  defaultAgentSurface,
+  resolveScope,
+  sampleInAgentScope,
+} from "../scope.js";
+
+const RANGE: DateRange = {
+  start: new Date("2026-05-01T00:00:00.000Z"),
+  end: new Date("2026-05-31T00:00:00.000Z"),
+};
+
+/** Fixed agent surface rooted at /home/simon/agent (matches defaultAgentSurface). */
+const SURFACE: AgentSurface = defaultAgentSurface("/home/simon");
+
+function s(labels: Record<string, string>, value = 1): MetricSample {
+  return { ts: new Date("2026-05-10T00:00:00.000Z"), value, labels };
+}
+
+/** Inner provider that records the filters it received and returns fixed samples. */
+class FakeProvider implements TelemetryProvider {
+  lastFilters?: Record<string, string>;
+  constructor(private readonly samples: MetricSample[]) {}
+  contractVersion(): string {
+    return "1.1.0";
+  }
+  capabilities(): TelemetryCapability[] {
+    return [];
+  }
+  async query(
+    _stream: TelemetryStream,
+    _range: DateRange,
+    filters?: Record<string, string>,
+  ): Promise<MetricSample[]> {
+    this.lastFilters = filters;
+    return this.samples;
+  }
+}
+
+describe("resolveScope precedence", () => {
+  it("per-subject > global > default", () => {
+    expect(resolveScope("all", "agent")).toBe("agent");
+    expect(resolveScope("agent", undefined)).toBe("agent");
+    expect(resolveScope(undefined, undefined)).toBe(DEFAULT_SCOPE);
+  });
+});
+
+describe("defaultAgentSurface", () => {
+  it('does NOT carry the generic source="cron" marker (fix #1)', () => {
+    // A generic cron tag would attribute the whole cron/cost stream to the agent.
+    expect(SURFACE.jobMarkers).not.toContain('source="cron"');
+    // Only agent-specific markers remain.
+    expect(SURFACE.jobMarkers).toEqual(["bus-scheduler", "/home/simon/agent"]);
+  });
+});
+
+describe("sampleInAgentScope — cron/cost attribution (fix #1)", () => {
+  for (const stream of ["cron_run", "session_cost"] as const) {
+    it(`${stream}: generic cron row is NOT attributed to the agent`, () => {
+      // Carries the generic tag every cron row has, but no agent-specific marker.
+      const generic = s({ job: '<channel source="cron" chat_id="telegram:123">', model: "opus" });
+      expect(sampleInAgentScope(stream, generic, SURFACE)).toBe(false);
+    });
+
+    it(`${stream}: bus-scheduler row IS attributed`, () => {
+      const agentJob = s({ job: '<channel source="cron" chat_id="bus-scheduler:abc">' });
+      expect(sampleInAgentScope(stream, agentJob, SURFACE)).toBe(true);
+    });
+
+    it(`${stream}: a unit anchored under the agent root IS attributed`, () => {
+      const byUnit = s({ unit: "/home/simon/agent/jobs/nightly.service" });
+      expect(sampleInAgentScope(stream, byUnit, SURFACE)).toBe(true);
+    });
+
+    it(`${stream}: empty markers never match everything`, () => {
+      const surfaceWithEmpty: AgentSurface = { ...SURFACE, jobMarkers: [""] };
+      expect(sampleInAgentScope(stream, s({ job: "anything" }), surfaceWithEmpty)).toBe(false);
+    });
+  }
+});
+
+describe("sampleInAgentScope — memory_access root boundary (fix #3)", () => {
+  it("keeps a file under the agent root", () => {
+    expect(
+      sampleInAgentScope("memory_access", s({ file: "/home/simon/agent/memory/x.md" }), SURFACE),
+    ).toBe(true);
+  });
+
+  it("keeps the root path itself", () => {
+    expect(sampleInAgentScope("memory_access", s({ file: "/home/simon/agent" }), SURFACE)).toBe(
+      true,
+    );
+  });
+
+  it("does NOT match the agent-backup sibling directory", () => {
+    // /home/simon/agent must not prefix-match /home/simon/agent-backup/...
+    expect(
+      sampleInAgentScope(
+        "memory_access",
+        s({ file: "/home/simon/agent-backup/secrets.md" }),
+        SURFACE,
+      ),
+    ).toBe(false);
+  });
+
+  it("drops a sample with no file label", () => {
+    expect(sampleInAgentScope("memory_access", s({}), SURFACE)).toBe(false);
+  });
+});
+
+describe("sampleInAgentScope — fail closed for non-predicate streams (fix #2)", () => {
+  const nonPredicate: TelemetryStream[] = [
+    "hook_exec",
+    "skill_access",
+    "template_feedback",
+    "mode_dispatch",
+    "mcp.tool_call",
+  ];
+  for (const stream of nonPredicate) {
+    it(`${stream}: dropped (no attribution, no ack)`, () => {
+      expect(sampleInAgentScope(stream, s({ some: "label" }), SURFACE)).toBe(false);
+    });
+    it(`${stream}: kept when the producer stamps the explicit ack`, () => {
+      expect(sampleInAgentScope(stream, s({ [SCOPE_ACK_LABEL]: "agent" }), SURFACE)).toBe(true);
+    });
+  }
+
+  it("a wrong ack value does not pass", () => {
+    expect(sampleInAgentScope("mode_dispatch", s({ [SCOPE_ACK_LABEL]: "all" }), SURFACE)).toBe(
+      false,
+    );
+  });
+
+  it("source-scoped streams (tool_call, agent_dispatch) are kept (narrowed upstream)", () => {
+    for (const stream of SOURCE_SCOPED_STREAMS) {
+      expect(sampleInAgentScope(stream, s({}), SURFACE)).toBe(true);
+    }
+  });
+
+  it("allowlists are disjoint and cover the intended streams", () => {
+    for (const stream of PREDICATE_STREAMS) {
+      expect(SOURCE_SCOPED_STREAMS.has(stream)).toBe(false);
+    }
+    expect([...PREDICATE_STREAMS].sort()).toEqual(["cron_run", "memory_access", "session_cost"]);
+  });
+});
+
+describe("ScopedTelemetryProvider", () => {
+  it("all scope is a pure pass-through (no filters injected, no drops)", async () => {
+    const inner = new FakeProvider([s({ some: "x" })]);
+    const p = new ScopedTelemetryProvider(inner, "all", SURFACE);
+    const out = await p.query("mode_dispatch", RANGE);
+    expect(out).toHaveLength(1);
+    expect(inner.lastFilters).toBeUndefined();
+  });
+
+  it("agent scope injects scope hints into the inner query", async () => {
+    const inner = new FakeProvider([]);
+    const p = new ScopedTelemetryProvider(inner, "agent", SURFACE);
+    await p.query("tool_call", RANGE, { existing: "keep" });
+    expect(inner.lastFilters?.[SCOPE_FILTER_KEY]).toBe("agent");
+    expect(inner.lastFilters?.[AGENT_SESSION_DIRS_FILTER_KEY]).toBe(
+      SURFACE.sessionProjectDirs.join(","),
+    );
+    expect(inner.lastFilters?.existing).toBe("keep");
+  });
+
+  it("agent scope drops generic cron rows but keeps agent ones", async () => {
+    const inner = new FakeProvider([
+      s({ job: '<channel source="cron" chat_id="telegram:1">' }), // generic → dropped
+      s({ job: '<channel source="cron" chat_id="bus-scheduler:2">' }), // agent → kept
+    ]);
+    const p = new ScopedTelemetryProvider(inner, "agent", SURFACE);
+    const out = await p.query("cron_run", RANGE);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.labels?.job).toContain("bus-scheduler");
+  });
+
+  it("agent scope fails closed on a non-predicate stream whose producer ignores the hint", async () => {
+    // Producer returns rows without honouring __scope / without an ack → all dropped.
+    const inner = new FakeProvider([s({ mode: "agentic" }), s({ mode: "plan" })]);
+    const p = new ScopedTelemetryProvider(inner, "agent", SURFACE);
+    const out = await p.query("mode_dispatch", RANGE);
+    expect(out).toHaveLength(0);
+  });
+});

--- a/src/skills-tuner/core/audit-log.ts
+++ b/src/skills-tuner/core/audit-log.ts
@@ -1,0 +1,178 @@
+/**
+ * OutcomeLoop audit log — the commercial-auditability deliverable.
+ *
+ * Every proposal, activation, baseline, verdict, approval and revert is an
+ * immutable, attributable, exportable record an external auditor can inspect:
+ * *why was X changed, did it measurably help, who approved it, how was it
+ * reverted?* Append-only JSONL with a SHA-256 hash chain → tamper-evident
+ * (any edit to an earlier line breaks every subsequent `hash`). One certifiable
+ * surface, pairing with the single `TelemetryProvider`.
+ *
+ * Phase 1 emits: fitness_active / fitness_inactive (activation gate),
+ * baseline_snapshot (at apply), verdict (maturation), revert (defensive close).
+ * telemetry_query records each fitness measurement served over the MCP bridge,
+ * so the provenance of every number that fed a verdict is itself in the chain.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { dirname } from "node:path";
+import { homedir } from "node:os";
+
+export type AuditEvent =
+  | "fitness_active"
+  | "fitness_inactive"
+  | "baseline_snapshot"
+  | "verdict"
+  | "revert"
+  | "proposal"
+  | "telemetry_query"
+  // Proposal-gate lifecycle over the MCP bridge (gate-mcp.ts). detail carries
+  // source (cron|research|mcp) so an auditor reads which surface drove the call.
+  | "gate_propose"
+  | "gate_apply"
+  | "gate_refuse"
+  | "gate_mature"
+  // Provenance: the active global + per-subject tuning scope at boot/registration.
+  // An auditor reads "the tuner operated at scope=X" from one immutable record.
+  | "scope_registration"
+  // Phase A observability hub: one tamper-evident record per MCP tool call,
+  // emitted by the gateway (mcp-multiplexer) onto a DEDICATED tool-call chain
+  // (never the tuner's outcome chain). subject=plugin; detail carries tool,
+  // status, duration_ms, agent_id, args_hash (no raw args).
+  | "mcp.tool_call"
+  // Mandatory-audit Phase 1: the INTENT record written synchronously at the
+  // gateway BEFORE a tool dispatches, under `audit: "enforce"`. Distinct event
+  // name (not `mcp.tool_call`) so the metrics producer — which filters on
+  // `mcp.tool_call` — never counts an intent as a completed call. subject=plugin;
+  // detail carries tool, agent_id, args_hash, event_ts (no status/duration — the
+  // call hasn't run yet). Pairs with the later `mcp.tool_call` result record.
+  | "mcp.tool_call_intent"
+  // Boot provenance: the active mandatory-audit policy (enforce|best-effort)
+  // recorded once at multiplexer start under enforce, so an auditor reads
+  // "the gateway operated fail-closed" from the chain itself.
+  | "mcp.audit_policy";
+
+/** The author-supplied content of an audit record (everything but the chain fields). */
+export interface AuditEntry {
+  event: AuditEvent;
+  subject?: string;
+  metric?: string;
+  proposal_id?: string;
+  commit_sha?: string;
+  /** Attribution: `system` for automated steps, `human:<id>` for gated approvals. */
+  actor?: string;
+  detail?: Record<string, unknown>;
+}
+
+/** A persisted record: the entry plus immutable chain metadata. */
+export interface AuditRecord extends AuditEntry {
+  seq: number;
+  ts: string; // ISO-8601
+  prev_hash: string;
+  hash: string;
+}
+
+const GENESIS_HASH = "0".repeat(64);
+
+/** Canonical, stable serialization of the chained fields (key order fixed). */
+function canonical(seq: number, ts: string, prevHash: string, entry: AuditEntry): string {
+  return JSON.stringify({
+    seq,
+    ts,
+    prev_hash: prevHash,
+    event: entry.event,
+    subject: entry.subject ?? null,
+    metric: entry.metric ?? null,
+    proposal_id: entry.proposal_id ?? null,
+    commit_sha: entry.commit_sha ?? null,
+    actor: entry.actor ?? "system",
+    detail: entry.detail ?? {},
+  });
+}
+
+function hashRecord(seq: number, ts: string, prevHash: string, entry: AuditEntry): string {
+  return createHash("sha256")
+    .update(canonical(seq, ts, prevHash, entry))
+    .digest("hex");
+}
+
+/**
+ * Append-only audit log. File-backed (JSONL) when given a path; in-memory when
+ * `path` is omitted or `":memory:"` (tests). Reads existing tail to continue
+ * the chain across process restarts.
+ */
+export class AuditLog {
+  private readonly path: string | null;
+  private records: AuditRecord[] = [];
+  private lastHash = GENESIS_HASH;
+  private seq = 0;
+
+  constructor(path?: string) {
+    this.path = path && path !== ":memory:" ? path.replace(/^~/, homedir()) : null;
+    if (this.path && existsSync(this.path)) this.loadTail();
+  }
+
+  private loadTail(): void {
+    const text = readFileSync(this.path as string, "utf8");
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const rec = JSON.parse(trimmed) as AuditRecord;
+      this.records.push(rec);
+    }
+    const last = this.records.at(-1);
+    if (last) {
+      this.lastHash = last.hash;
+      this.seq = last.seq;
+    }
+  }
+
+  append(entry: AuditEntry): AuditRecord {
+    const seq = this.seq + 1;
+    const ts = new Date().toISOString();
+    const prev_hash = this.lastHash;
+    const hash = hashRecord(seq, ts, prev_hash, entry);
+    const record: AuditRecord = {
+      seq,
+      ts,
+      prev_hash,
+      hash,
+      event: entry.event,
+      ...(entry.subject !== undefined ? { subject: entry.subject } : {}),
+      ...(entry.metric !== undefined ? { metric: entry.metric } : {}),
+      ...(entry.proposal_id !== undefined ? { proposal_id: entry.proposal_id } : {}),
+      ...(entry.commit_sha !== undefined ? { commit_sha: entry.commit_sha } : {}),
+      actor: entry.actor ?? "system",
+      ...(entry.detail !== undefined ? { detail: entry.detail } : {}),
+    };
+    if (this.path) {
+      mkdirSync(dirname(this.path), { recursive: true });
+      appendFileSync(this.path, `${JSON.stringify(record)}\n`);
+    }
+    this.records.push(record);
+    this.lastHash = hash;
+    this.seq = seq;
+    return record;
+  }
+
+  all(): readonly AuditRecord[] {
+    return this.records;
+  }
+
+  /** Re-derive the chain and report the first index where it breaks, if any. */
+  verifyChain(): { ok: boolean; brokenAtSeq?: number } {
+    let prev = GENESIS_HASH;
+    for (const r of this.records) {
+      const expected = hashRecord(r.seq, r.ts, prev, r);
+      if (expected !== r.hash) return { ok: false, brokenAtSeq: r.seq };
+      prev = r.hash;
+    }
+    return { ok: true };
+  }
+
+  /** Exportable JSONL snapshot for an external auditor. */
+  exportJsonl(): string {
+    return this.records.map((r) => JSON.stringify(r)).join("\n");
+  }
+}

--- a/src/skills-tuner/core/audit-log.ts
+++ b/src/skills-tuner/core/audit-log.ts
@@ -39,14 +39,14 @@ export type AuditEvent =
   // Phase A observability hub: one tamper-evident record per MCP tool call,
   // emitted by the gateway (mcp-multiplexer) onto a DEDICATED tool-call chain
   // (never the tuner's outcome chain). subject=plugin; detail carries tool,
-  // status, duration_ms, agent_id, args_hash (no raw args).
+  // status, duration_ms, agent_id (no args — not even a hash).
   | "mcp.tool_call"
   // Mandatory-audit Phase 1: the INTENT record written synchronously at the
   // gateway BEFORE a tool dispatches, under `audit: "enforce"`. Distinct event
   // name (not `mcp.tool_call`) so the metrics producer — which filters on
   // `mcp.tool_call` — never counts an intent as a completed call. subject=plugin;
-  // detail carries tool, agent_id, args_hash, event_ts (no status/duration — the
-  // call hasn't run yet). Pairs with the later `mcp.tool_call` result record.
+  // detail carries tool, agent_id, event_ts (no status/duration — the call
+  // hasn't run yet; no args). Pairs with the later `mcp.tool_call` result record.
   | "mcp.tool_call_intent"
   // Boot provenance: the active mandatory-audit policy (enforce|best-effort)
   // recorded once at multiplexer start under enforce, so an auditor reads

--- a/src/skills-tuner/core/audit-log.ts
+++ b/src/skills-tuner/core/audit-log.ts
@@ -14,7 +14,7 @@
  * so the provenance of every number that fed a verdict is itself in the chain.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { dirname } from "node:path";
 import { homedir } from "node:os";
@@ -97,6 +97,22 @@ function hashRecord(seq: number, ts: string, prevHash: string, entry: AuditEntry
     .digest("hex");
 }
 
+/** Tuning knobs for a file-backed chain. Both default to "off", which preserves
+ *  the original unbounded, non-rotating outcome-chain behaviour byte-for-byte. */
+export interface AuditLogOptions {
+  /** Ring-buffer cap on the in-memory `records[]` window. Omit for unbounded
+   *  (the low-volume outcome chain, which is queried via `.all()`). The
+   *  high-volume tool-call chain sets this so a process-lifetime singleton can't
+   *  leak memory — its reads go through the file-based producer, not `.all()`. */
+  maxRecords?: number;
+  /** Rotate the active file to `<path>.1` once it exceeds this many bytes. Omit
+   *  to never rotate (the outcome chain must stay one continuous, verifiable
+   *  file). Rotation restarts the on-disk chain segment; each segment is
+   *  independently `verifyChain()`-able — intended for the high-volume tool-call
+   *  chain where bounded files matter more than one cross-rotation chain. */
+  rotateBytes?: number;
+}
+
 /**
  * Append-only audit log. File-backed (JSONL) when given a path; in-memory when
  * `path` is omitted or `":memory:"` (tests). Reads existing tail to continue
@@ -104,22 +120,54 @@ function hashRecord(seq: number, ts: string, prevHash: string, entry: AuditEntry
  */
 export class AuditLog {
   private readonly path: string | null;
+  private readonly maxRecords?: number;
+  private readonly rotateBytes?: number;
   private records: AuditRecord[] = [];
   private lastHash = GENESIS_HASH;
   private seq = 0;
 
-  constructor(path?: string) {
+  constructor(path?: string, opts: AuditLogOptions = {}) {
     this.path = path && path !== ":memory:" ? path.replace(/^~/, homedir()) : null;
+    this.maxRecords = opts.maxRecords;
+    this.rotateBytes = opts.rotateBytes;
     if (this.path && existsSync(this.path)) this.loadTail();
   }
 
+  /** Drop the oldest retained records once the in-memory window exceeds the cap.
+   *  Chain fields (`seq`/`lastHash`) live outside `records[]`, so trimming the
+   *  window never disturbs chain continuity for subsequent appends. */
+  private trimWindow(): void {
+    if (this.maxRecords === undefined) return;
+    while (this.records.length > this.maxRecords) this.records.shift();
+  }
+
   private loadTail(): void {
-    const text = readFileSync(this.path as string, "utf8");
+    let text: string;
+    try {
+      text = readFileSync(this.path as string, "utf8");
+    } catch {
+      // Unreadable existing file must not brick construction — start a fresh
+      // chain segment rather than throw on the call path that lazily builds us.
+      return;
+    }
     for (const line of text.split("\n")) {
       const trimmed = line.trim();
       if (!trimmed) continue;
-      const rec = JSON.parse(trimmed) as AuditRecord;
+      let rec: AuditRecord;
+      try {
+        rec = JSON.parse(trimmed) as AuditRecord;
+      } catch {
+        // A torn/partial final line (crash or full disk mid-appendFileSync) or a
+        // corrupt entry must NEVER throw here: under `audit: "enforce"` the first
+        // tool call lazily constructs this log, and a throw would fail the whole
+        // MCP gateway closed and permanently (see ToolCallSink.recordIntent). The
+        // producer already tolerates such lines; the writer now does too. Skip
+        // and continue from the valid records — verifyChain() still surfaces any
+        // real mid-chain tampering.
+        continue;
+      }
       this.records.push(rec);
+      this.trimWindow();
     }
     const last = this.records.at(-1);
     if (last) {
@@ -128,7 +176,66 @@ export class AuditLog {
     }
   }
 
+  /** Re-read the actual on-disk tail and resync `seq`/`lastHash` to it. Closes
+   *  the multi-writer chain-fork window: if another process (e.g. the CLI `apply`
+   *  alongside the served daemon) appended since we last wrote, we chain off that
+   *  real last record instead of forking a duplicate `seq` off stale in-memory
+   *  state. Best-effort and never throws — on any read error we keep our own
+   *  state. */
+  private resyncFromDisk(): void {
+    if (!this.path || !existsSync(this.path)) return;
+    let text: string;
+    try {
+      text = readFileSync(this.path, "utf8");
+    } catch {
+      return;
+    }
+    const lines = text.split("\n");
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const trimmed = lines[i].trim();
+      if (!trimmed) continue;
+      try {
+        const rec = JSON.parse(trimmed) as AuditRecord;
+        if (typeof rec.seq === "number" && typeof rec.hash === "string") {
+          if (rec.seq >= this.seq) {
+            this.seq = rec.seq;
+            this.lastHash = rec.hash;
+          }
+          return;
+        }
+      } catch {
+        // Torn final line — try the previous one.
+      }
+    }
+  }
+
+  /** Rotate the active file to `<path>.1` once it grows past `rotateBytes`. The
+   *  new segment restarts from an empty file; in-process `seq`/`lastHash` stay
+   *  monotonic for the current run. Best-effort — a rotation failure must not
+   *  break the append. */
+  private maybeRotate(): void {
+    if (this.rotateBytes === undefined || !this.path) return;
+    try {
+      if (!existsSync(this.path)) return;
+      if (statSync(this.path).size < this.rotateBytes) return;
+      renameSync(this.path, `${this.path}.1`);
+      // Start a fresh, independently-verifiable segment: the new file begins at
+      // GENESIS so a reader of the active file alone sees an intact chain.
+      this.seq = 0;
+      this.lastHash = GENESIS_HASH;
+      this.records = [];
+    } catch {
+      // Keep appending to the current file if rotation can't proceed.
+    }
+  }
+
   append(entry: AuditEntry): AuditRecord {
+    if (this.path) {
+      // Chain off the real on-disk tail (multi-writer safety) and rotate an
+      // oversized segment before deciding this record's seq/prev_hash.
+      this.resyncFromDisk();
+      this.maybeRotate();
+    }
     const seq = this.seq + 1;
     const ts = new Date().toISOString();
     const prev_hash = this.lastHash;
@@ -151,6 +258,7 @@ export class AuditLog {
       appendFileSync(this.path, `${JSON.stringify(record)}\n`);
     }
     this.records.push(record);
+    this.trimWindow();
     this.lastHash = hash;
     this.seq = seq;
     return record;

--- a/src/skills-tuner/core/scope.ts
+++ b/src/skills-tuner/core/scope.ts
@@ -88,8 +88,8 @@ export interface AgentSurface {
 
 /**
  * Claude Code encodes a project cwd into a `~/.claude/projects` dir name by
- * replacing path separators and dots with `-` (e.g. `/home/simon/agent` →
- * `-home-simon-agent`). We match dir-name PREFIXES with this, so a deeper agent
+ * replacing path separators and dots with `-` (e.g. `/home/user/agent` →
+ * `-home-user-agent`). We match dir-name PREFIXES with this, so a deeper agent
  * cwd still resolves under its root.
  */
 export function encodeProjectDir(absPath: string): string {
@@ -98,11 +98,11 @@ export function encodeProjectDir(absPath: string): string {
 
 /**
  * Default agent surface for a host whose agent lives under `~/agent` (the
- * ProDesk layout in this repo: `~/agent/skills`, `~/agent/agents`, cron jobs the
+ * The agent layout in this repo: `~/agent/skills`, `~/agent/agents`, cron jobs the
  * agent schedules via the bus-scheduler).
  *
  * FLAGGED AMBIGUITY — agent sessions: the autonomous agent and interactive Claude
- * Code sessions can both run with cwd `~` (project dir `-home-simon`), which would
+ * Code sessions can both run with cwd `~` (project dir `-home-user`), which would
  * make the two indistinguishable by directory. We therefore bound agent sessions
  * to project dirs encoding a path UNDER `~/agent` (a strict subset). If the agent
  * actually runs from `~`, this UNDER-includes its sessions — the conservative
@@ -169,7 +169,7 @@ export const SOURCE_SCOPED_STREAMS: ReadonlySet<TelemetryStream> = new Set<Telem
 ]);
 
 /** True when `file` lives at or under one of `roots` on a path-SEGMENT boundary
- * (so root `/home/simon/agent` does NOT match `/home/simon/agent-backup/...`). */
+ * (so root `/home/user/agent` does NOT match `/home/user/agent-backup/...`). */
 function fileUnderRoot(file: string, roots: readonly string[]): boolean {
   if (file === "") return false;
   return roots.some((r) => {

--- a/src/skills-tuner/core/scope.ts
+++ b/src/skills-tuner/core/scope.ts
@@ -1,0 +1,246 @@
+/**
+ * Tuning scope — the operator's control over the tuner's blast radius.
+ *
+ * The tuner operates on the GENERAL Claude Code surface (`~/.claude/*` config +
+ * ALL session transcripts), so a change reaches the operator's whole Claude Code
+ * setup, not just the autonomous agent. Some deployments must NOT grant that. So
+ * scope is an explicit, audited product control, not an implementation detail:
+ *
+ *   - `all`   (default) — tune everything. scan_dirs span `~/.claude/*` and every
+ *                         telemetry stream is read unfiltered. The current,
+ *                         backward-compatible behaviour.
+ *   - `agent` — restrict every subject to the AGENT's own surface: its skills /
+ *               hooks / agents dirs under `~/agent/*`, and telemetry filtered to
+ *               agent-originated rows (agent sessions, cron/cost rows the agent
+ *               produced). A change can then only touch what the agent owns.
+ *
+ * Scope is set globally and may be overridden per subject. The effective scope of
+ * a subject is `per-subject ?? global ?? all`. Subjects never read raw sources —
+ * they only call `provider.query(...)`, so agent-scoping a stream is done by the
+ * single `ScopedTelemetryProvider` wrapper here (inject filters + post-filter by
+ * an attribution predicate), keeping every subject scope-agnostic.
+ *
+ * AMBIGUITY (flagged, see `defaultAgentSurface`): on a single-operator host the
+ * agent and the general user share the same home, so "the agent's surface" cannot
+ * always be cleanly separated from the general one by path or label alone. Where
+ * it can't, we take the CONSERVATIVE bound (narrow — never tune outside the
+ * agent) and document it on the relevant field/predicate below.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type {
+  DateRange,
+  MetricSample,
+  TelemetryCapability,
+  TelemetryProvider,
+  TelemetryStream,
+} from "./telemetry.js";
+
+export const SCOPES = ["all", "agent"] as const;
+export type Scope = (typeof SCOPES)[number];
+
+/** Default when neither a per-subject nor a global scope is set: optimise everything. */
+export const DEFAULT_SCOPE: Scope = "all";
+
+export function isScope(v: unknown): v is Scope {
+  return typeof v === "string" && (SCOPES as readonly string[]).includes(v);
+}
+
+/**
+ * Effective scope of a subject: per-subject override wins over the global setting,
+ * which wins over the `all` default. Mirrors the `subjectConfig` precedence rule.
+ */
+export function resolveScope(global: Scope | undefined, perSubject: Scope | undefined): Scope {
+  return perSubject ?? global ?? DEFAULT_SCOPE;
+}
+
+/**
+ * The concrete definition of "the agent's surface" — what `agent` scope restricts
+ * to. Conservative by construction: every field names a STRICT SUBSET of the
+ * general surface, so an `agent`-scoped subject can only ever see less than an
+ * `all`-scoped one.
+ */
+export interface AgentSurface {
+  /** Filesystem roots the agent owns; scan_dirs + file-labelled samples are bounded to these. */
+  roots: string[];
+  /** The agent's skills dir(s) — the SkillsSubject scan surface under `agent` scope. */
+  skillsDirs: string[];
+  /**
+   * Encoded `~/.claude/projects/<enc-cwd>` dir-name prefixes that hold agent
+   * sessions. Session-derived streams (tool_call / agent_dispatch / memory_access)
+   * are restricted to transcripts under these dirs.
+   */
+  sessionProjectDirs: string[];
+  /**
+   * Substrings that mark a `session_cost` / `cron_run` row as agent-originated
+   * (matched against the `job` / `unit` label). The cost store's `job` is
+   * free-text, so attribution is substring-based, mirroring CronSubject.costJobMatch.
+   */
+  jobMarkers: string[];
+}
+
+/**
+ * Claude Code encodes a project cwd into a `~/.claude/projects` dir name by
+ * replacing path separators and dots with `-` (e.g. `/home/simon/agent` →
+ * `-home-simon-agent`). We match dir-name PREFIXES with this, so a deeper agent
+ * cwd still resolves under its root.
+ */
+export function encodeProjectDir(absPath: string): string {
+  return absPath.replace(/[/.]/g, "-");
+}
+
+/**
+ * Default agent surface for a host whose agent lives under `~/agent` (the
+ * ProDesk layout in this repo: `~/agent/skills`, `~/agent/agents`, cron jobs the
+ * agent schedules via the bus-scheduler).
+ *
+ * FLAGGED AMBIGUITY — agent sessions: the autonomous agent and interactive Claude
+ * Code sessions can both run with cwd `~` (project dir `-home-simon`), which would
+ * make the two indistinguishable by directory. We therefore bound agent sessions
+ * to project dirs encoding a path UNDER `~/agent` (a strict subset). If the agent
+ * actually runs from `~`, this UNDER-includes its sessions — the conservative
+ * direction (we never tune on general-surface sessions), but it means agent-scoped
+ * session fitness may see fewer rows than truly exist. Override `sessionProjectDirs`
+ * when the deployment pins the agent to a dedicated cwd.
+ */
+export function defaultAgentSurface(home: string = homedir()): AgentSurface {
+  const agentRoot = join(home, "agent");
+  return {
+    roots: [agentRoot],
+    skillsDirs: [join(agentRoot, "skills")],
+    sessionProjectDirs: [encodeProjectDir(agentRoot)],
+    jobMarkers: ['source="cron"', "bus-scheduler", agentRoot],
+  };
+}
+
+// ── Telemetry filter keys ─────────────────────────────────────────────────────
+//
+// `provider.query` carries scope hints in its `filters` map (a `Record<string,
+// string>`), so a scope-aware producer can self-restrict at the source (e.g. the
+// session producer scans only agent project dirs). Keys are namespaced so they
+// never collide with a real label filter.
+
+/** Filter key carrying the active scope ("agent"); absent ⇒ "all" (no restriction). */
+export const SCOPE_FILTER_KEY = "__scope";
+/** Filter key carrying a comma-joined list of agent session-project-dir prefixes. */
+export const AGENT_SESSION_DIRS_FILTER_KEY = "__agent_session_dirs";
+
+/**
+ * Per-stream agent-attribution predicate applied to a sample AFTER the inner
+ * provider returns it. Decides whether `sample` belongs to the agent surface.
+ *
+ *  - `session_cost` / `cron_run` — attributed by a job/unit-label substring match
+ *    against `surface.jobMarkers`. Real, label-based narrowing.
+ *  - `memory_access` — attributed by `file` label living under an agent root.
+ *  - everything else — KEPT (returns true). Two reasons: session-derived streams
+ *    (tool_call / agent_dispatch) are already narrowed upstream by the session-dir
+ *    filter, so re-filtering here would be redundant and wrong; and hook_exec /
+ *    skill_access / template_feedback carry NO agent-vs-general signal in their
+ *    labels on the reference host (FLAGGED — agent-scoping those streams requires
+ *    pointing their producer at an agent-specific source via config, not a label
+ *    filter). Keeping them is the documented limit of label-based scoping.
+ */
+export function sampleInAgentScope(
+  stream: TelemetryStream,
+  sample: MetricSample,
+  surface: AgentSurface,
+): boolean {
+  const labels = sample.labels ?? {};
+  switch (stream) {
+    case "session_cost":
+    case "cron_run": {
+      const hay = `${labels["job"] ?? ""} ${labels["unit"] ?? ""}`;
+      return surface.jobMarkers.some((m) => hay.includes(m));
+    }
+    case "memory_access": {
+      const file = labels["file"] ?? "";
+      return file !== "" && surface.roots.some((r) => file.startsWith(r));
+    }
+    default:
+      return true;
+  }
+}
+
+/**
+ * Scope-aware decorator over a host `TelemetryProvider`. For `all` scope it is a
+ * pure pass-through. For `agent` scope it (1) injects scope hints into the
+ * `filters` map so scope-aware producers self-restrict at the source, and (2)
+ * post-filters the returned samples through `sampleInAgentScope`. Subjects still
+ * only ever call `query(...)` — they never learn they were scoped.
+ *
+ * `capabilities()` is intentionally NOT scoped: stream availability answers "can
+ * this environment emit this stream at all", which is a host property, not a
+ * per-subject one. Scope narrows the DATA a subject sees, not which streams exist.
+ */
+export class ScopedTelemetryProvider implements TelemetryProvider {
+  constructor(
+    private readonly inner: TelemetryProvider,
+    private readonly scope: Scope,
+    private readonly surface: AgentSurface,
+  ) {}
+
+  contractVersion(): string {
+    return this.inner.contractVersion();
+  }
+
+  capabilities(): TelemetryCapability[] {
+    return this.inner.capabilities();
+  }
+
+  async query(
+    stream: TelemetryStream,
+    range: DateRange,
+    filters?: Record<string, string>,
+  ): Promise<MetricSample[]> {
+    if (this.scope === "all") {
+      return this.inner.query(stream, range, filters);
+    }
+    const scoped: Record<string, string> = {
+      ...(filters ?? {}),
+      [SCOPE_FILTER_KEY]: "agent",
+      [AGENT_SESSION_DIRS_FILTER_KEY]: this.surface.sessionProjectDirs.join(","),
+    };
+    const samples = await this.inner.query(stream, range, scoped);
+    return samples.filter((s) => sampleInAgentScope(stream, s, this.surface));
+  }
+}
+
+/**
+ * Resolves + applies scope for a set of subjects. Built once at registration from
+ * the global + per-subject config and the host's agent surface; handed to the
+ * OutcomeRecorder so each subject's `measureFitness` reads a provider scoped to
+ * ITS effective scope. `snapshot()` produces the record written to the audit chain.
+ */
+export class ScopeResolver {
+  constructor(
+    private readonly global: Scope,
+    private readonly perSubject: Readonly<Record<string, Scope>>,
+    readonly surface: AgentSurface,
+  ) {}
+
+  /** Effective scope for a subject (per-subject override ?? global ?? all). */
+  for(subjectName: string): Scope {
+    return resolveScope(this.global, this.perSubject[subjectName]);
+  }
+
+  /** Wrap `inner` so the subject sees only its in-scope telemetry. Identity for `all`. */
+  scopedProvider(subjectName: string, inner: TelemetryProvider): TelemetryProvider {
+    const scope = this.for(subjectName);
+    return scope === "all" ? inner : new ScopedTelemetryProvider(inner, scope, this.surface);
+  }
+
+  /**
+   * Provenance snapshot for the audit chain: the active global scope plus the
+   * effective scope of each named subject. An auditor reads "the tuner operated
+   * at scope=X (subject Y at Z)" from one record.
+   */
+  snapshot(subjectNames: readonly string[]): {
+    global: Scope;
+    per_subject: Record<string, Scope>;
+  } {
+    const per_subject: Record<string, Scope> = {};
+    for (const name of subjectNames) per_subject[name] = this.for(name);
+    return { global: this.global, per_subject };
+  }
+}

--- a/src/skills-tuner/core/scope.ts
+++ b/src/skills-tuner/core/scope.ts
@@ -28,7 +28,7 @@
  */
 
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import type {
   DateRange,
   MetricSample,
@@ -76,6 +76,12 @@ export interface AgentSurface {
    * Substrings that mark a `session_cost` / `cron_run` row as agent-originated
    * (matched against the `job` / `unit` label). The cost store's `job` is
    * free-text, so attribution is substring-based, mirroring CronSubject.costJobMatch.
+   *
+   * MUST be AGENT-SPECIFIC markers only (e.g. the bus-scheduler tag the agent's
+   * own cron jobs carry, or the agent root path a unit name is anchored under).
+   * A GENERIC tag every cron row carries (e.g. `source="cron"`) does NOT narrow
+   * anything — it attributes the whole cron/cost stream to the agent, defeating
+   * the scope. Empty markers are ignored (they would match every row).
    */
   jobMarkers: string[];
 }
@@ -110,7 +116,12 @@ export function defaultAgentSurface(home: string = homedir()): AgentSurface {
     roots: [agentRoot],
     skillsDirs: [join(agentRoot, "skills")],
     sessionProjectDirs: [encodeProjectDir(agentRoot)],
-    jobMarkers: ['source="cron"', "bus-scheduler", agentRoot],
+    // AGENT-SPECIFIC markers only. `bus-scheduler` is the tag the agent's own
+    // cron jobs carry; `agentRoot` matches a unit/job label anchored under the
+    // agent's home. The generic `source="cron"` tag was REMOVED — nearly every
+    // cron row carries it, so including it attributed the entire cron/cost
+    // stream to the agent and made `scope: agent` a no-op for those streams.
+    jobMarkers: ["bus-scheduler", agentRoot],
   };
 }
 
@@ -127,19 +138,66 @@ export const SCOPE_FILTER_KEY = "__scope";
 export const AGENT_SESSION_DIRS_FILTER_KEY = "__agent_session_dirs";
 
 /**
+ * Label a scope-aware producer stamps on the samples it returns to ATTEST that
+ * it already restricted them to the agent surface at the source (e.g. after
+ * honouring the `__agent_session_dirs` hint). This is the explicit ack that lets
+ * a stream WITHOUT a label-based attribution predicate still pass agent scope —
+ * instead of failing closed. Value must equal the active scope ("agent").
+ */
+export const SCOPE_ACK_LABEL = "__scoped";
+
+/**
+ * Streams whose returned samples carry a REAL, label-based agent-attribution
+ * predicate applied post-hoc in `sampleInAgentScope`. These narrow by data.
+ */
+export const PREDICATE_STREAMS: ReadonlySet<TelemetryStream> = new Set<TelemetryStream>([
+  "session_cost",
+  "cron_run",
+  "memory_access",
+]);
+
+/**
+ * Streams narrowed at the SOURCE by the injected `__agent_session_dirs` filter,
+ * whose host producer (`SessionJsonlTelemetryProducer`) is known to honour it:
+ * the rows it returns are already agent-only, so a post-filter would be
+ * redundant. This is a CLOSED allowlist — any stream not named here and lacking
+ * a predicate fails closed rather than being kept.
+ */
+export const SOURCE_SCOPED_STREAMS: ReadonlySet<TelemetryStream> = new Set<TelemetryStream>([
+  "tool_call",
+  "agent_dispatch",
+]);
+
+/** True when `file` lives at or under one of `roots` on a path-SEGMENT boundary
+ * (so root `/home/simon/agent` does NOT match `/home/simon/agent-backup/...`). */
+function fileUnderRoot(file: string, roots: readonly string[]): boolean {
+  if (file === "") return false;
+  return roots.some((r) => {
+    if (r === "") return false;
+    const root = r.endsWith(sep) ? r.slice(0, -1) : r;
+    return file === root || file.startsWith(root + sep);
+  });
+}
+
+/**
  * Per-stream agent-attribution predicate applied to a sample AFTER the inner
  * provider returns it. Decides whether `sample` belongs to the agent surface.
+ * FAILS CLOSED: a sample is kept only when it can be POSITIVELY attributed.
  *
  *  - `session_cost` / `cron_run` — attributed by a job/unit-label substring match
- *    against `surface.jobMarkers`. Real, label-based narrowing.
- *  - `memory_access` — attributed by `file` label living under an agent root.
- *  - everything else — KEPT (returns true). Two reasons: session-derived streams
- *    (tool_call / agent_dispatch) are already narrowed upstream by the session-dir
- *    filter, so re-filtering here would be redundant and wrong; and hook_exec /
- *    skill_access / template_feedback carry NO agent-vs-general signal in their
- *    labels on the reference host (FLAGGED — agent-scoping those streams requires
- *    pointing their producer at an agent-specific source via config, not a label
- *    filter). Keeping them is the documented limit of label-based scoping.
+ *    against `surface.jobMarkers` (agent-specific markers only). Real narrowing.
+ *  - `memory_access` — attributed by `file` label living under an agent root,
+ *    matched on a path-segment boundary (see `fileUnderRoot`).
+ *  - `tool_call` / `agent_dispatch` (SOURCE_SCOPED_STREAMS) — already narrowed
+ *    upstream by the injected session-dir filter, whose producer honours it, so
+ *    they are kept without a post-filter.
+ *  - everything else (hook_exec / skill_access / template_feedback /
+ *    mode_dispatch / mcp.tool_call …) — carries NO agent-vs-general signal in its
+ *    labels AND is not a trusted source-scoped stream. Previously these were
+ *    KEPT (return true), which made `scope: agent` a SILENT NO-OP whenever the
+ *    producer ignored the injected hint (e.g. the mode-dispatch reader). Now they
+ *    fail CLOSED — DROPPED unless the producer stamped the explicit
+ *    `SCOPE_ACK_LABEL` ack asserting it already scoped the row itself.
  */
 export function sampleInAgentScope(
   stream: TelemetryStream,
@@ -150,15 +208,17 @@ export function sampleInAgentScope(
   switch (stream) {
     case "session_cost":
     case "cron_run": {
-      const hay = `${labels["job"] ?? ""} ${labels["unit"] ?? ""}`;
-      return surface.jobMarkers.some((m) => hay.includes(m));
+      const hay = `${labels.job ?? ""} ${labels.unit ?? ""}`;
+      return surface.jobMarkers.some((m) => m !== "" && hay.includes(m));
     }
-    case "memory_access": {
-      const file = labels["file"] ?? "";
-      return file !== "" && surface.roots.some((r) => file.startsWith(r));
-    }
+    case "memory_access":
+      return fileUnderRoot(labels.file ?? "", surface.roots);
     default:
-      return true;
+      // Trusted source-scoped streams were already narrowed at the producer.
+      if (SOURCE_SCOPED_STREAMS.has(stream)) return true;
+      // No predicate + not source-scoped ⇒ fail closed. A producer that scoped
+      // the row itself opts in by echoing the ack label.
+      return labels[SCOPE_ACK_LABEL] === "agent";
   }
 }
 

--- a/src/skills-tuner/core/telemetry.ts
+++ b/src/skills-tuner/core/telemetry.ts
@@ -1,0 +1,231 @@
+/**
+ * OutcomeLoop telemetry contract (Phase 1, observation-only).
+ *
+ * The OutcomeLoop measures whether an *applied* tuning change improved the
+ * system. Fitness signals come from telemetry, NOT from the observation
+ * collector (`collectObservations` yields qualitative correction/feedback
+ * signals, not numeric metrics — see `~/simon-memory/decisions/tuner-outcome-loop.md`).
+ *
+ * Decision (host-provided telemetry contract, option A): the ClaudeClaw-Plus
+ * HOST exposes ONE standard, versioned telemetry surface that every subject
+ * consumes via `provider.query(...)`. Subjects never embed file/DB adapters
+ * or hardcoded paths. Rationale: a single surface to certify and audit (one
+ * schema, one provenance point) — decisive for a commercial auditable product.
+ *
+ * Portability: a `Metric.source` is a `TelemetryStream` NAME (Tier 1) or the
+ * literal `"artifact"` (Tier 1b, a static scan of the managed file — always
+ * available, no capability gate). At registration the loop intersects each
+ * subject's declared `fitnessSignals()` sources with `provider.capabilities()`
+ * and activates fitness ONLY for streams the host advertises in THIS
+ * environment; missing streams degrade to proposal-only, logged as
+ * `fitness_inactive(reason)`. Never design fitness for telemetry an
+ * environment may not emit.
+ */
+
+/**
+ * Canonical telemetry streams the host may advertise. Adding a stream here is
+ * a contract change (bump `TELEMETRY_CONTRACT_VERSION`). `agent_dispatch` is
+ * declared but not yet emitted by any reference host — AgentSubject's fitness
+ * stays proposal-only until a producer lands (see producer-wiring follow-ups).
+ */
+export const TELEMETRY_STREAMS = [
+  "session_cost",
+  "tool_call",
+  "hook_exec",
+  "skill_access",
+  "cron_run",
+  "mode_dispatch",
+  "template_feedback",
+  "memory_access",
+  "agent_dispatch",
+  // Phase A observability hub: the universal MCP boundary stream the gateway
+  // (mcp-multiplexer) emits for EVERY plugin's tool I/O. Labelled by `plugin`
+  // so the hub auto-discovers plugins with zero per-plugin code. `value` is the
+  // call's `duration_ms`. Added in contract 1.1.0.
+  "mcp.tool_call",
+] as const;
+
+export type TelemetryStream = (typeof TELEMETRY_STREAMS)[number];
+
+/**
+ * The whole contract surface is versioned per host release for certification.
+ * 1.1.0 adds the `mcp.tool_call` stream + the optional view-manifest surface
+ * (`viewManifest`/`viewData`) — both additive, older consumers unaffected.
+ */
+export const TELEMETRY_CONTRACT_VERSION = "1.1.0";
+
+/** Half-open time window [start, end) for a fitness measurement. */
+export interface DateRange {
+  start: Date;
+  end: Date;
+}
+
+/**
+ * One observation pulled from a stream. `value` is the metric-bearing number;
+ * `labels` carry dimensions a subject filters/groups on (model, unit, tool…).
+ * Aggregation into a single fitness number is the subject's job and MUST be
+ * outlier-robust (median / trimmed mean, never a raw sum — cost is spiky).
+ */
+export interface MetricSample {
+  ts: Date;
+  value: number;
+  labels?: Record<string, string>;
+}
+
+/**
+ * The host advertises, per stream, whether it is emitting in this environment
+ * and at which schema version. This is the single auditable surface that
+ * folds in the role the per-subject `healthCheck()` producer-probe used to
+ * play: "is this subject's producer present?" is now answered by intersecting
+ * `fitnessSignals()` sources against `capabilities()`.
+ */
+export interface TelemetryCapability {
+  stream: TelemetryStream;
+  schemaVersion: string;
+  available: boolean;
+  /** Optional diagnostic when `available` is false (mirrors healthCheck.reason). */
+  reason?: string;
+}
+
+/**
+ * Implemented by the HOST. Owns telemetry PRODUCTION + schema + provenance.
+ * The tuner owns CONSUMPTION + fitness logic only. Versioned: a customer host
+ * at vX advertises its streams; the tuner degrades for missing/older ones.
+ */
+export interface TelemetryProvider {
+  /** Contract version this provider implements. */
+  contractVersion(): string;
+  /** Which streams this environment advertises, with availability + schema. */
+  capabilities(): TelemetryCapability[];
+  /** Pull samples for a stream over a window, optionally filtered by labels. */
+  query(
+    stream: TelemetryStream,
+    range: DateRange,
+    filters?: Record<string, string>,
+  ): Promise<MetricSample[]>;
+  /**
+   * OPTIONAL (contract 1.1.0). A plugin advertises a view-manifest to declare
+   * its own specialized observability page. Providers that don't implement this
+   * (or return `undefined`) get the universal boundary page only — the hub
+   * never hardcodes a plugin's page.
+   */
+  viewManifest?(): ViewManifest | undefined;
+  /**
+   * OPTIONAL (contract 1.1.0). Fill one panel declared by `viewManifest()` over
+   * a window. Returns `undefined` when this provider doesn't own `panelId`.
+   * READ-ONLY: it must never mutate plugin state.
+   */
+  viewData?(panelId: string, range: DateRange): Promise<PanelData | undefined>;
+}
+
+// ── View-manifest surface (Phase A observability hub) ───────────────────────
+//
+// A plugin OPTIONALLY advertises a view-manifest: pure data describing the
+// domain metrics it wants surfaced and a layout of panel primitives the hub
+// renders generically. The hub renders whatever the manifest declares and
+// nothing more — it never embeds plugin-specific rendering. A plugin with no
+// manifest still gets the universal boundary page (volume / p95 latency /
+// error-rate / cost) the reader derives from the `mcp.tool_call` stream.
+
+/** The generic panel renderers the hub provides. A manifest composes these. */
+export type PanelKind = "timeline" | "table" | "metric-cards" | "log";
+
+/** A domain metric a plugin wants shown. `direction` is a colouring hint only —
+ *  the hub never optimises on it (no Goodhart surface here). */
+export interface ManifestMetric {
+  name: string;
+  /** Display unit, e.g. "ms", "USD", "count", "ratio". */
+  unit?: string;
+  direction?: "up_good" | "down_good" | "neutral";
+  description?: string;
+}
+
+/**
+ * One panel in a plugin's page. `kind` selects a generic renderer; `columns`
+ * orders the fields shown for row-shaped panels (table/timeline/log). The hub
+ * passes `id` back to `viewData(id, …)` and never interprets panel internals.
+ */
+export interface PanelSpec {
+  id: string;
+  kind: PanelKind;
+  title: string;
+  /** Field order for row-shaped panels (table/timeline/log). */
+  columns?: string[];
+}
+
+/** A plugin's declared page: domain metrics + a layout of panels. Pure data. */
+export interface ViewManifest {
+  /** The plugin this belongs to — matched against discovered `plugin` labels. */
+  plugin: string;
+  /** Manifest schema version, independent of the telemetry contract version. */
+  schemaVersion: string;
+  metrics?: ManifestMetric[];
+  panels: PanelSpec[];
+}
+
+/** Rows that fill one panel. Shape is generic; the hub renders per `PanelSpec.kind`. */
+export interface PanelData {
+  panelId: string;
+  rows: Array<Record<string, unknown>>;
+}
+
+/**
+ * A surface that aggregates multiple plugins' view-manifests. The hub's reader
+ * consumes this to discover specialized pages without knowing any plugin.
+ * Implemented by `CompositeTelemetryProvider`.
+ */
+export interface ViewManifestSource {
+  /** Every declared manifest — one per plugin that advertises one. */
+  viewManifests(): ViewManifest[];
+  /**
+   * Fill a panel for a named plugin. `undefined` for an unknown plugin/panel.
+   * Distinct from a provider's own `viewData(panelId, range)` — this aggregator
+   * dispatches by plugin to the provider that declared the manifest.
+   */
+  panelData(plugin: string, panelId: string, range: DateRange): Promise<PanelData | undefined>;
+}
+
+/** RLVR axis: a fitness signal is either programmatically verifiable or needs a judge. */
+export type MetricKind = "verifiable" | "judge" | "proxy_state";
+export type MetricDirection = "lower_is_better" | "higher_is_better";
+
+/** Tier 1b: artifact metrics scan the managed file directly — no stream gate. */
+export const ARTIFACT_SOURCE = "artifact" as const;
+export type MetricSource = TelemetryStream | typeof ARTIFACT_SOURCE;
+
+/**
+ * A fitness metric declared by a subject via `fitnessSignals()`.
+ * `guardrails` names companion metrics that must NOT regress beyond noise for
+ * a verdict of `improved` — the anti-Goodhart no-regression rule. Single-number
+ * maximisation is forbidden (it's the gameable shape).
+ */
+export interface Metric {
+  name: string;
+  source: MetricSource;
+  kind: MetricKind;
+  direction: MetricDirection;
+  windowDays: number;
+  guardrails?: string[];
+}
+
+/** True when a metric reads a static artifact and so is always activatable. */
+export function isArtifactMetric(m: Metric): boolean {
+  return m.source === ARTIFACT_SOURCE;
+}
+
+/**
+ * A host that advertises NO streams. Artifact (Tier 1b) metrics still
+ * activate; every stream-based metric degrades to proposal-only. Useful as a
+ * safe default and in tests.
+ */
+export class NullTelemetryProvider implements TelemetryProvider {
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+  capabilities(): TelemetryCapability[] {
+    return [];
+  }
+  async query(): Promise<MetricSample[]> {
+    return [];
+  }
+}

--- a/src/skills-tuner/core/telemetry.ts
+++ b/src/skills-tuner/core/telemetry.ts
@@ -44,6 +44,9 @@ export const TELEMETRY_STREAMS = [
   // so the hub auto-discovers plugins with zero per-plugin code. `value` is the
   // call's `duration_ms`. Added in contract 1.1.0.
   "mcp.tool_call",
+  // Memory degradation signal (load latency / size / dead-ratio), sampled
+  // tuner-side from the memory index. Added in contract 1.2.0.
+  "memory_signal",
 ] as const;
 
 export type TelemetryStream = (typeof TELEMETRY_STREAMS)[number];
@@ -53,7 +56,7 @@ export type TelemetryStream = (typeof TELEMETRY_STREAMS)[number];
  * 1.1.0 adds the `mcp.tool_call` stream + the optional view-manifest surface
  * (`viewManifest`/`viewData`) — both additive, older consumers unaffected.
  */
-export const TELEMETRY_CONTRACT_VERSION = "1.1.0";
+export const TELEMETRY_CONTRACT_VERSION = "1.2.0";
 
 /** Half-open time window [start, end) for a fitness measurement. */
 export interface DateRange {

--- a/src/skills-tuner/core/telemetry.ts
+++ b/src/skills-tuner/core/telemetry.ts
@@ -4,7 +4,7 @@
  * The OutcomeLoop measures whether an *applied* tuning change improved the
  * system. Fitness signals come from telemetry, NOT from the observation
  * collector (`collectObservations` yields qualitative correction/feedback
- * signals, not numeric metrics — see `~/simon-memory/decisions/tuner-outcome-loop.md`).
+ * signals, not numeric metrics).
  *
  * Decision (host-provided telemetry contract, option A): the ClaudeClaw-Plus
  * HOST exposes ONE standard, versioned telemetry surface that every subject
@@ -25,8 +25,9 @@
 /**
  * Canonical telemetry streams the host may advertise. Adding a stream here is
  * a contract change (bump `TELEMETRY_CONTRACT_VERSION`). `agent_dispatch` is
- * declared but not yet emitted by any reference host — AgentSubject's fitness
- * stays proposal-only until a producer lands (see producer-wiring follow-ups).
+ * emitted by `SessionJsonlTelemetryProducer` (from `Agent`/`Task` tool_use
+ * blocks in the session transcript); a stream with no live source advertises
+ * `available:false` + reason rather than faking data.
  */
 export const TELEMETRY_STREAMS = [
   "session_cost",

--- a/src/skills-tuner/core/template-feedback.ts
+++ b/src/skills-tuner/core/template-feedback.ts
@@ -1,0 +1,74 @@
+/**
+ * template_feedback — the rating mechanism that feeds the `template_feedback`
+ * telemetry stream (OutcomeLoop Phase B).
+ *
+ * `PromptTemplateSubject` already CONSUMES this log (its `collectObservations`
+ * + `measureFitness` read `~/.config/tuner/template_feedback.jsonl`), but nothing
+ * PRODUCED it. The `tuner rate-template <id> <yes|yes-but|no>` CLI command and
+ * the `TemplateFeedbackTelemetryProducer` both go through here so the on-disk
+ * shape stays in one place.
+ *
+ * Verdict → rating uses the same yes/yes-but/no vocabulary the proposal
+ * `feedback` command uses, mapped onto the 1..5 scale the subject buckets on
+ * (`rating <= 2` correction, `>= 4` positive, middle = neutral). The stream
+ * metric `template_avg_rating` is a median, higher_is_better.
+ *
+ * Line shape (matches PromptTemplateSubject.defaultFeedbackReader):
+ *   { ts, template_id, rating, verdict, comment? }
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export const DEFAULT_TEMPLATE_FEEDBACK_LOG = join(
+  homedir(),
+  ".config",
+  "tuner",
+  "template_feedback.jsonl",
+);
+
+export type TemplateVerdict = "yes" | "yes-but" | "no";
+
+/** 1..5 scale: yes = strong-positive, yes-but = neutral, no = correction. */
+export const VERDICT_RATING: Record<TemplateVerdict, number> = {
+  yes: 5,
+  "yes-but": 3,
+  no: 1,
+};
+
+export function isTemplateVerdict(v: string): v is TemplateVerdict {
+  return v === "yes" || v === "yes-but" || v === "no";
+}
+
+export interface TemplateFeedbackEntry {
+  ts: string;
+  template_id: string;
+  rating: number;
+  verdict: TemplateVerdict;
+  comment?: string;
+}
+
+/**
+ * Append one rating to the feedback log (default
+ * `~/.config/tuner/template_feedback.jsonl`), creating the parent dir. Returns
+ * the written entry. Throws on a bad verdict (caller validates user input).
+ */
+export function appendTemplateFeedback(
+  input: { templateId: string; verdict: TemplateVerdict; comment?: string; ts?: string },
+  path: string = DEFAULT_TEMPLATE_FEEDBACK_LOG,
+): TemplateFeedbackEntry {
+  if (!isTemplateVerdict(input.verdict)) {
+    throw new Error(`invalid verdict: ${input.verdict} (expected yes|yes-but|no)`);
+  }
+  const entry: TemplateFeedbackEntry = {
+    ts: input.ts ?? new Date().toISOString(),
+    template_id: input.templateId,
+    rating: VERDICT_RATING[input.verdict],
+    verdict: input.verdict,
+    ...(input.comment ? { comment: input.comment } : {}),
+  };
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, `${JSON.stringify(entry)}\n`);
+  return entry;
+}

--- a/src/tuner/__tests__/wisecron/audit-log-hardening.test.ts
+++ b/src/tuner/__tests__/wisecron/audit-log-hardening.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Hardening regression tests for skills-tuner/core/audit-log.ts.
+ *
+ * Covers the ultra-review remediation:
+ *  - a torn/partial final line never bricks construction (fail-open on read,
+ *    fail-closed only on write — the MCP gateway must not wedge on a crash tail)
+ *  - `maxRecords` bounds the in-memory window without disturbing the chain
+ *  - `rotateBytes` rotates to `<path>.1` and starts a fresh verifiable segment
+ *  - a concurrent second writer chains off the real on-disk tail (no fork)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  appendFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AuditLog, type AuditRecord } from "../../../skills-tuner/core/audit-log.js";
+
+let dir: string;
+const logPath = () => join(dir, "chain.jsonl");
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "audit-hardening-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("AuditLog — torn-line tolerance (CRITICAL: gateway must not wedge)", () => {
+  it("constructs and keeps appending when the existing file ends in a partial line", () => {
+    const first = new AuditLog(logPath());
+    first.append({ event: "mcp.tool_call", subject: "p" });
+    // Simulate a crash mid-appendFileSync: a truncated JSON line at the tail.
+    appendFileSync(logPath(), '{"seq":2,"event":"mcp.tool_call","ha');
+
+    // Previously this threw in loadTail -> constructor -> permanent gateway wedge.
+    const reopened = new AuditLog(logPath());
+    expect(() => reopened.append({ event: "mcp.tool_call", subject: "p" })).not.toThrow();
+    // The valid record survived; the torn line was skipped.
+    expect(reopened.all().some((r) => r.seq === 1)).toBe(true);
+  });
+
+  it("skips a corrupt middle line without throwing", () => {
+    writeFileSync(
+      logPath(),
+      `${[
+        '{"seq":1,"hash":"a","event":"proposal"}',
+        "not json at all",
+        '{"seq":2,"hash":"b","event":"verdict"}',
+      ].join("\n")}\n`,
+    );
+    const reopened = new AuditLog(logPath());
+    // Both valid records loaded, garbage dropped.
+    expect(reopened.all()).toHaveLength(2);
+  });
+
+  it("still fails closed on a genuine write failure (unwritable path)", () => {
+    // A path whose parent is a file, not a dir, makes appendFileSync throw.
+    const notADir = join(dir, "afile");
+    writeFileSync(notADir, "x");
+    const bad = new AuditLog(join(notADir, "nested", "chain.jsonl"));
+    expect(() => bad.append({ event: "mcp.tool_call_intent", subject: "p" })).toThrow();
+  });
+});
+
+describe("AuditLog — maxRecords bounds memory without breaking the chain", () => {
+  it("retains only the last N in memory but keeps seq/hash monotonic on disk", () => {
+    const cap = 10;
+    const alog = new AuditLog(logPath(), { maxRecords: cap });
+    for (let i = 0; i < 50; i++) alog.append({ event: "mcp.tool_call", subject: "p" });
+
+    expect(alog.all().length).toBeLessThanOrEqual(cap);
+    // On-disk chain has all 50, still a valid chain from genesis.
+    const lines = readFileSync(logPath(), "utf8").trim().split("\n");
+    expect(lines).toHaveLength(50);
+    const parsed = lines.map((l) => JSON.parse(l) as AuditRecord);
+    expect(parsed[0].seq).toBe(1);
+    expect(parsed[49].seq).toBe(50);
+    for (let i = 1; i < parsed.length; i++) {
+      expect(parsed[i].prev_hash).toBe(parsed[i - 1].hash);
+    }
+  });
+});
+
+describe("AuditLog — rotateBytes bounds file size with verifiable segments", () => {
+  it("rotates to <path>.1 and the new active segment verifies from genesis", () => {
+    const alog = new AuditLog(logPath(), { rotateBytes: 400 });
+    for (let i = 0; i < 40; i++)
+      alog.append({ event: "mcp.tool_call", subject: "plugin-with-a-longish-name" });
+
+    expect(existsSync(`${logPath()}.1`)).toBe(true);
+    // Active file is bounded (well under the pre-rotation total).
+    const activeLines = readFileSync(logPath(), "utf8").trim().split("\n");
+    expect(activeLines.length).toBeLessThan(40);
+    // The active segment restarts at genesis and chains intact.
+    const parsed = activeLines.map((l) => JSON.parse(l) as AuditRecord);
+    expect(parsed[0].prev_hash).toBe("0".repeat(64));
+    expect(parsed[0].seq).toBe(1);
+    const reopened = new AuditLog(logPath(), { rotateBytes: 400 });
+    expect(reopened.verifyChain().ok).toBe(true);
+  });
+});
+
+describe("AuditLog — concurrent writers chain off the on-disk tail (no fork)", () => {
+  it("a second instance resyncs to the tail written by the first", () => {
+    const a = new AuditLog(logPath());
+    const b = new AuditLog(logPath()); // opened at the same (empty) point
+    a.append({ event: "proposal", subject: "s" }); // a: seq 1
+    a.append({ event: "verdict", subject: "s" }); // a: seq 2
+
+    // b still thinks seq=0; without resync it would fork a duplicate seq=1.
+    b.append({ event: "revert", subject: "s" });
+
+    const parsed = readFileSync(logPath(), "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as AuditRecord);
+    const seqs = parsed.map((r) => r.seq);
+    // No duplicate seq — b chained off a's tail (seq 3, prev = a's last hash).
+    expect(new Set(seqs).size).toBe(seqs.length);
+    expect(parsed[parsed.length - 1].seq).toBe(3);
+    expect(new AuditLog(logPath()).verifyChain().ok).toBe(true);
+  });
+});

--- a/src/tuner/__tests__/wisecron/host-telemetry-provider.test.ts
+++ b/src/tuner/__tests__/wisecron/host-telemetry-provider.test.ts
@@ -615,7 +615,7 @@ describe("SessionJsonlTelemetryProducer", () => {
           type: "tool_use",
           id: "r2",
           name: "Read",
-          input: { file_path: "/home/x/simon-memory/a.md" },
+          input: { file_path: "/home/x/memory/a.md" },
         },
         { type: "tool_use", id: "r3", name: "Read", input: { file_path: "/home/x/src/index.ts" } }, // not memory
       ]),
@@ -626,7 +626,7 @@ describe("SessionJsonlTelemetryProducer", () => {
     expect(samples.every((s) => s.value === 1)).toBe(true);
     expect(samples.map((s) => s.labels!.file).sort()).toEqual([
       "/home/x/CLAUDE.md",
-      "/home/x/simon-memory/a.md",
+      "/home/x/memory/a.md",
     ]);
   });
 

--- a/src/tuner/__tests__/wisecron/host-telemetry-provider.test.ts
+++ b/src/tuner/__tests__/wisecron/host-telemetry-provider.test.ts
@@ -107,6 +107,34 @@ describe("CronRunTelemetryProducer", () => {
     expect(await p.query("hook_exec", RANGE)).toEqual([]);
   });
 
+  it("caches the resolved source-kind within the TTL (no re-spawn on repeat calls)", () => {
+    let probes = 0;
+    let clock = 1_000_000;
+    const p = new CronRunTelemetryProducer({
+      journalRunner: () => {
+        probes++;
+        return journalLine({ unit: "wisecron-a.service", ts: IN, exit: 0 });
+      },
+      costDbPath: "/nonexistent/costs.db",
+      kindCacheTtlMs: 60_000,
+      now: () => clock,
+    });
+
+    // First call resolves + caches (one journalctl spawn).
+    expect(p.capabilities()[0]!.available).toBe(true);
+    expect(probes).toBe(1);
+
+    // Repeat calls within the TTL reuse the cached kind — no new spawn.
+    p.capabilities();
+    p.capabilities();
+    expect(probes).toBe(1);
+
+    // Past the TTL, it re-probes.
+    clock += 61_000;
+    p.capabilities();
+    expect(probes).toBe(2);
+  });
+
   it("auto-detects the bus_scheduler source from costs.db when no systemd units", async () => {
     const dbDir = mkdtempSync(join(tmpdir(), "cron-costs-"));
     const dbPath = join(dbDir, "costs.db");
@@ -658,5 +686,58 @@ describe("SessionJsonlTelemetryProducer", () => {
     const p = new SessionJsonlTelemetryProducer({ projectsDir: root });
     expect(await p.query("cron_run", RANGE)).toEqual([]);
     expect(await p.query("session_cost", RANGE)).toEqual([]);
+  });
+
+  it("caps the scan at the newest 200 transcripts (bounded reads) and warns", async () => {
+    // 205 in-window sessions, each with one tool_use. The producer must scan at
+    // most 200 (newest by mtime) so a busy host can't stall / OOM the sync path.
+    const total = 205;
+    for (let i = 0; i < total; i++) {
+      writeSession(`s${i}.jsonl`, [
+        assistantToolUse(IN, [{ type: "tool_use", id: `t${i}`, name: "Bash", input: {} }]),
+      ]);
+    }
+    const warnings: string[] = [];
+    const orig = console.warn;
+    console.warn = (msg?: unknown) => {
+      warnings.push(String(msg));
+    };
+    try {
+      const p = new SessionJsonlTelemetryProducer({ projectsDir: root });
+      const samples = await p.query("tool_call", RANGE);
+      expect(samples).toHaveLength(200);
+      expect(warnings.some((w) => /scan capped at 200 of 205/.test(w))).toBe(true);
+    } finally {
+      console.warn = orig;
+    }
+  });
+
+  it("streams a transcript larger than the read chunk without slurping (all lines parsed)", async () => {
+    // >64KB single file spanning many read chunks: padding forces multi-chunk
+    // reads, and a multibyte path exercises the chunk-boundary decode. Every
+    // in-window tool_use must still be derived (behaviour identical to a slurp).
+    const lines: object[] = [];
+    const pad = "x".repeat(4096); // bloat each line so the file crosses 64KB
+    for (let i = 0; i < 40; i++) {
+      lines.push(
+        assistantToolUse(IN, [
+          { type: "tool_use", id: `b${i}`, name: "Bash", input: { note: pad } },
+          {
+            type: "tool_use",
+            id: `m${i}`,
+            name: "Read",
+            input: { file_path: `/home/x/mémoire/${i}/CLAUDE.md` },
+          },
+        ]),
+      );
+    }
+    writeSession("big.jsonl", lines);
+    const p = new SessionJsonlTelemetryProducer({ projectsDir: root });
+    const calls = await p.query("tool_call", RANGE);
+    expect(calls).toHaveLength(80); // 40 Bash + 40 Read
+    const mem = await p.query("memory_access", RANGE);
+    expect(mem).toHaveLength(40);
+    // Multibyte path survived the chunk-boundary decode intact.
+    expect(mem.every((s) => s.labels!.file.includes("mémoire"))).toBe(true);
   });
 });

--- a/src/tuner/__tests__/wisecron/host-telemetry-provider.test.ts
+++ b/src/tuner/__tests__/wisecron/host-telemetry-provider.test.ts
@@ -1,0 +1,662 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CronRunTelemetryProducer,
+  HookExecTelemetryProducer,
+  SkillAccessTelemetryProducer,
+  JournalTelemetryProducer,
+  ModeDispatchTelemetryProducer,
+  TemplateFeedbackTelemetryProducer,
+  CompositeTelemetryProvider,
+  buildHostTelemetryProvider,
+} from "../../wisecron/host-telemetry-provider.js";
+import { SessionJsonlTelemetryProducer } from "../../wisecron/session-jsonl-provider.js";
+import type {
+  DateRange,
+  MetricSample,
+  TelemetryProvider,
+  TelemetryStream,
+} from "../../../skills-tuner/core/telemetry.js";
+import { TELEMETRY_STREAMS } from "../../../skills-tuner/core/telemetry.js";
+
+// Relative to now so the wall-clock probe in `capabilities()` (last 30d) always
+// brackets IN — a fixed calendar fixture silently drifts out of the window and
+// flips data-derived streams to available:false as time passes.
+const DAY_MS = 86_400_000;
+const NOW_MS = Date.now();
+const RANGE: DateRange = {
+  start: new Date(NOW_MS - 9 * DAY_MS),
+  end: new Date(NOW_MS - 1 * DAY_MS),
+};
+const IN = new Date(NOW_MS - 5 * DAY_MS); // inside RANGE and inside the 30d probe
+const OUT = new Date(NOW_MS - 40 * DAY_MS); // before RANGE.start -> excluded
+
+/** Build a journalctl JSON line as `journalctl --output json` would emit. */
+function journalLine(opts: { unit: string; ts: Date; exit?: number | null }): string {
+  const obj: Record<string, unknown> = {
+    _SYSTEMD_USER_UNIT: opts.unit,
+    __REALTIME_TIMESTAMP: String(opts.ts.getTime() * 1000),
+    MESSAGE: "ran",
+  };
+  if (opts.exit !== null && opts.exit !== undefined) obj.EXIT_STATUS = String(opts.exit);
+  return JSON.stringify(obj);
+}
+
+describe("CronRunTelemetryProducer", () => {
+  it("emits cron_run samples with value=exit_code and status label", async () => {
+    const raw = [
+      journalLine({ unit: "wisecron-a.service", ts: IN, exit: 0 }),
+      journalLine({ unit: "wisecron-b.service", ts: IN, exit: 1 }),
+      journalLine({ unit: "wisecron-a.service", ts: IN, exit: null }), // no EXIT_STATUS → ignored
+      journalLine({ unit: "wisecron-c.service", ts: OUT, exit: 0 }), // out of window
+    ].join("\n");
+    const p = new CronRunTelemetryProducer({ journalRunner: () => raw });
+    const samples = await p.query("cron_run", RANGE);
+    expect(samples).toHaveLength(2);
+    expect(samples[0]!.value).toBe(0);
+    expect(samples[0]!.labels).toEqual({
+      unit: "wisecron-a.service",
+      exit_code: "0",
+      status: "success",
+      source: "systemd",
+    });
+    expect(samples[1]!.labels!.status).toBe("failure");
+  });
+
+  it("advertises systemd source when wisecron completions exist", () => {
+    const ok = new CronRunTelemetryProducer({
+      journalRunner: () => journalLine({ unit: "wisecron-a.service", ts: IN, exit: 0 }),
+    });
+    const cap = ok.capabilities()[0]!;
+    expect(cap.available).toBe(true);
+    expect(cap.reason).toMatch(/source=systemd/);
+  });
+
+  it("advertises unavailable+reason naming configured cron when no completion source", () => {
+    const empty = new CronRunTelemetryProducer({
+      journalRunner: () => "",
+      costDbPath: "/nonexistent/costs.db",
+      cronConfigProbe: () => ({ crontab: true, configSnapshot: true }),
+    });
+    const cap = empty.capabilities()[0]!;
+    expect(cap.available).toBe(false);
+    expect(cap.reason).toMatch(/no cron run-completion source/);
+    expect(cap.reason).toMatch(/crontab/);
+  });
+
+  it("returns [] (does not throw) when the journal runner fails", async () => {
+    const p = new CronRunTelemetryProducer({
+      journalRunner: () => {
+        throw new Error("journalctl missing");
+      },
+      costDbPath: "/nonexistent/costs.db",
+      cronConfigProbe: () => ({ crontab: false, configSnapshot: false }),
+    });
+    expect(await p.query("cron_run", RANGE)).toEqual([]);
+    expect(p.capabilities()[0]!.available).toBe(false);
+  });
+
+  it("returns [] for any non-cron_run stream", async () => {
+    const p = new CronRunTelemetryProducer({
+      journalRunner: () => "",
+      costDbPath: "/nonexistent/costs.db",
+    });
+    expect(await p.query("hook_exec", RANGE)).toEqual([]);
+  });
+
+  it("auto-detects the bus_scheduler source from costs.db when no systemd units", async () => {
+    const dbDir = mkdtempSync(join(tmpdir(), "cron-costs-"));
+    const dbPath = join(dbDir, "costs.db");
+    const db = new Database(dbPath);
+    db.run(
+      "CREATE TABLE session_costs (session_id TEXT, date TEXT, job TEXT, model TEXT, cost_usd REAL)",
+    );
+    // Dates relative to now (see IN/OUT) so they bracket RANGE regardless of wall-clock.
+    const inDay = IN.toISOString().slice(0, 10); // in-window
+    const outDay = OUT.toISOString().slice(0, 10); // out-of-window
+    db.run(
+      `INSERT INTO session_costs VALUES
+        ('s1', '${inDay}', '<channel source="cron" chat_id="bus-scheduler:abc">', 'opus', 0.1),
+        ('s2', '${inDay}', 'gmail', 'opus', 0.2),
+        ('s3', '${outDay}', '<channel source="cron" chat_id="bus-scheduler:abc">', 'opus', 0.1)`,
+    );
+    db.close();
+
+    const p = new CronRunTelemetryProducer({
+      journalRunner: () => "", // no systemd units
+      costDbPath: dbPath,
+    });
+    const cap = p.capabilities()[0]!;
+    expect(cap.available).toBe(true);
+    expect(cap.reason).toMatch(/source=bus_scheduler/);
+
+    const samples = await p.query("cron_run", RANGE);
+    // s1 in-window (cron), s2 not cron, s3 out-of-window.
+    expect(samples).toHaveLength(1);
+    expect(samples[0]!.value).toBe(0); // completed fire
+    expect(samples[0]!.labels).toEqual({
+      unit: "bus-scheduler:abc",
+      exit_code: "0",
+      status: "success",
+      source: "bus_scheduler",
+    });
+    rmSync(dbDir, { recursive: true, force: true });
+  });
+});
+
+describe("HookExecTelemetryProducer", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hooks-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("emits hook_exec with value=duration_ms and exit_code/event labels", async () => {
+    writeFileSync(
+      join(dir, "pre.log"),
+      [
+        JSON.stringify({
+          hook: "pre",
+          exit_code: 0,
+          duration_ms: 120,
+          event: "UserPromptSubmit",
+          ts: IN.toISOString(),
+        }),
+        JSON.stringify({
+          hook: "pre",
+          exit_code: 2,
+          duration_ms: 999,
+          event: "UserPromptSubmit",
+          ts: IN.toISOString(),
+        }),
+        JSON.stringify({
+          hook: "pre",
+          exit_code: 0,
+          duration_ms: 50,
+          event: "x",
+          ts: OUT.toISOString(),
+        }), // out of window
+        "not json",
+      ].join("\n"),
+    );
+    const p = new HookExecTelemetryProducer({ hooksDir: dir });
+    const samples = await p.query("hook_exec", RANGE);
+    expect(samples).toHaveLength(2);
+    expect(samples.map((s) => s.value).sort((a, b) => a - b)).toEqual([120, 999]);
+    expect(samples.find((s) => s.value === 999)!.labels!.exit_code).toBe("2");
+    expect(p.capabilities()[0]!.available).toBe(true);
+  });
+
+  it("reads the canonical exec-log.jsonl sink written by exec-log.sh", async () => {
+    writeFileSync(
+      join(dir, "exec-log.jsonl"),
+      [
+        JSON.stringify({
+          ts: IN.toISOString(),
+          hook: "log-skill-access",
+          exit_code: 0,
+          duration_ms: 42,
+          event: "PostToolUse",
+        }),
+        JSON.stringify({
+          ts: IN.toISOString(),
+          hook: "context-injector",
+          exit_code: 1,
+          duration_ms: 1500,
+          event: "UserPromptSubmit",
+        }),
+      ].join("\n"),
+    );
+    const p = new HookExecTelemetryProducer({ hooksDir: dir });
+    const samples = await p.query("hook_exec", RANGE);
+    expect(samples).toHaveLength(2);
+    expect(samples.map((s) => s.value).sort((a, b) => a - b)).toEqual([42, 1500]);
+    expect(samples.find((s) => s.value === 1500)!.labels!.exit_code).toBe("1");
+    expect(samples.find((s) => s.value === 42)!.labels!.hook).toBe("log-skill-access");
+    expect(p.capabilities()[0]!.available).toBe(true);
+  });
+
+  it("advertises unavailable+reason when no exec-log/*.log present", () => {
+    const p = new HookExecTelemetryProducer({ hooksDir: dir });
+    const cap = p.capabilities()[0]!;
+    expect(cap.available).toBe(false);
+    expect(cap.reason).toMatch(/no parseable .* entries/);
+    expect(cap.reason).toMatch(/exec-log\.sh wrapper not wired/);
+  });
+});
+
+describe("SkillAccessTelemetryProducer", () => {
+  let dir: string;
+  let log: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "skill-"));
+    log = join(dir, "skill_accesses.jsonl");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("emits one skill_access sample per in-window access, labelled by skill name", async () => {
+    writeFileSync(
+      log,
+      [
+        JSON.stringify({
+          skill_path: "/home/x/agent/skills/foo.md",
+          accessed_at: IN.toISOString(),
+        }),
+        JSON.stringify({
+          skill_path: "/home/x/agent/skills/foo.md",
+          accessed_at: IN.toISOString(),
+        }),
+        JSON.stringify({
+          skill_path: "/home/x/agent/skills/bar.md",
+          accessed_at: OUT.toISOString(),
+        }), // out
+      ].join("\n"),
+    );
+    const p = new SkillAccessTelemetryProducer({ accessLog: log });
+    const samples = await p.query("skill_access", RANGE);
+    expect(samples).toHaveLength(2);
+    expect(samples[0]!.value).toBe(1);
+    expect(samples[0]!.labels!.skill).toBe("foo");
+    expect(p.capabilities()[0]!.available).toBe(true);
+  });
+
+  it("advertises unavailable+reason when the log is absent", () => {
+    const p = new SkillAccessTelemetryProducer({ accessLog: join(dir, "missing.jsonl") });
+    expect(p.capabilities()[0]!.available).toBe(false);
+    expect(p.capabilities()[0]!.reason).toMatch(/no skill-access entries/);
+  });
+});
+
+describe("JournalTelemetryProducer", () => {
+  let dir: string;
+  let journal: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "journal-"));
+    journal = join(dir, "operations.jsonl");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("advertises the 4 derived streams unavailable+reason when no matching events", () => {
+    writeFileSync(journal, `${JSON.stringify({ type: "deploy", ts: IN.toISOString() })}\n`);
+    const p = new JournalTelemetryProducer({ journalPath: journal });
+    const caps = p.capabilities();
+    expect(caps.map((c) => c.stream).sort()).toEqual([
+      "agent_dispatch",
+      "memory_access",
+      "mode_dispatch",
+      "tool_call",
+    ]);
+    expect(caps.every((c) => c.available === false && /no '.*' events/.test(c.reason ?? ""))).toBe(
+      true,
+    );
+  });
+
+  it("activates + emits a stream when matching events appear (no faked data)", async () => {
+    writeFileSync(
+      journal,
+      [
+        JSON.stringify({
+          type: "tool_call",
+          tool: "Read",
+          server: "fs",
+          success: true,
+          ts: IN.toISOString(),
+        }),
+        JSON.stringify({
+          type: "tool_call",
+          tool: "Bash",
+          server: "fs",
+          success: false,
+          ts: IN.toISOString(),
+        }),
+        JSON.stringify({ type: "deploy", ts: IN.toISOString() }),
+      ].join("\n"),
+    );
+    const p = new JournalTelemetryProducer({ journalPath: journal });
+    const cap = p.capabilities().find((c) => c.stream === "tool_call")!;
+    expect(cap.available).toBe(true);
+    const samples = await p.query("tool_call", RANGE);
+    expect(samples).toHaveLength(2);
+    // value 1 = failed/blocked, 0 = ok
+    expect(samples.map((s) => s.value).sort()).toEqual([0, 1]);
+  });
+
+  it("reports journal-not-found reason when the file is absent", () => {
+    const p = new JournalTelemetryProducer({ journalPath: join(dir, "nope.jsonl") });
+    expect(p.capabilities().every((c) => /journal not found/.test(c.reason ?? ""))).toBe(true);
+  });
+});
+
+describe("ModeDispatchTelemetryProducer", () => {
+  let dir: string;
+  let journal: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mode-dispatch-"));
+    journal = join(dir, "mode_dispatch.jsonl");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("emits mode_dispatch with value=reclassified and mode/matched_keyword labels", async () => {
+    writeFileSync(
+      journal,
+      [
+        JSON.stringify({
+          ts: IN.toISOString(),
+          mode: "coding",
+          matched_keyword: "fix",
+          reclassified: false,
+        }),
+        JSON.stringify({
+          ts: IN.toISOString(),
+          mode: "planning",
+          matched_keyword: "design",
+          reclassified: true,
+        }),
+        JSON.stringify({
+          ts: OUT.toISOString(),
+          mode: "coding",
+          matched_keyword: "x",
+          reclassified: false,
+        }), // out of window
+        "not json",
+      ].join("\n"),
+    );
+    const p = new ModeDispatchTelemetryProducer({ journalPath: journal });
+    const samples = await p.query("mode_dispatch", RANGE);
+    expect(samples).toHaveLength(2);
+    const reclassified = samples.find((s) => s.value === 1)!;
+    expect(reclassified.labels).toEqual({ mode: "planning", matched_keyword: "design" });
+    expect(samples.find((s) => s.value === 0)!.labels!.mode).toBe("coding");
+    expect(p.capabilities()[0]!.available).toBe(true);
+  });
+
+  it("advertises unavailable+reason when the dispatch journal is absent", () => {
+    const p = new ModeDispatchTelemetryProducer({ journalPath: journal });
+    const cap = p.capabilities()[0]!;
+    expect(cap.available).toBe(false);
+    expect(cap.reason).toMatch(/dispatch journal not found/);
+    expect(cap.reason).toMatch(/no agentic-mode route emitted yet/);
+  });
+
+  it("advertises unavailable+reason when the journal exists but is empty", () => {
+    writeFileSync(journal, "");
+    const p = new ModeDispatchTelemetryProducer({ journalPath: journal });
+    expect(p.capabilities()[0]!.available).toBe(false);
+    expect(p.capabilities()[0]!.reason).toMatch(/no dispatch records/);
+  });
+
+  it("returns [] for streams it does not own", async () => {
+    writeFileSync(
+      journal,
+      `${JSON.stringify({ ts: IN.toISOString(), mode: "coding", matched_keyword: "fix", reclassified: false })}\n`,
+    );
+    const p = new ModeDispatchTelemetryProducer({ journalPath: journal });
+    expect(await p.query("hook_exec", RANGE)).toEqual([]);
+  });
+});
+
+describe("TemplateFeedbackTelemetryProducer", () => {
+  let dir: string;
+  let log: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "tmpl-fb-"));
+    log = join(dir, "template_feedback.jsonl");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("emits template_feedback with value=rating and template_id/verdict labels", async () => {
+    writeFileSync(
+      log,
+      [
+        JSON.stringify({
+          ts: IN.toISOString(),
+          template_id: "daily-brief",
+          rating: 5,
+          verdict: "yes",
+        }),
+        JSON.stringify({ ts: IN.toISOString(), template_id: "pitch", rating: 1, verdict: "no" }),
+        JSON.stringify({ ts: OUT.toISOString(), template_id: "x", rating: 3, verdict: "yes-but" }), // out
+        "not json",
+      ].join("\n"),
+    );
+    const p = new TemplateFeedbackTelemetryProducer({ feedbackLog: log });
+    const samples = await p.query("template_feedback", RANGE);
+    expect(samples).toHaveLength(2);
+    expect(samples.map((s) => s.value).sort((a, b) => a - b)).toEqual([1, 5]);
+    expect(samples.find((s) => s.value === 5)!.labels).toEqual({
+      template_id: "daily-brief",
+      verdict: "yes",
+    });
+    expect(p.capabilities()[0]!.available).toBe(true);
+  });
+
+  it("advertises unavailable+reason (with the rate-template hint) when no log exists", () => {
+    const p = new TemplateFeedbackTelemetryProducer({ feedbackLog: log });
+    const cap = p.capabilities()[0]!;
+    expect(cap.available).toBe(false);
+    expect(cap.reason).toMatch(/no ratings yet/);
+    expect(cap.reason).toMatch(/rate-template/);
+  });
+
+  it("returns [] for streams it does not own", async () => {
+    writeFileSync(
+      log,
+      `${JSON.stringify({ ts: IN.toISOString(), template_id: "t", rating: 5, verdict: "yes" })}\n`,
+    );
+    const p = new TemplateFeedbackTelemetryProducer({ feedbackLog: log });
+    expect(await p.query("mode_dispatch", RANGE)).toEqual([]);
+  });
+});
+
+describe("CompositeTelemetryProvider", () => {
+  /** A trivial provider owning exactly one stream. */
+  function one(
+    stream: TelemetryStream,
+    available: boolean,
+    samples: MetricSample[],
+  ): TelemetryProvider {
+    return {
+      contractVersion: () => "1.0.0",
+      capabilities: () => [
+        {
+          stream,
+          schemaVersion: "1.0.0",
+          available,
+          ...(available ? {} : { reason: `${stream} down` }),
+        },
+      ],
+      query: async (s) => (s === stream ? samples : []),
+    };
+  }
+
+  it("merges to one capability per contract stream, preferring available", () => {
+    const c = new CompositeTelemetryProvider([
+      one("cron_run", true, []),
+      one("hook_exec", false, []),
+    ]);
+    const caps = c.capabilities();
+    // Exactly one entry per declared stream.
+    expect(caps).toHaveLength(TELEMETRY_STREAMS.length);
+    expect(caps.find((x) => x.stream === "cron_run")!.available).toBe(true);
+    expect(caps.find((x) => x.stream === "hook_exec")!.available).toBe(false);
+    // A stream no producer claims is reported unavailable with a reason.
+    const uncovered = caps.find((x) => x.stream === "agent_dispatch")!;
+    expect(uncovered.available).toBe(false);
+    expect(uncovered.reason).toMatch(/no producer wired/);
+  });
+
+  it("upgrades an unavailable stream to available when a later producer emits it", () => {
+    const c = new CompositeTelemetryProvider([
+      one("session_cost", false, []),
+      one("session_cost", true, []),
+    ]);
+    expect(c.capabilities().find((x) => x.stream === "session_cost")!.available).toBe(true);
+  });
+
+  it("query concatenates across producers (each returns [] for unowned streams)", async () => {
+    const sample: MetricSample = { ts: IN, value: 5, labels: {} };
+    const c = new CompositeTelemetryProvider([
+      one("cron_run", true, [sample]),
+      one("hook_exec", true, []),
+    ]);
+    expect(await c.query("cron_run", RANGE)).toEqual([sample]);
+    expect(await c.query("hook_exec", RANGE)).toEqual([]);
+  });
+});
+
+describe("buildHostTelemetryProvider (real host wiring)", () => {
+  it("returns a provider advertising one capability per declared stream", () => {
+    const dir = mkdtempSync(join(tmpdir(), "host-"));
+    mkdirSync(join(dir, "hooks"), { recursive: true });
+    mkdirSync(join(dir, "projects"), { recursive: true });
+    const p = buildHostTelemetryProvider({
+      costDbPath: join(dir, "costs.db"),
+      hooksDir: join(dir, "hooks"),
+      skillAccessLog: join(dir, "skills.jsonl"),
+      journalPath: join(dir, "ops.jsonl"),
+      modeDispatchLog: join(dir, "mode_dispatch.jsonl"),
+      templateFeedbackLog: join(dir, "template_feedback.jsonl"),
+      sessionProjectsDir: join(dir, "projects"),
+      cronJournalRunner: () => "",
+      cronConfigProbe: () => ({ crontab: false, configSnapshot: false }),
+    });
+    const caps = p.capabilities();
+    expect(caps).toHaveLength(TELEMETRY_STREAMS.length);
+    // Nothing seeded → every stream degrades to unavailable, each with a reason.
+    expect(caps.every((c) => c.available === false && !!c.reason)).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("SessionJsonlTelemetryProducer", () => {
+  let root: string;
+  let sessionDir: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "sessions-"));
+    sessionDir = join(root, "-home-x-proj");
+    mkdirSync(sessionDir, { recursive: true });
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  /** Build a session JSONL fixture: assistant tool_use lines + user tool_result lines. */
+  function writeSession(name: string, lines: object[]): void {
+    writeFileSync(join(sessionDir, name), `${lines.map((l) => JSON.stringify(l)).join("\n")}\n`);
+  }
+
+  function assistantToolUse(ts: Date, blocks: object[]): object {
+    return {
+      type: "assistant",
+      timestamp: ts.toISOString(),
+      message: { role: "assistant", content: blocks },
+    };
+  }
+  function userToolResult(ts: Date, toolUseId: string, isError: boolean): object {
+    return {
+      type: "user",
+      timestamp: ts.toISOString(),
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: toolUseId, content: "ok", is_error: isError },
+        ],
+      },
+    };
+  }
+
+  it("derives tool_call with failure joined from the matching tool_result is_error", async () => {
+    writeSession("s.jsonl", [
+      assistantToolUse(IN, [
+        { type: "tool_use", id: "t1", name: "Bash", input: {} },
+        { type: "tool_use", id: "t2", name: "mcp__busplug__reply", input: {} },
+      ]),
+      userToolResult(IN, "t1", false),
+      userToolResult(IN, "t2", true), // failed MCP call
+      // out-of-window line ignored
+      assistantToolUse(OUT, [
+        { type: "tool_use", id: "t3", name: "Read", input: { file_path: "/x" } },
+      ]),
+    ]);
+    const p = new SessionJsonlTelemetryProducer({ projectsDir: root });
+    const samples = await p.query("tool_call", RANGE);
+    expect(samples).toHaveLength(2);
+    const bash = samples.find((s) => s.labels!.tool === "Bash")!;
+    expect(bash.value).toBe(0);
+    expect(bash.labels!.server).toBe("");
+    const mcp = samples.find((s) => s.labels!.tool === "mcp__busplug__reply")!;
+    expect(mcp.value).toBe(1); // is_error → failure
+    expect(mcp.labels!.server).toBe("busplug");
+    expect(p.capabilities().find((c) => c.stream === "tool_call")!.available).toBe(true);
+  });
+
+  it("derives agent_dispatch from Agent/Task tool_use, labelled by subagent (value 0)", async () => {
+    writeSession("s.jsonl", [
+      assistantToolUse(IN, [
+        { type: "tool_use", id: "a1", name: "Agent", input: { subagent_type: "Explore" } },
+        { type: "tool_use", id: "a2", name: "Agent", input: {} }, // no subagent_type → default
+        { type: "tool_use", id: "t1", name: "Bash", input: {} }, // not a dispatch
+      ]),
+    ]);
+    const p = new SessionJsonlTelemetryProducer({ projectsDir: root });
+    const samples = await p.query("agent_dispatch", RANGE);
+    expect(samples).toHaveLength(2);
+    expect(samples.every((s) => s.value === 0)).toBe(true);
+    expect(samples.map((s) => s.labels!.agent).sort()).toEqual(["Explore", "default"]);
+    expect(p.capabilities().find((c) => c.stream === "agent_dispatch")!.available).toBe(true);
+  });
+
+  it("derives memory_access only for Reads of memory/CLAUDE.md paths", async () => {
+    writeSession("s.jsonl", [
+      assistantToolUse(IN, [
+        { type: "tool_use", id: "r1", name: "Read", input: { file_path: "/home/x/CLAUDE.md" } },
+        {
+          type: "tool_use",
+          id: "r2",
+          name: "Read",
+          input: { file_path: "/home/x/simon-memory/a.md" },
+        },
+        { type: "tool_use", id: "r3", name: "Read", input: { file_path: "/home/x/src/index.ts" } }, // not memory
+      ]),
+    ]);
+    const p = new SessionJsonlTelemetryProducer({ projectsDir: root });
+    const samples = await p.query("memory_access", RANGE);
+    expect(samples).toHaveLength(2);
+    expect(samples.every((s) => s.value === 1)).toBe(true);
+    expect(samples.map((s) => s.labels!.file).sort()).toEqual([
+      "/home/x/CLAUDE.md",
+      "/home/x/simon-memory/a.md",
+    ]);
+  });
+
+  it("advertises mode_dispatch inactive-with-reason (not in the transcript)", () => {
+    const p = new SessionJsonlTelemetryProducer({ projectsDir: root });
+    const cap = p.capabilities().find((c) => c.stream === "mode_dispatch")!;
+    expect(cap.available).toBe(false);
+    expect(cap.reason).toMatch(/orchestration event/);
+  });
+
+  it("degrades gracefully (all active streams unavailable+reason) on an empty/absent dir", async () => {
+    const empty = new SessionJsonlTelemetryProducer({ projectsDir: root }); // dir exists, no sessions
+    const caps = empty.capabilities();
+    for (const s of ["tool_call", "agent_dispatch", "memory_access"] as const) {
+      const c = caps.find((x) => x.stream === s)!;
+      expect(c.available).toBe(false);
+      expect(c.reason).toBeTruthy();
+    }
+    expect(await empty.query("tool_call", RANGE)).toEqual([]);
+
+    const absent = new SessionJsonlTelemetryProducer({ projectsDir: join(root, "nope") });
+    expect(await absent.query("tool_call", RANGE)).toEqual([]);
+    expect(absent.capabilities().find((c) => c.stream === "tool_call")!.reason).toMatch(
+      /projects dir not found/,
+    );
+  });
+
+  it("returns [] for streams it does not own", async () => {
+    const p = new SessionJsonlTelemetryProducer({ projectsDir: root });
+    expect(await p.query("cron_run", RANGE)).toEqual([]);
+    expect(await p.query("session_cost", RANGE)).toEqual([]);
+  });
+});

--- a/src/tuner/__tests__/wisecron/memory-signal-provider.test.ts
+++ b/src/tuner/__tests__/wisecron/memory-signal-provider.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemorySignalProducer } from "../../wisecron/memory-signal-provider.ts";
+
+const range = (a: string, b: string) => ({ start: new Date(a), end: new Date(b) });
+const HISTORY = [
+  { ts: "2026-06-28T00:00:00.000Z", bytes: 10000, entries: 100, deadRatio: 0, loadMs: 1.0 },
+  { ts: "2026-06-29T00:00:00.000Z", bytes: 14000, entries: 122, deadRatio: 0.02, loadMs: 1.6 },
+  { ts: "2026-06-30T00:00:00.000Z", bytes: 20000, entries: 150, deadRatio: 0.05, loadMs: 2.4 },
+].map((s) => JSON.stringify(s)).join("\n") + "\n";
+
+describe("MemorySignalProducer — memory_signal telemetry stream", () => {
+  let dir: string;
+  let historyPath: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "memsig-"));
+    historyPath = join(dir, "memory-signal-history.jsonl");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("advertises memory_signal UNAVAILABLE when no history file", () => {
+    const caps = new MemorySignalProducer({ historyPath }).capabilities();
+    expect(caps[0]!.stream).toBe("memory_signal");
+    expect(caps[0]!.available).toBe(false);
+    expect(caps[0]!.reason).toContain("not found");
+  });
+
+  it("advertises AVAILABLE once samples exist", () => {
+    writeFileSync(historyPath, HISTORY);
+    const caps = new MemorySignalProducer({ historyPath }).capabilities();
+    expect(caps[0]!.available).toBe(true);
+  });
+
+  it("queries the latency series (default metric=loadMs) within a range", async () => {
+    writeFileSync(historyPath, HISTORY);
+    const p = new MemorySignalProducer({ historyPath });
+    const rows = await p.query("memory_signal", range("2026-06-28T00:00:00Z", "2026-07-01T00:00:00Z"));
+    expect(rows.map((r) => r.value)).toEqual([1.0, 1.6, 2.4]);
+    expect(rows[0]!.ts).toBeInstanceOf(Date);
+    expect(rows[2]!.labels!.dead_ratio).toBe("0.05");
+  });
+
+  it("respects the half-open time window [start, end)", async () => {
+    writeFileSync(historyPath, HISTORY);
+    const rows = await new MemorySignalProducer({ historyPath }).query(
+      "memory_signal",
+      range("2026-06-29T00:00:00Z", "2026-06-30T00:00:00Z"),
+    );
+    expect(rows).toHaveLength(1); // 06-29 in, 06-30 excluded (end is open)
+    expect(rows[0]!.value).toBe(1.6);
+  });
+
+  it("series a different dimension via filters.metric", async () => {
+    writeFileSync(historyPath, HISTORY);
+    const p = new MemorySignalProducer({ historyPath });
+    const r = range("2026-06-28T00:00:00Z", "2026-07-01T00:00:00Z");
+    expect((await p.query("memory_signal", r, { metric: "bytes" })).map((x) => x.value)).toEqual([10000, 14000, 20000]);
+    expect((await p.query("memory_signal", r, { metric: "dead_ratio" })).map((x) => x.value)).toEqual([0, 0.02, 0.05]);
+  });
+
+  it("returns nothing for a different stream", async () => {
+    writeFileSync(historyPath, HISTORY);
+    const rows = await new MemorySignalProducer({ historyPath }).query(
+      "memory_access",
+      range("2026-06-01T00:00:00Z", "2026-07-01T00:00:00Z"),
+    );
+    expect(rows).toEqual([]);
+  });
+
+  it("tolerates a corrupt line without throwing", async () => {
+    writeFileSync(historyPath, HISTORY + "{not json}\n");
+    const rows = await new MemorySignalProducer({ historyPath }).query(
+      "memory_signal",
+      range("2026-06-01T00:00:00Z", "2026-07-01T00:00:00Z"),
+    );
+    expect(rows).toHaveLength(3);
+  });
+});

--- a/src/tuner/__tests__/wisecron/memory-signal-provider.test.ts
+++ b/src/tuner/__tests__/wisecron/memory-signal-provider.test.ts
@@ -5,11 +5,13 @@ import { join } from "node:path";
 import { MemorySignalProducer } from "../../wisecron/memory-signal-provider.ts";
 
 const range = (a: string, b: string) => ({ start: new Date(a), end: new Date(b) });
-const HISTORY = [
+const HISTORY = `${[
   { ts: "2026-06-28T00:00:00.000Z", bytes: 10000, entries: 100, deadRatio: 0, loadMs: 1.0 },
   { ts: "2026-06-29T00:00:00.000Z", bytes: 14000, entries: 122, deadRatio: 0.02, loadMs: 1.6 },
   { ts: "2026-06-30T00:00:00.000Z", bytes: 20000, entries: 150, deadRatio: 0.05, loadMs: 2.4 },
-].map((s) => JSON.stringify(s)).join("\n") + "\n";
+]
+  .map((s) => JSON.stringify(s))
+  .join("\n")}\n`;
 
 describe("MemorySignalProducer — memory_signal telemetry stream", () => {
   let dir: string;
@@ -22,24 +24,27 @@ describe("MemorySignalProducer — memory_signal telemetry stream", () => {
 
   it("advertises memory_signal UNAVAILABLE when no history file", () => {
     const caps = new MemorySignalProducer({ historyPath }).capabilities();
-    expect(caps[0]!.stream).toBe("memory_signal");
-    expect(caps[0]!.available).toBe(false);
-    expect(caps[0]!.reason).toContain("not found");
+    expect(caps[0]?.stream).toBe("memory_signal");
+    expect(caps[0]?.available).toBe(false);
+    expect(caps[0]?.reason).toContain("not found");
   });
 
   it("advertises AVAILABLE once samples exist", () => {
     writeFileSync(historyPath, HISTORY);
     const caps = new MemorySignalProducer({ historyPath }).capabilities();
-    expect(caps[0]!.available).toBe(true);
+    expect(caps[0]?.available).toBe(true);
   });
 
   it("queries the latency series (default metric=loadMs) within a range", async () => {
     writeFileSync(historyPath, HISTORY);
     const p = new MemorySignalProducer({ historyPath });
-    const rows = await p.query("memory_signal", range("2026-06-28T00:00:00Z", "2026-07-01T00:00:00Z"));
+    const rows = await p.query(
+      "memory_signal",
+      range("2026-06-28T00:00:00Z", "2026-07-01T00:00:00Z"),
+    );
     expect(rows.map((r) => r.value)).toEqual([1.0, 1.6, 2.4]);
-    expect(rows[0]!.ts).toBeInstanceOf(Date);
-    expect(rows[2]!.labels!.dead_ratio).toBe("0.05");
+    expect(rows[0]?.ts).toBeInstanceOf(Date);
+    expect(rows[2]?.labels?.dead_ratio).toBe("0.05");
   });
 
   it("respects the half-open time window [start, end)", async () => {
@@ -49,15 +54,19 @@ describe("MemorySignalProducer — memory_signal telemetry stream", () => {
       range("2026-06-29T00:00:00Z", "2026-06-30T00:00:00Z"),
     );
     expect(rows).toHaveLength(1); // 06-29 in, 06-30 excluded (end is open)
-    expect(rows[0]!.value).toBe(1.6);
+    expect(rows[0]?.value).toBe(1.6);
   });
 
   it("series a different dimension via filters.metric", async () => {
     writeFileSync(historyPath, HISTORY);
     const p = new MemorySignalProducer({ historyPath });
     const r = range("2026-06-28T00:00:00Z", "2026-07-01T00:00:00Z");
-    expect((await p.query("memory_signal", r, { metric: "bytes" })).map((x) => x.value)).toEqual([10000, 14000, 20000]);
-    expect((await p.query("memory_signal", r, { metric: "dead_ratio" })).map((x) => x.value)).toEqual([0, 0.02, 0.05]);
+    expect((await p.query("memory_signal", r, { metric: "bytes" })).map((x) => x.value)).toEqual([
+      10000, 14000, 20000,
+    ]);
+    expect(
+      (await p.query("memory_signal", r, { metric: "dead_ratio" })).map((x) => x.value),
+    ).toEqual([0, 0.02, 0.05]);
   });
 
   it("returns nothing for a different stream", async () => {
@@ -70,7 +79,7 @@ describe("MemorySignalProducer — memory_signal telemetry stream", () => {
   });
 
   it("tolerates a corrupt line without throwing", async () => {
-    writeFileSync(historyPath, HISTORY + "{not json}\n");
+    writeFileSync(historyPath, `${HISTORY}{not json}\n`);
     const rows = await new MemorySignalProducer({ historyPath }).query(
       "memory_signal",
       range("2026-06-01T00:00:00Z", "2026-07-01T00:00:00Z"),

--- a/src/tuner/__tests__/wisecron/session-cost-provider.test.ts
+++ b/src/tuner/__tests__/wisecron/session-cost-provider.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionCostTelemetryProvider } from "../../wisecron/session-cost-provider.js";
+import { TELEMETRY_CONTRACT_VERSION } from "../../../skills-tuner/core/telemetry.js";
+
+let dir: string;
+let dbPath: string;
+
+function seed(rows: Array<{ date: string; job: string; model: string; cost: number }>): void {
+  const db = new Database(dbPath);
+  db.exec(`CREATE TABLE session_costs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT UNIQUE NOT NULL,
+    date TEXT NOT NULL, job TEXT NOT NULL, model TEXT NOT NULL,
+    cost_usd REAL DEFAULT 0
+  );`);
+  const ins = db.prepare(
+    "INSERT INTO session_costs(session_id, date, job, model, cost_usd) VALUES (?,?,?,?,?)",
+  );
+  rows.forEach((r, i) => {
+    ins.run(`s-${i}`, r.date, r.job, r.model, r.cost);
+  });
+  db.close();
+}
+
+const range = (startDay: string, endDay: string) => ({
+  start: new Date(`${startDay}T00:00:00.000Z`),
+  end: new Date(`${endDay}T00:00:00.000Z`),
+});
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "session-cost-"));
+  dbPath = join(dir, "costs.db");
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("SessionCostTelemetryProvider — capabilities", () => {
+  it("advertises session_cost available when the store has rows", () => {
+    seed([{ date: "2026-05-20", job: "bootstrap", model: "sonnet", cost: 1.5 }]);
+    const p = new SessionCostTelemetryProvider({ dbPath });
+    const caps = p.capabilities();
+    const cost = caps.find((c) => c.stream === "session_cost")!;
+    expect(cost.available).toBe(true);
+    expect(cost.schemaVersion).toBe(TELEMETRY_CONTRACT_VERSION);
+    p.close();
+  });
+
+  it("degrades session_cost to unavailable with a reason when the store is absent", () => {
+    const p = new SessionCostTelemetryProvider({ dbPath: join(dir, "nope.db") });
+    const cost = p.capabilities().find((c) => c.stream === "session_cost")!;
+    expect(cost.available).toBe(false);
+    expect(cost.reason).toMatch(/not found/);
+    p.close();
+  });
+
+  it("degrades to unavailable with a reason when the table is empty", () => {
+    seed([]);
+    const p = new SessionCostTelemetryProvider({ dbPath });
+    const cost = p.capabilities().find((c) => c.stream === "session_cost")!;
+    expect(cost.available).toBe(false);
+    expect(cost.reason).toMatch(/empty/);
+    p.close();
+  });
+
+  it("advertises every other contract stream as unavailable (no producer)", () => {
+    seed([{ date: "2026-05-20", job: "x", model: "opus", cost: 1 }]);
+    const p = new SessionCostTelemetryProvider({ dbPath });
+    const caps = p.capabilities();
+    const others = caps.filter((c) => c.stream !== "session_cost");
+    expect(others.length).toBeGreaterThan(0);
+    expect(others.every((c) => c.available === false && !!c.reason)).toBe(true);
+    p.close();
+  });
+});
+
+describe("SessionCostTelemetryProvider — query", () => {
+  it("returns samples in the window with value=cost and labels={job,model}", async () => {
+    seed([
+      { date: "2026-05-18", job: "bootstrap", model: "sonnet", cost: 2.0 },
+      { date: "2026-05-20", job: '<channel source="cron" id=1>', model: "opus", cost: 5.0 },
+      { date: "2026-06-01", job: "later", model: "opus", cost: 99 }, // out of window
+    ]);
+    const p = new SessionCostTelemetryProvider({ dbPath });
+    const samples = await p.query("session_cost", range("2026-05-17", "2026-05-25"));
+    expect(samples).toHaveLength(2);
+    expect(samples[1]!.value).toBe(5.0);
+    expect(samples[1]!.labels).toEqual({ job: '<channel source="cron" id=1>', model: "opus" });
+    p.close();
+  });
+
+  it("applies exact label filters on job and model when supplied", async () => {
+    seed([
+      { date: "2026-05-20", job: "gmail", model: "sonnet", cost: 1 },
+      { date: "2026-05-20", job: "gmail", model: "opus", cost: 2 },
+      { date: "2026-05-20", job: "diag", model: "opus", cost: 3 },
+    ]);
+    const p = new SessionCostTelemetryProvider({ dbPath });
+    const r = await p.query("session_cost", range("2026-05-19", "2026-05-21"), {
+      job: "gmail",
+      model: "opus",
+    });
+    expect(r).toHaveLength(1);
+    expect(r[0]!.value).toBe(2);
+    p.close();
+  });
+
+  it("returns [] for any non-session_cost stream (no producer)", async () => {
+    seed([{ date: "2026-05-20", job: "x", model: "opus", cost: 1 }]);
+    const p = new SessionCostTelemetryProvider({ dbPath });
+    expect(await p.query("cron_run", range("2026-05-19", "2026-05-21"))).toEqual([]);
+    expect(await p.query("hook_exec", range("2026-05-19", "2026-05-21"))).toEqual([]);
+    p.close();
+  });
+
+  it("returns [] (does not throw) when the store is absent", async () => {
+    const p = new SessionCostTelemetryProvider({ dbPath: join(dir, "missing.db") });
+    expect(await p.query("session_cost", range("2026-05-19", "2026-05-21"))).toEqual([]);
+    p.close();
+  });
+});

--- a/src/tuner/__tests__/wisecron/telemetry-ingest-hardening.test.ts
+++ b/src/tuner/__tests__/wisecron/telemetry-ingest-hardening.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression tests for untrusted-input hardening in the telemetry ingest path.
+ *
+ * Two confirmed bugs, both from transcripts/logs the host does NOT control:
+ *  (a) SessionJsonl `scanFile` iterated `message.content` with `for...of`; a
+ *      non-array content (`{"message":{"content":{}}}`) threw TypeError that
+ *      escaped scanFile/collect/query/capabilities — crashing the whole
+ *      telemetry surface (capabilities() is sync and feeds the activation gate).
+ *  (b) HookExec coerced `duration_ms` with `Number(...)` straight into a sample
+ *      `value`; a non-numeric field yielded NaN, poisoning downstream mean/p95.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionJsonlTelemetryProducer } from "../../wisecron/session-jsonl-provider.js";
+import { HookExecTelemetryProducer } from "../../wisecron/host-telemetry-provider.js";
+import type { DateRange } from "../../../skills-tuner/core/telemetry.js";
+
+const DAY_MS = 86_400_000;
+const NOW_MS = Date.now();
+const RANGE: DateRange = {
+  start: new Date(NOW_MS - 9 * DAY_MS),
+  end: new Date(NOW_MS - 1 * DAY_MS),
+};
+const IN = new Date(NOW_MS - 5 * DAY_MS); // inside RANGE and the 30d capability probe
+
+describe("SessionJsonl hardening — non-array message.content does not throw", () => {
+  let root: string;
+  let sessionDir: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "sessions-harden-"));
+    sessionDir = join(root, "-home-x-proj");
+    mkdirSync(sessionDir, { recursive: true });
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  function writeRawLines(name: string, lines: string[]): void {
+    writeFileSync(join(sessionDir, name), `${lines.join("\n")}\n`);
+  }
+
+  it("does not throw when an assistant line's message.content is a non-array", async () => {
+    // A malformed assistant line (object content) followed by a well-formed one.
+    // Before the fix, `for (const block of {})` threw and took down the scan.
+    const malformed = JSON.stringify({
+      type: "assistant",
+      timestamp: IN.toISOString(),
+      message: { role: "assistant", content: {} }, // non-array — the poison
+    });
+    const nullContent = JSON.stringify({
+      type: "assistant",
+      timestamp: IN.toISOString(),
+      message: { role: "assistant", content: null },
+    });
+    const good = JSON.stringify({
+      type: "assistant",
+      timestamp: IN.toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "t1", name: "Bash", input: {} }],
+      },
+    });
+    writeRawLines("s.jsonl", [malformed, nullContent, good]);
+
+    const p = new SessionJsonlTelemetryProducer({ projectsDir: root });
+    // capabilities() is sync and must not throw (activation gate depends on it).
+    expect(() => p.capabilities()).not.toThrow();
+    // The malformed lines contribute nothing; the good line still yields its sample.
+    const samples = await p.query("tool_call", RANGE);
+    expect(samples).toHaveLength(1);
+    expect(samples[0]?.labels?.tool).toBe("Bash");
+    // Contract: query returns [] (never throws) even for an all-malformed corpus.
+    expect(await p.query("agent_dispatch", RANGE)).toEqual([]);
+  });
+
+  it("skips a bad file and still scans the rest (per-file tolerance)", async () => {
+    // File 1: entirely poison. File 2: valid. One bad file must not lose the good one.
+    writeRawLines("bad.jsonl", [
+      JSON.stringify({
+        type: "assistant",
+        timestamp: IN.toISOString(),
+        message: { role: "assistant", content: 42 }, // non-array
+      }),
+    ]);
+    writeRawLines("good.jsonl", [
+      JSON.stringify({
+        type: "assistant",
+        timestamp: IN.toISOString(),
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t2", name: "Read", input: { file_path: "/x" } }],
+        },
+      }),
+    ]);
+
+    const p = new SessionJsonlTelemetryProducer({ projectsDir: root });
+    const samples = await p.query("tool_call", RANGE);
+    expect(samples).toHaveLength(1);
+    expect(samples[0]?.labels?.tool).toBe("Read");
+  });
+});
+
+describe("HookExec hardening — non-numeric duration_ms is dropped, not emitted as NaN", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hooks-harden-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("drops the sample whose duration_ms is non-numeric and keeps the finite ones", async () => {
+    const poison = JSON.stringify({
+      hook: "bad",
+      exit_code: 0,
+      duration_ms: "oops", // Number("oops") === NaN
+      event: "PostToolUse",
+      ts: IN.toISOString(),
+    });
+    const good = JSON.stringify({
+      hook: "ok",
+      exit_code: 0,
+      duration_ms: 12,
+      event: "PostToolUse",
+      ts: IN.toISOString(),
+    });
+    writeFileSync(join(dir, "exec-log.jsonl"), `${poison}\n${good}\n`);
+
+    const p = new HookExecTelemetryProducer({ hooksDir: dir });
+    const samples = await p.query("hook_exec", RANGE);
+    // Only the finite-duration sample survives; no NaN leaks into the stream.
+    expect(samples).toHaveLength(1);
+    expect(samples[0]?.value).toBe(12);
+    expect(samples.some((s) => Number.isNaN(s.value))).toBe(false);
+    // Sanity: an all-poison corpus yields no samples (not a NaN sample).
+    writeFileSync(join(dir, "exec-log.jsonl"), `${poison}\n`);
+    const p2 = new HookExecTelemetryProducer({ hooksDir: dir });
+    expect(await p2.query("hook_exec", RANGE)).toEqual([]);
+  });
+});

--- a/src/tuner/__tests__/wisecron/telemetry-mcp.test.ts
+++ b/src/tuner/__tests__/wisecron/telemetry-mcp.test.ts
@@ -21,6 +21,8 @@ import {
 } from "../../../skills-tuner/core/telemetry.js";
 import {
   bridgeToolCaller,
+  MAX_QUERY_SAMPLES,
+  MAX_QUERY_WINDOW_DAYS,
   McpTelemetryProvider,
   registerHostTelemetryTools,
   TELEMETRY_CAPABILITIES_TOOL,
@@ -164,6 +166,74 @@ describe("McpTelemetryProvider — degrade gracefully", () => {
     const out = await provider.query("cron_run", RANGE);
     expect(out.map((s) => s.value)).toEqual([1, 3]);
     expect(out.every((s) => !Number.isNaN(s.ts.getTime()))).toBe(true);
+  });
+});
+
+describe("telemetry__query resource guards (range clamp + array cap)", () => {
+  const DAY_MS = 86_400_000;
+
+  /** Captures the range it was queried with, and returns a configurable count. */
+  class CapturingProvider implements TelemetryProvider {
+    lastRange: DateRange | null = null;
+    constructor(private readonly count: number) {}
+    contractVersion(): string {
+      return TELEMETRY_CONTRACT_VERSION;
+    }
+    capabilities(): TelemetryCapability[] {
+      return [{ stream: "cron_run", schemaVersion: TELEMETRY_CONTRACT_VERSION, available: true }];
+    }
+    async query(stream: TelemetryStream, range: DateRange): Promise<MetricSample[]> {
+      this.lastRange = range;
+      if (stream !== "cron_run") return [];
+      return Array.from({ length: this.count }, () => ({ ts: IN, value: 0 }));
+    }
+  }
+
+  it("clamps an over-wide window to the most-recent MAX_QUERY_WINDOW_DAYS and flags truncated", async () => {
+    const bridge = new PluginMcpBridge(join(tmpDir, "audit.jsonl"));
+    const host = new CapturingProvider(1);
+    registerHostTelemetryTools(bridge, { provider: host });
+
+    // A decade-wide request must reach the provider as a <=90d window ending at `end`.
+    const end = "2030-01-01T00:00:00.000Z";
+    const res = (await bridge.invokeTool(TELEMETRY_QUERY_TOOL, {
+      stream: "cron_run",
+      start: "2020-01-01T00:00:00.000Z",
+      end,
+    })) as { samples: unknown[]; truncated?: boolean };
+    expect(res.truncated).toBe(true);
+    const span = host.lastRange!.end.getTime() - host.lastRange!.start.getTime();
+    expect(span).toBeLessThanOrEqual(MAX_QUERY_WINDOW_DAYS * DAY_MS);
+    expect(host.lastRange!.end.toISOString()).toBe(end);
+  });
+
+  it("caps the returned sample array at MAX_QUERY_SAMPLES with truncated: true", async () => {
+    const bridge = new PluginMcpBridge(join(tmpDir, "audit.jsonl"));
+    registerHostTelemetryTools(bridge, { provider: new CapturingProvider(MAX_QUERY_SAMPLES + 25) });
+
+    // In-range window (well under the cap) but a dense stream → array is clipped.
+    const res = (await bridge.invokeTool(TELEMETRY_QUERY_TOOL, {
+      stream: "cron_run",
+      start: RANGE.start.toISOString(),
+      end: RANGE.end.toISOString(),
+    })) as { samples: unknown[]; truncated?: boolean };
+    expect(res.samples).toHaveLength(MAX_QUERY_SAMPLES);
+    expect(res.truncated).toBe(true);
+  });
+
+  it("leaves a normal query unclamped (no truncated flag)", async () => {
+    const bridge = new PluginMcpBridge(join(tmpDir, "audit.jsonl"));
+    const host = new CapturingProvider(3);
+    registerHostTelemetryTools(bridge, { provider: host });
+
+    const res = (await bridge.invokeTool(TELEMETRY_QUERY_TOOL, {
+      stream: "cron_run",
+      start: RANGE.start.toISOString(),
+      end: RANGE.end.toISOString(),
+    })) as { samples: unknown[]; truncated?: boolean };
+    expect(res.samples).toHaveLength(3);
+    expect(res.truncated).toBeUndefined();
+    expect(host.lastRange!.start.toISOString()).toBe(RANGE.start.toISOString());
   });
 });
 

--- a/src/tuner/__tests__/wisecron/telemetry-mcp.test.ts
+++ b/src/tuner/__tests__/wisecron/telemetry-mcp.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Telemetry over the MCP bridge: the host-served tools, the tuner-side
+ * `McpTelemetryProvider` (in-process AND over a real MCP transport), graceful
+ * degradation, and the audit provenance of served queries.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { PluginMcpBridge, _resetMcpBridge, _setMcpBridge } from "../../../plugins/mcp-bridge.js";
+import { AuditLog } from "../../../skills-tuner/core/audit-log.js";
+import {
+  type DateRange,
+  type MetricSample,
+  type TelemetryCapability,
+  type TelemetryProvider,
+  type TelemetryStream,
+  TELEMETRY_CONTRACT_VERSION,
+} from "../../../skills-tuner/core/telemetry.js";
+import {
+  bridgeToolCaller,
+  McpTelemetryProvider,
+  registerHostTelemetryTools,
+  TELEMETRY_CAPABILITIES_TOOL,
+  TELEMETRY_QUERY_TOOL,
+  type TelemetryMcpClient,
+} from "../../wisecron/telemetry-mcp.js";
+
+const RANGE: DateRange = {
+  start: new Date("2026-05-13T00:00:00Z"),
+  end: new Date("2026-05-21T00:00:00Z"),
+};
+const IN = new Date("2026-05-20T12:00:00Z");
+
+/** Deterministic host producer: advertises cron_run, answers queries for it. */
+class StubHostProvider implements TelemetryProvider {
+  queries: Array<{ stream: TelemetryStream; range: DateRange }> = [];
+  constructor(private readonly available = true) {}
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+  capabilities(): TelemetryCapability[] {
+    return [
+      this.available
+        ? { stream: "cron_run", schemaVersion: TELEMETRY_CONTRACT_VERSION, available: true }
+        : {
+            stream: "cron_run",
+            schemaVersion: TELEMETRY_CONTRACT_VERSION,
+            available: false,
+            reason: "no wisecron units in this env",
+          },
+    ];
+  }
+  async query(stream: TelemetryStream, range: DateRange): Promise<MetricSample[]> {
+    this.queries.push({ stream, range });
+    if (stream !== "cron_run") return [];
+    return [{ ts: IN, value: 0, labels: { unit: "wisecron-a.service", status: "success" } }];
+  }
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "telemetry-mcp-"));
+  _resetMcpBridge();
+  _setMcpBridge(new PluginMcpBridge(join(tmpDir, "bridge-audit.jsonl")));
+});
+
+afterEach(() => {
+  _resetMcpBridge();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("registerHostTelemetryTools + bridgeToolCaller (in-process)", () => {
+  it("round-trips capabilities + query through the bridge", async () => {
+    const bridge = new PluginMcpBridge(join(tmpDir, "audit.jsonl"));
+    const host = new StubHostProvider();
+    const reg = registerHostTelemetryTools(bridge, { provider: host });
+    expect(reg.capabilitiesTool).toBe(TELEMETRY_CAPABILITIES_TOOL);
+    expect(reg.queryTool).toBe(TELEMETRY_QUERY_TOOL);
+
+    const provider = new McpTelemetryProvider(bridgeToolCaller(bridge));
+    const conn = await provider.connect();
+    expect(conn.ok).toBe(true);
+    expect(provider.isConnected()).toBe(true);
+    expect(provider.contractVersion()).toBe(TELEMETRY_CONTRACT_VERSION);
+
+    const cap = provider.capabilities().find((c) => c.stream === "cron_run");
+    expect(cap?.available).toBe(true);
+
+    const samples = await provider.query("cron_run", RANGE);
+    expect(samples).toHaveLength(1);
+    expect(samples[0]!.value).toBe(0);
+    expect(samples[0]!.ts.toISOString()).toBe(IN.toISOString());
+    expect(samples[0]!.labels).toEqual({ unit: "wisecron-a.service", status: "success" });
+
+    // The host actually received the query over the boundary.
+    expect(host.queries).toHaveLength(1);
+    expect(host.queries[0]!.stream).toBe("cron_run");
+  });
+
+  it("re-registration replaces the prior tools (idempotent surface)", () => {
+    const bridge = new PluginMcpBridge(join(tmpDir, "audit.jsonl"));
+    registerHostTelemetryTools(bridge, { provider: new StubHostProvider() });
+    expect(() =>
+      registerHostTelemetryTools(bridge, { provider: new StubHostProvider() }),
+    ).not.toThrow();
+    const fqns = bridge.listTools().map((t) => t.fqn);
+    expect(fqns.filter((f) => f === TELEMETRY_QUERY_TOOL)).toHaveLength(1);
+  });
+});
+
+describe("McpTelemetryProvider — degrade gracefully", () => {
+  it("empty capabilities + empty query when the endpoint is unreachable", async () => {
+    const throwing: TelemetryMcpClient = {
+      async callTool() {
+        throw new Error("ECONNREFUSED: telemetry endpoint absent");
+      },
+    };
+    const provider = new McpTelemetryProvider(throwing);
+
+    // Before connect: empty cache, every stream degrades to proposal-only.
+    expect(provider.capabilities()).toEqual([]);
+
+    const conn = await provider.connect();
+    expect(conn.ok).toBe(false);
+    expect(conn.reason).toContain("ECONNREFUSED");
+    expect(provider.isConnected()).toBe(false);
+    expect(provider.capabilities()).toEqual([]);
+
+    // Query never throws — returns [].
+    expect(await provider.query("cron_run", RANGE)).toEqual([]);
+  });
+
+  it("empty capabilities when the host returns a malformed payload", async () => {
+    const bad: TelemetryMcpClient = {
+      async callTool() {
+        return { contractVersion: "1.0.0" }; // no `capabilities` array
+      },
+    };
+    const provider = new McpTelemetryProvider(bad);
+    const conn = await provider.connect();
+    expect(conn.ok).toBe(false);
+    expect(provider.capabilities()).toEqual([]);
+  });
+});
+
+describe("telemetry_query audit provenance", () => {
+  it("records each served query with stream/window/sample_count and keeps the chain intact", async () => {
+    const bridge = new PluginMcpBridge(join(tmpDir, "audit.jsonl"));
+    const audit = new AuditLog(join(tmpDir, "outcome-audit.jsonl"));
+    registerHostTelemetryTools(bridge, { provider: new StubHostProvider(), audit });
+
+    const provider = new McpTelemetryProvider(bridgeToolCaller(bridge));
+    await provider.connect();
+    await provider.query("cron_run", RANGE);
+    await provider.query("hook_exec", RANGE); // host owns no hook_exec → 0 samples
+
+    const records = audit.all().filter((r) => r.event === "telemetry_query");
+    expect(records).toHaveLength(2);
+    expect(records[0]!.detail).toMatchObject({
+      stream: "cron_run",
+      window_start: RANGE.start.toISOString(),
+      window_end: RANGE.end.toISOString(),
+      sample_count: 1,
+      contract_version: TELEMETRY_CONTRACT_VERSION,
+    });
+    expect(records[1]!.detail).toMatchObject({ stream: "hook_exec", sample_count: 0 });
+    expect(audit.verifyChain().ok).toBe(true);
+
+    // Tamper with an earlier record → chain breaks.
+    const tampered = new AuditLog(join(tmpDir, "tamper.jsonl"));
+    tampered.append({ event: "telemetry_query", detail: { stream: "cron_run" } });
+    tampered.append({ event: "telemetry_query", detail: { stream: "hook_exec" } });
+    const arr = tampered.all() as unknown as Array<{ detail?: Record<string, unknown> }>;
+    arr[0]!.detail = { stream: "MUTATED" };
+    expect(tampered.verifyChain().ok).toBe(false);
+  });
+});
+
+// NOTE: end-to-end coverage over a real MCP transport (`startMcpServer`) and the
+// full `serveTunerOverMcp` wiring (which also serves the mutating `tuner__*`
+// gate) lives with the OutcomeLoop PR, not this read-only telemetry PR. The
+// in-process bridge tests above exercise the host + client contract.

--- a/src/tuner/__tests__/wisecron/telemetry-mcp.test.ts
+++ b/src/tuner/__tests__/wisecron/telemetry-mcp.test.ts
@@ -92,13 +92,13 @@ describe("registerHostTelemetryTools + bridgeToolCaller (in-process)", () => {
 
     const samples = await provider.query("cron_run", RANGE);
     expect(samples).toHaveLength(1);
-    expect(samples[0]!.value).toBe(0);
-    expect(samples[0]!.ts.toISOString()).toBe(IN.toISOString());
-    expect(samples[0]!.labels).toEqual({ unit: "wisecron-a.service", status: "success" });
+    expect(samples[0]?.value).toBe(0);
+    expect(samples[0]?.ts.toISOString()).toBe(IN.toISOString());
+    expect(samples[0]?.labels).toEqual({ unit: "wisecron-a.service", status: "success" });
 
     // The host actually received the query over the boundary.
     expect(host.queries).toHaveLength(1);
-    expect(host.queries[0]!.stream).toBe("cron_run");
+    expect(host.queries[0]?.stream).toBe("cron_run");
   });
 
   it("re-registration replaces the prior tools (idempotent surface)", () => {
@@ -145,6 +145,26 @@ describe("McpTelemetryProvider — degrade gracefully", () => {
     expect(conn.ok).toBe(false);
     expect(provider.capabilities()).toEqual([]);
   });
+
+  it("drops query samples with an invalid timestamp or non-finite value", async () => {
+    const wire: TelemetryMcpClient = {
+      async callTool() {
+        return {
+          samples: [
+            { ts: RANGE.start.toISOString(), value: 1 }, // valid
+            { ts: "not-a-date", value: 2 }, // bad ts → dropped
+            { ts: RANGE.end.toISOString(), value: Number.NaN }, // NaN → dropped
+            { ts: RANGE.end.toISOString(), value: "x" }, // non-number → dropped
+            { ts: RANGE.end.toISOString(), value: 3 }, // valid
+          ],
+        };
+      },
+    };
+    const provider = new McpTelemetryProvider(wire);
+    const out = await provider.query("cron_run", RANGE);
+    expect(out.map((s) => s.value)).toEqual([1, 3]);
+    expect(out.every((s) => !Number.isNaN(s.ts.getTime()))).toBe(true);
+  });
 });
 
 describe("telemetry_query audit provenance", () => {
@@ -160,14 +180,14 @@ describe("telemetry_query audit provenance", () => {
 
     const records = audit.all().filter((r) => r.event === "telemetry_query");
     expect(records).toHaveLength(2);
-    expect(records[0]!.detail).toMatchObject({
+    expect(records[0]?.detail).toMatchObject({
       stream: "cron_run",
       window_start: RANGE.start.toISOString(),
       window_end: RANGE.end.toISOString(),
       sample_count: 1,
       contract_version: TELEMETRY_CONTRACT_VERSION,
     });
-    expect(records[1]!.detail).toMatchObject({ stream: "hook_exec", sample_count: 0 });
+    expect(records[1]?.detail).toMatchObject({ stream: "hook_exec", sample_count: 0 });
     expect(audit.verifyChain().ok).toBe(true);
 
     // Tamper with an earlier record → chain breaks.

--- a/src/tuner/__tests__/wisecron/tuner-view-provider.test.ts
+++ b/src/tuner/__tests__/wisecron/tuner-view-provider.test.ts
@@ -74,9 +74,9 @@ describe("TunerViewProvider", () => {
     const m = p.viewManifest();
     expect(m.plugin).toBe(TUNER_PLUGIN);
     expect(m.panels).toHaveLength(1);
-    expect(m.panels[0]!.kind).toBe("timeline");
-    expect(m.panels[0]!.id).toBe(TUNER_TIMELINE_PANEL);
-    expect(m.panels[0]!.columns).toEqual([
+    expect(m.panels[0]?.kind).toBe("timeline");
+    expect(m.panels[0]?.id).toBe(TUNER_TIMELINE_PANEL);
+    expect(m.panels[0]?.columns).toEqual([
       "ts",
       "subject",
       "change",
@@ -132,6 +132,33 @@ describe("TunerViewProvider", () => {
       branch: "tune/proposal-7",
       commit: "cafe01",
     });
+  });
+
+  it("surfaces the decisive verdict, not the alphabetically-first matured guardrail", async () => {
+    writeFileSync(
+      proposalsPath,
+      proposalLine({
+        id: 11,
+        subject: "model_routing",
+        kind: "patch",
+        target_path: "p",
+        event: "applied",
+        ts: "2026-05-13T12:00:00.000Z",
+        commit_sha: "dec01",
+      }),
+    );
+    // Ordered by metric ASC: a neutral guardrail ("cost_guard") sorts before the
+    // target ("latency") that actually regressed. The panel must show the target.
+    const rows: OutcomeRow[] = [
+      outcome({ proposal_id: "11", metric: "cost_guard", delta: 0, verdict: "neutral" }),
+      outcome({ proposal_id: "11", metric: "latency", delta: 42, verdict: "regressed" }),
+    ];
+    const p = new TunerViewProvider({
+      proposals: new ProposalsStore(proposalsPath),
+      outcomesFor: () => rows,
+    });
+    const data = await p.viewData(TUNER_TIMELINE_PANEL, RANGE);
+    expect(data?.rows[0]).toMatchObject({ verdict: "regressed", delta: 42 });
   });
 
   it("shows an applied proposal with blank delta/verdict when no outcome matured yet", async () => {

--- a/src/tuner/__tests__/wisecron/tuner-view-provider.test.ts
+++ b/src/tuner/__tests__/wisecron/tuner-view-provider.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ProposalsStore } from "../../../skills-tuner/storage/proposals.js";
+import type { OutcomeRow } from "../../wisecron/state-db.js";
+import {
+  TUNER_PLUGIN,
+  TUNER_TIMELINE_PANEL,
+  TunerViewProvider,
+} from "../../wisecron/tuner-view-provider.js";
+
+const RANGE = {
+  start: new Date("2026-05-01T00:00:00.000Z"),
+  end: new Date("2026-06-01T00:00:00.000Z"),
+};
+
+function proposalLine(over: {
+  id: number;
+  subject: string;
+  kind: string;
+  target_path: string;
+  event: "created" | "applied" | "refused";
+  ts: string;
+  commit_sha?: string;
+}): string {
+  return JSON.stringify({
+    proposal: {
+      id: over.id,
+      cluster_id: `c${over.id}`,
+      subject: over.subject,
+      kind: over.kind,
+      target_path: over.target_path,
+      alternatives: [{ id: "alt-1", diff_or_content: "..." }],
+      pattern_signature: `sig${over.id}`,
+      created_at: over.ts,
+      signature: "sig",
+    },
+    event: over.event,
+    ts: over.ts,
+    ...(over.commit_sha ? { commit_sha: over.commit_sha } : {}),
+  });
+}
+
+function outcome(over: Partial<OutcomeRow> & { proposal_id: string }): OutcomeRow {
+  return {
+    metric: "cron_cost",
+    commit_sha: "abc123",
+    subject: "cron",
+    baseline: 100,
+    post: 80,
+    delta: -20,
+    window_start: "2026-05-01T00:00:00.000Z",
+    window_end: "2026-05-08T00:00:00.000Z",
+    verdict: "improved",
+    ...over,
+  };
+}
+
+describe("TunerViewProvider", () => {
+  let dir: string;
+  let proposalsPath: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "tuner-view-"));
+    proposalsPath = join(dir, "proposals.jsonl");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("declares a timeline manifest for the tuner plugin", () => {
+    const p = new TunerViewProvider({
+      proposals: new ProposalsStore(proposalsPath),
+      outcomesFor: () => [],
+    });
+    const m = p.viewManifest();
+    expect(m.plugin).toBe(TUNER_PLUGIN);
+    expect(m.panels).toHaveLength(1);
+    expect(m.panels[0]!.kind).toBe("timeline");
+    expect(m.panels[0]!.id).toBe(TUNER_TIMELINE_PANEL);
+    expect(m.panels[0]!.columns).toEqual([
+      "ts",
+      "subject",
+      "change",
+      "delta",
+      "verdict",
+      "branch",
+      "commit",
+    ]);
+    // view-only: advertises no telemetry streams.
+    expect(p.capabilities()).toEqual([]);
+  });
+
+  it("builds timeline rows from applied proposals joined to their outcomes", async () => {
+    writeFileSync(
+      proposalsPath,
+      [
+        proposalLine({
+          id: 7,
+          subject: "cron",
+          kind: "patch",
+          target_path: "~/.config/cron.yaml",
+          event: "applied",
+          ts: "2026-05-10T12:00:00.000Z",
+          commit_sha: "cafe01",
+        }),
+        // a 'created' (not applied) row must be ignored
+        proposalLine({
+          id: 8,
+          subject: "hook",
+          kind: "patch",
+          target_path: "x",
+          event: "created",
+          ts: "2026-05-11T12:00:00.000Z",
+        }),
+      ].join("\n"),
+    );
+    const outcomesByProposal: Record<string, OutcomeRow[]> = {
+      "7": [outcome({ proposal_id: "7", delta: -20, verdict: "improved" })],
+    };
+    const p = new TunerViewProvider({
+      proposals: new ProposalsStore(proposalsPath),
+      outcomesFor: (id) => outcomesByProposal[id] ?? [],
+    });
+
+    const data = await p.viewData(TUNER_TIMELINE_PANEL, RANGE);
+    expect(data?.panelId).toBe(TUNER_TIMELINE_PANEL);
+    expect(data?.rows).toHaveLength(1);
+    expect(data?.rows[0]).toMatchObject({
+      subject: "cron",
+      change: "patch: ~/.config/cron.yaml",
+      delta: -20,
+      verdict: "improved",
+      branch: "tune/proposal-7",
+      commit: "cafe01",
+    });
+  });
+
+  it("shows an applied proposal with blank delta/verdict when no outcome matured yet", async () => {
+    writeFileSync(
+      proposalsPath,
+      proposalLine({
+        id: 9,
+        subject: "model_routing",
+        kind: "patch",
+        target_path: "p",
+        event: "applied",
+        ts: "2026-05-12T12:00:00.000Z",
+        commit_sha: "beef02",
+      }),
+    );
+    const p = new TunerViewProvider({
+      proposals: new ProposalsStore(proposalsPath),
+      outcomesFor: () => [],
+    });
+    const data = await p.viewData(TUNER_TIMELINE_PANEL, RANGE);
+    expect(data?.rows).toHaveLength(1);
+    expect(data?.rows[0]).toMatchObject({ delta: null, verdict: null, branch: "tune/proposal-9" });
+  });
+
+  it("excludes applied proposals outside the window", async () => {
+    writeFileSync(
+      proposalsPath,
+      proposalLine({
+        id: 10,
+        subject: "cron",
+        kind: "patch",
+        target_path: "p",
+        event: "applied",
+        ts: "2025-01-01T00:00:00.000Z",
+        commit_sha: "old",
+      }),
+    );
+    const p = new TunerViewProvider({
+      proposals: new ProposalsStore(proposalsPath),
+      outcomesFor: () => [],
+    });
+    const data = await p.viewData(TUNER_TIMELINE_PANEL, RANGE);
+    expect(data?.rows).toEqual([]);
+  });
+
+  it("returns undefined for an unknown panel id", async () => {
+    const p = new TunerViewProvider({
+      proposals: new ProposalsStore(proposalsPath),
+      outcomesFor: () => [],
+    });
+    expect(await p.viewData("nope", RANGE)).toBeUndefined();
+  });
+});

--- a/src/tuner/wisecron/host-telemetry-provider.ts
+++ b/src/tuner/wisecron/host-telemetry-provider.ts
@@ -47,6 +47,7 @@ import {
   type ViewManifestSource,
 } from "../../skills-tuner/core/telemetry.js";
 import { McpToolCallTelemetryProducer } from "../../observability/mcp-tool-call-producer.js";
+import { forEachLineSync } from "./line-reader.js";
 import { type TunerViewSources, TunerViewProvider } from "./tuner-view-provider.js";
 import { DEFAULT_MODE_DISPATCH_LOG } from "../../governance/mode-dispatch-journal.js";
 import { DEFAULT_TEMPLATE_FEEDBACK_LOG } from "../../skills-tuner/core/template-feedback.js";
@@ -80,6 +81,12 @@ export interface CronRunProducerConfig {
   /** Injected cron-config presence probe (feeds the unavailable reason). Default
    *  inspects `crontab -l` + `~/.config/cron`. Tests override for hermeticity. */
   cronConfigProbe?: () => CronConfigPresence;
+  /** TTL (ms) for the memoised source-kind. Default 60s. The probe spawns
+   *  journalctl (+ maybe crontab) — up to ~15s sync — so repeat `capabilities()`
+   *  / `query()` calls within the TTL reuse the resolved kind for free. */
+  kindCacheTtlMs?: number;
+  /** Injected clock (ms). Test seam for exercising the cache TTL. Default `Date.now`. */
+  now?: () => number;
 }
 
 interface CronRunEntry {
@@ -127,6 +134,10 @@ export class CronRunTelemetryProducer implements TelemetryProvider {
   private readonly journalRunner: (args: string[]) => string;
   private readonly costDbPath: string;
   private readonly cronConfigProbe: () => CronConfigPresence;
+  private readonly kindCacheTtlMs: number;
+  private readonly now: () => number;
+  /** Memoised source-kind + when it was resolved (see `detectKind`). */
+  private kindCache: { kind: CronSourceKind; at: number } | null = null;
 
   constructor(cfg: CronRunProducerConfig = {}) {
     this.journalUnitGlob = cfg.journalUnitGlob ?? "wisecron-*.service";
@@ -135,6 +146,8 @@ export class CronRunTelemetryProducer implements TelemetryProvider {
     this.journalRunner = cfg.journalRunner ?? defaultJournalRunner;
     this.costDbPath = expandHome(cfg.costDbPath ?? join(homedir(), "agent", "data", "costs.db"));
     this.cronConfigProbe = cfg.cronConfigProbe ?? defaultCronConfigProbe;
+    this.kindCacheTtlMs = cfg.kindCacheTtlMs ?? 60_000;
+    this.now = cfg.now ?? Date.now;
   }
 
   contractVersion(): string {
@@ -160,9 +173,27 @@ export class CronRunTelemetryProducer implements TelemetryProvider {
     return parseCronRunJournal(raw);
   }
 
-  /** Resolve the active source by probing each candidate in priority order. */
+  /**
+   * Resolve the active source, MEMOISED with a TTL. `detectKind` is called by
+   * both `capabilities()` and `query()` — and `telemetry__capabilities` is
+   * socket-exposed, so a client looping it would otherwise re-spawn journalctl
+   * (+ maybe crontab), up to ~15s SYNC each, and stall the daemon. First call in
+   * a TTL window probes + caches; repeats within the TTL cost nothing; after the
+   * TTL we re-probe so a newly-configured source is still picked up.
+   */
   private detectKind(): CronSourceKind {
-    if (this.readEntries(new Date(Date.now() - 7 * 86_400_000)).length > 0) return "systemd";
+    const now = this.now();
+    if (this.kindCache && now - this.kindCache.at < this.kindCacheTtlMs) {
+      return this.kindCache.kind;
+    }
+    const kind = this.probeKind();
+    this.kindCache = { kind, at: now };
+    return kind;
+  }
+
+  /** The actual (expensive) source probe, in priority order. */
+  private probeKind(): CronSourceKind {
+    if (this.readEntries(new Date(this.now() - 7 * 86_400_000)).length > 0) return "systemd";
     if (busSchedulerRowCount(this.costDbPath) > 0) return "bus_scheduler";
     return "none";
   }
@@ -607,22 +638,22 @@ export class JournalTelemetryProducer implements TelemetryProvider {
 
   private readAll(): Array<Record<string, unknown>> {
     if (!existsSync(this.journalPath)) return [];
-    let content: string;
+    const out: Array<Record<string, unknown>> = [];
+    // Stream line-by-line (bounded memory) rather than slurping the whole
+    // operations journal — it is append-only and can grow large on a busy host.
     try {
-      content = readFileSync(this.journalPath, "utf8");
+      forEachLineSync(this.journalPath, (line) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        try {
+          const obj = JSON.parse(trimmed);
+          if (typeof obj === "object" && obj !== null) out.push(obj as Record<string, unknown>);
+        } catch {
+          /* skip */
+        }
+      });
     } catch {
       return [];
-    }
-    const out: Array<Record<string, unknown>> = [];
-    for (const line of content.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        const obj = JSON.parse(trimmed);
-        if (typeof obj === "object" && obj !== null) out.push(obj as Record<string, unknown>);
-      } catch {
-        /* skip */
-      }
     }
     return out;
   }

--- a/src/tuner/wisecron/host-telemetry-provider.ts
+++ b/src/tuner/wisecron/host-telemetry-provider.ts
@@ -473,6 +473,10 @@ function defaultHookLogReader(dir: string): HookExecEntry[] {
         const hook = (obj.hook as string) ?? f.replace(/\.log$/, "");
         const exitCode = Number(obj.exit_code ?? 0);
         const durationMs = Number(obj.duration_ms ?? 0);
+        // `duration_ms` is the sample `value`; a non-numeric field (e.g. "oops")
+        // yields NaN which would poison downstream mean/p95. Drop the sample
+        // rather than emit NaN (mirrors the template-feedback rating guard).
+        if (!Number.isFinite(durationMs)) continue;
         const event = (obj.event as string) ?? "unknown";
         const tsRaw = obj.ts as string | number | undefined;
         const ts = tsRaw ? new Date(tsRaw) : new Date();

--- a/src/tuner/wisecron/host-telemetry-provider.ts
+++ b/src/tuner/wisecron/host-telemetry-provider.ts
@@ -977,7 +977,11 @@ export class CompositeTelemetryProvider implements TelemetryProvider, ViewManife
   }
 }
 
+import { MemorySignalProducer } from "./memory-signal-provider.js";
+
 export interface HostTelemetryConfig {
+  /** Path to the memory-signal sampler history; when set, wires the `memory_signal` stream. */
+  memorySignalHistoryPath?: string;
   costDbPath?: string;
   hooksDir?: string;
   skillAccessLog?: string;
@@ -1045,6 +1049,9 @@ export function buildHostTelemetryProvider(
   // Phase A: universal MCP boundary stream — wired only when the gateway log is
   // configured, so existing capability tests (every stream unavailable on an
   // empty host) stay deterministic and machine-state-independent.
+  if (cfg.memorySignalHistoryPath) {
+    providers.push(new MemorySignalProducer({ historyPath: cfg.memorySignalHistoryPath }));
+  }
   if (cfg.mcpToolCallLog) {
     providers.push(new McpToolCallTelemetryProducer({ logPath: cfg.mcpToolCallLog }));
   }

--- a/src/tuner/wisecron/host-telemetry-provider.ts
+++ b/src/tuner/wisecron/host-telemetry-provider.ts
@@ -1,0 +1,1056 @@
+/**
+ * Host telemetry producers + composite (OutcomeLoop Phase B).
+ *
+ * The tuner CONSUMES telemetry through `provider.query(...)`; the HOST PRODUCES
+ * it. `session-cost-provider.ts` covers the `session_cost` stream. This file
+ * adds the remaining feasible reference-host producers, each owning ONE stream,
+ * each reading a single real source with graceful degradation, and composes
+ * them (+ the cost provider) into one `TelemetryProvider` the subjects see.
+ *
+ * Provenance, per stream:
+ *  - `cron_run`     ← `journalctl --user -u 'wisecron-*'` (unit run completions).
+ *                     value = exit_code (0 = clean, nonzero = failure — matches
+ *                     CronSubject.critical_fire_success); labels = unit, status,
+ *                     exit_code.
+ *  - `hook_exec`    ← `~/.claude/hooks/*.log` (one JSON line per hook fire).
+ *                     value = duration_ms; labels = hook, exit_code, event.
+ *  - `skill_access` ← `~/.config/tuner/skill_accesses.jsonl` (log-skill-access.py
+ *                     PostToolUse hook). value = 1 per access; labels = skill.
+ *  - `tool_call`, `mode_dispatch`, `agent_dispatch`, `memory_access`
+ *                   ← `~/.claudeclaw/journal/operations.jsonl`, IF the journal
+ *                     carries matching event types. The reference journal records
+ *                     coarse operation entries only, so these advertise
+ *                     `available:false` with a reason today — declared + inactive
+ *                     by design (no faked data), active the day those events land.
+ *
+ * Every producer returns `[]` (never throws) for a stream it does not own and
+ * for its own stream when the source is absent. The composite therefore just
+ * concatenates query results, and merges capabilities one-per-stream preferring
+ * an available producer.
+ */
+
+import { Database } from "bun:sqlite";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import {
+  type DateRange,
+  type MetricSample,
+  type PanelData,
+  type TelemetryCapability,
+  type TelemetryProvider,
+  type TelemetryStream,
+  TELEMETRY_CONTRACT_VERSION,
+  TELEMETRY_STREAMS,
+  type ViewManifest,
+  type ViewManifestSource,
+} from "../../skills-tuner/core/telemetry.js";
+import { McpToolCallTelemetryProducer } from "../../observability/mcp-tool-call-producer.js";
+import { type TunerViewSources, TunerViewProvider } from "./tuner-view-provider.js";
+import { DEFAULT_MODE_DISPATCH_LOG } from "../../governance/mode-dispatch-journal.js";
+import { DEFAULT_TEMPLATE_FEEDBACK_LOG } from "../../skills-tuner/core/template-feedback.js";
+import { SessionCostTelemetryProvider } from "./session-cost-provider.js";
+import { SessionJsonlTelemetryProducer } from "./session-jsonl-provider.js";
+
+function expandHome(p: string): string {
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+function inRange(ts: Date, range: DateRange): boolean {
+  const t = ts.getTime();
+  return t >= range.start.getTime() && t < range.end.getTime();
+}
+
+// ── cron_run ─────────────────────────────────────────────────────────────────
+
+export interface CronRunProducerConfig {
+  /** journalctl unit glob. Default 'wisecron-*.service'. */
+  journalUnitGlob?: string;
+  /** Required unit prefix used for the capability match rate. Default 'wisecron-'. */
+  unitPrefix?: string;
+  schemaVersion?: string;
+  /** Injected journalctl runner (args → raw stdout). Synchronous so capability
+   *  detection stays sync per the TelemetryProvider contract. Tests pass a fixture. */
+  journalRunner?: (args: string[]) => string;
+  /** costs.db for ClaudeClaw bus-scheduler cron-session detection (fallback
+   *  source). Default `~/agent/data/costs.db`. */
+  costDbPath?: string;
+  /** Injected cron-config presence probe (feeds the unavailable reason). Default
+   *  inspects `crontab -l` + `~/.config/cron`. Tests override for hermeticity. */
+  cronConfigProbe?: () => CronConfigPresence;
+}
+
+interface CronRunEntry {
+  unit: string;
+  ts: Date;
+  exitCode: number;
+}
+
+/** Which classic cron systems are configured (for diagnostics only). */
+interface CronConfigPresence {
+  /** `crontab -l` returned at least one schedule line. */
+  crontab: boolean;
+  /** `~/.config/cron` (XDG crontab snapshot sidecar) is present. */
+  configSnapshot: boolean;
+}
+
+/** The cron source auto-detection resolved to. */
+type CronSourceKind = "systemd" | "bus_scheduler" | "none";
+
+/**
+ * Emits `cron_run` from whichever real cron source THIS host actually has,
+ * detected at registration instead of assuming `wisecron-*`. Priority:
+ *
+ *   1. **systemd**       — `journalctl --user -u 'wisecron-*'` entries that
+ *                          carry `EXIT_STATUS` (a service run completed).
+ *                          value = exit_code (0 clean, nonzero failure) — the
+ *                          richest source, true crash detection.
+ *   2. **bus_scheduler** — ClaudeClaw bus-scheduler cron sessions in costs.db
+ *                          (`job LIKE '%source="cron"%'` …). A recorded session
+ *                          IS a completed fire, so value = 0 (success); costs.db
+ *                          carries no exit code, so this source cannot surface
+ *                          crash-failures — flagged in the capability reason.
+ *   3. **none**          — neither present. Advertised unavailable, the reason
+ *                          naming any classic cron config found (crontab /
+ *                          `~/.config/cron`) which defines schedules but logs no
+ *                          machine-readable run completions.
+ *
+ * Either way the consumer (`CronSubject.critical_fire_success = 1 - nonzeroRate`)
+ * reads the same value contract: 0 = clean, nonzero = failure.
+ */
+export class CronRunTelemetryProducer implements TelemetryProvider {
+  private readonly journalUnitGlob: string;
+  private readonly unitPrefix: string;
+  private readonly schemaVersion: string;
+  private readonly journalRunner: (args: string[]) => string;
+  private readonly costDbPath: string;
+  private readonly cronConfigProbe: () => CronConfigPresence;
+
+  constructor(cfg: CronRunProducerConfig = {}) {
+    this.journalUnitGlob = cfg.journalUnitGlob ?? "wisecron-*.service";
+    this.unitPrefix = cfg.unitPrefix ?? "wisecron-";
+    this.schemaVersion = cfg.schemaVersion ?? TELEMETRY_CONTRACT_VERSION;
+    this.journalRunner = cfg.journalRunner ?? defaultJournalRunner;
+    this.costDbPath = expandHome(cfg.costDbPath ?? join(homedir(), "agent", "data", "costs.db"));
+    this.cronConfigProbe = cfg.cronConfigProbe ?? defaultCronConfigProbe;
+  }
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  private readEntries(since: Date): CronRunEntry[] {
+    const args = [
+      "--user",
+      "-u",
+      this.journalUnitGlob,
+      "--since",
+      since.toISOString(),
+      "--output",
+      "json",
+    ];
+    let raw: string;
+    try {
+      raw = this.journalRunner(args);
+    } catch {
+      return [];
+    }
+    return parseCronRunJournal(raw);
+  }
+
+  /** Resolve the active source by probing each candidate in priority order. */
+  private detectKind(): CronSourceKind {
+    if (this.readEntries(new Date(Date.now() - 7 * 86_400_000)).length > 0) return "systemd";
+    if (busSchedulerRowCount(this.costDbPath) > 0) return "bus_scheduler";
+    return "none";
+  }
+
+  capabilities(): TelemetryCapability[] {
+    const kind = this.detectKind();
+    if (kind === "systemd") {
+      return [
+        {
+          stream: "cron_run",
+          schemaVersion: this.schemaVersion,
+          available: true,
+          reason: `source=systemd ('${this.journalUnitGlob}' journal, exit codes)`,
+        },
+      ];
+    }
+    if (kind === "bus_scheduler") {
+      return [
+        {
+          stream: "cron_run",
+          schemaVersion: this.schemaVersion,
+          available: true,
+          reason: `source=bus_scheduler (ClaudeClaw cron sessions in ${this.costDbPath}; completions only, no crash-failure signal)`,
+        },
+      ];
+    }
+    const cfg = this.cronConfigProbe();
+    const configured: string[] = [];
+    if (cfg.crontab) configured.push("crontab");
+    if (cfg.configSnapshot) configured.push("~/.config/cron");
+    const tail =
+      configured.length > 0
+        ? `${configured.join(" + ")} present but log no machine-readable run completions`
+        : `no '${this.journalUnitGlob}' units, no bus-scheduler sessions, no crontab`;
+    return [
+      {
+        stream: "cron_run",
+        schemaVersion: this.schemaVersion,
+        available: false,
+        reason: `no cron run-completion source — ${tail}`,
+      },
+    ];
+  }
+
+  async query(stream: TelemetryStream, range: DateRange): Promise<MetricSample[]> {
+    if (stream !== "cron_run") return [];
+    const kind = this.detectKind();
+    if (kind === "systemd") {
+      return this.readEntries(range.start)
+        .filter((e) => inRange(e.ts, range))
+        .map((e) => ({
+          ts: e.ts,
+          value: e.exitCode,
+          labels: {
+            unit: e.unit,
+            exit_code: String(e.exitCode),
+            status: e.exitCode === 0 ? "success" : "failure",
+            source: "systemd",
+          },
+        }));
+    }
+    if (kind === "bus_scheduler") {
+      return readBusSchedulerRuns(this.costDbPath, range);
+    }
+    return [];
+  }
+}
+
+/** Count cron-attributed sessions in costs.db (any date). 0 when absent/unreadable. */
+function busSchedulerRowCount(dbPath: string): number {
+  if (!existsSync(dbPath)) return 0;
+  let db: Database | null = null;
+  try {
+    db = new Database(dbPath, { readonly: true });
+    const r = db
+      .query(
+        `SELECT COUNT(*) AS n FROM session_costs
+         WHERE job LIKE '%source="cron"%' OR job LIKE '%bus-scheduler%' OR job LIKE 'cron%'`,
+      )
+      .get() as { n: number } | null;
+    return r ? r.n : 0;
+  } catch {
+    return 0;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** Each cron-attributed session = one completed fire (value 0). day-granular ts. */
+function readBusSchedulerRuns(dbPath: string, range: DateRange): MetricSample[] {
+  if (!existsSync(dbPath)) return [];
+  let db: Database | null = null;
+  try {
+    db = new Database(dbPath, { readonly: true });
+    const rows = db
+      .query(
+        `SELECT date, job FROM session_costs
+         WHERE (job LIKE '%source="cron"%' OR job LIKE '%bus-scheduler%' OR job LIKE 'cron%')
+           AND date >= ? AND date < ?
+         ORDER BY date ASC`,
+      )
+      .all(range.start.toISOString().slice(0, 10), range.end.toISOString().slice(0, 10)) as Array<{
+      date: string;
+      job: string;
+    }>;
+    return rows.map((r) => ({
+      ts: new Date(`${r.date}T00:00:00.000Z`),
+      value: 0, // a recorded session is a completed fire; no exit code in costs.db
+      labels: {
+        unit: busSchedulerUnit(r.job),
+        exit_code: "0",
+        status: "success",
+        source: "bus_scheduler",
+      },
+    }));
+  } catch {
+    return [];
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** Pull the `chat_id="bus-scheduler:<id>"` out of a job string, else "bus-scheduler". */
+function busSchedulerUnit(job: string): string {
+  const m = job.match(/chat_id="(bus-scheduler:[^"]+)"/);
+  return m ? m[1]! : "bus-scheduler";
+}
+
+/** Default cron-config presence probe: `crontab -l` + `~/.config/cron`. */
+function defaultCronConfigProbe(): CronConfigPresence {
+  let crontab = false;
+  try {
+    const res = spawnSync("crontab", ["-l"], { encoding: "utf8", timeout: 5_000 });
+    crontab =
+      res.status === 0 &&
+      (res.stdout ?? "").split("\n").some((l) => l.trim() && !l.trim().startsWith("#"));
+  } catch {
+    crontab = false;
+  }
+  const configSnapshot = existsSync(join(homedir(), ".config", "cron"));
+  return { crontab, configSnapshot };
+}
+
+function parseCronRunJournal(raw: string): CronRunEntry[] {
+  const out: CronRunEntry[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    // Only run-completion entries carry EXIT_STATUS.
+    const exitStatus = parsed.EXIT_STATUS;
+    let exitCode: number | null = null;
+    if (typeof exitStatus === "string") {
+      const n = parseInt(exitStatus, 10);
+      if (!Number.isNaN(n)) exitCode = n;
+    } else if (typeof exitStatus === "number") {
+      exitCode = exitStatus;
+    }
+    if (exitCode === null) continue;
+
+    const unit =
+      (parsed._SYSTEMD_USER_UNIT as string) ??
+      (parsed._SYSTEMD_UNIT as string) ??
+      (parsed.UNIT as string) ??
+      "";
+    if (!unit) continue;
+
+    const tsRaw = parsed.__REALTIME_TIMESTAMP as string | undefined;
+    let ts = new Date();
+    if (tsRaw) {
+      const usec = Number(tsRaw);
+      if (!Number.isNaN(usec)) ts = new Date(Math.floor(usec / 1000));
+    }
+    out.push({ unit, ts, exitCode });
+  }
+  return out;
+}
+
+function defaultJournalRunner(args: string[]): string {
+  const res = spawnSync("journalctl", args, { encoding: "utf8", timeout: 10_000 });
+  // journalctl exits 0 with "No data available" on stderr when the unit glob
+  // matches nothing; treat any no-output case as empty rather than throwing.
+  if (res.error) return "";
+  return res.stdout ?? "";
+}
+
+// ── hook_exec ────────────────────────────────────────────────────────────────
+
+export interface HookExecProducerConfig {
+  /** Hooks dir. Default ~/.claude/hooks. */
+  hooksDir?: string;
+  schemaVersion?: string;
+  /** Injected reader (dir → parsed entries). Tests pass a fixture. */
+  logReader?: (dir: string) => HookExecEntry[];
+}
+
+export interface HookExecEntry {
+  hook: string;
+  exitCode: number;
+  durationMs: number;
+  event: string;
+  ts: Date;
+}
+
+/** Canonical exec-logger sink written by `~/.claude/hooks/exec-log.sh`. */
+const HOOK_EXEC_LOG_FILE = "exec-log.jsonl";
+
+/**
+ * Emits `hook_exec` from the hooks dir (one JSON object per line:
+ * `{ hook?, exit_code, duration_ms, event?, ts }`). value = duration_ms;
+ * exit_code + event ride in labels so a consumer can derive crash-rate and p95.
+ *
+ * Source files, in order: the canonical `exec-log.jsonl` written by the
+ * `exec-log.sh` wrapper (the instrumentation this stream ships with), plus any
+ * legacy per-hook `*.log` files using the same line shape. The wrapper is the
+ * producer of record; `*.log` support is kept for hosts with an older logging
+ * convention.
+ */
+export class HookExecTelemetryProducer implements TelemetryProvider {
+  private readonly hooksDir: string;
+  private readonly schemaVersion: string;
+  private readonly logReader: (dir: string) => HookExecEntry[];
+
+  constructor(cfg: HookExecProducerConfig = {}) {
+    this.hooksDir = expandHome(cfg.hooksDir ?? join(homedir(), ".claude", "hooks"));
+    this.schemaVersion = cfg.schemaVersion ?? TELEMETRY_CONTRACT_VERSION;
+    this.logReader = cfg.logReader ?? defaultHookLogReader;
+  }
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  capabilities(): TelemetryCapability[] {
+    let entries: HookExecEntry[];
+    try {
+      entries = this.logReader(this.hooksDir);
+    } catch {
+      entries = [];
+    }
+    if (entries.length === 0) {
+      return [
+        {
+          stream: "hook_exec",
+          schemaVersion: this.schemaVersion,
+          available: false,
+          reason: `no parseable ${HOOK_EXEC_LOG_FILE}/*.log entries in ${this.hooksDir} (exec-log.sh wrapper not wired into any hook yet)`,
+        },
+      ];
+    }
+    return [{ stream: "hook_exec", schemaVersion: this.schemaVersion, available: true }];
+  }
+
+  async query(stream: TelemetryStream, range: DateRange): Promise<MetricSample[]> {
+    if (stream !== "hook_exec") return [];
+    let entries: HookExecEntry[];
+    try {
+      entries = this.logReader(this.hooksDir);
+    } catch {
+      return [];
+    }
+    return entries
+      .filter((e) => inRange(e.ts, range))
+      .map((e) => ({
+        ts: e.ts,
+        value: e.durationMs,
+        labels: { hook: e.hook, exit_code: String(e.exitCode), event: e.event },
+      }));
+  }
+}
+
+function defaultHookLogReader(dir: string): HookExecEntry[] {
+  if (!existsSync(dir)) return [];
+  let files: string[];
+  try {
+    // Canonical exec-logger sink (.jsonl) + legacy per-hook *.log files.
+    files = readdirSync(dir).filter((f) => f === HOOK_EXEC_LOG_FILE || f.endsWith(".log"));
+  } catch {
+    return [];
+  }
+  const out: HookExecEntry[] = [];
+  for (const f of files) {
+    let content: string;
+    try {
+      content = readFileSync(join(dir, f), "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed) as Record<string, unknown>;
+        if (typeof obj !== "object" || obj === null) continue;
+        const hook = (obj.hook as string) ?? f.replace(/\.log$/, "");
+        const exitCode = Number(obj.exit_code ?? 0);
+        const durationMs = Number(obj.duration_ms ?? 0);
+        const event = (obj.event as string) ?? "unknown";
+        const tsRaw = obj.ts as string | number | undefined;
+        const ts = tsRaw ? new Date(tsRaw) : new Date();
+        if (Number.isNaN(ts.getTime())) continue;
+        out.push({ hook, exitCode, durationMs, event, ts });
+      } catch {
+        /* skip malformed line */
+      }
+    }
+  }
+  return out;
+}
+
+// ── skill_access ───────────────────────────────────────────────────────────--
+
+export interface SkillAccessProducerConfig {
+  /** JSONL log. Default ~/.config/tuner/skill_accesses.jsonl. */
+  accessLog?: string;
+  schemaVersion?: string;
+}
+
+/**
+ * Emits `skill_access` from `~/.config/tuner/skill_accesses.jsonl`
+ * (`{ skill_path, accessed_at }` per line). value = 1 per access; the skill
+ * name (file basename, minus `.md`) rides in labels for per-skill grouping.
+ */
+export class SkillAccessTelemetryProducer implements TelemetryProvider {
+  private readonly accessLog: string;
+  private readonly schemaVersion: string;
+
+  constructor(cfg: SkillAccessProducerConfig = {}) {
+    this.accessLog = expandHome(
+      cfg.accessLog ?? join(homedir(), ".config", "tuner", "skill_accesses.jsonl"),
+    );
+    this.schemaVersion = cfg.schemaVersion ?? TELEMETRY_CONTRACT_VERSION;
+  }
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  private read(): Array<{ ts: Date; skill: string }> {
+    if (!existsSync(this.accessLog)) return [];
+    let content: string;
+    try {
+      content = readFileSync(this.accessLog, "utf8");
+    } catch {
+      return [];
+    }
+    const out: Array<{ ts: Date; skill: string }> = [];
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed) as Record<string, unknown>;
+        const path = obj.skill_path as string | undefined;
+        const at = obj.accessed_at as string | undefined;
+        if (!path || !at) continue;
+        const ts = new Date(at);
+        if (Number.isNaN(ts.getTime())) continue;
+        out.push({ ts, skill: basename(path, ".md") });
+      } catch {
+        /* skip */
+      }
+    }
+    return out;
+  }
+
+  capabilities(): TelemetryCapability[] {
+    if (this.read().length === 0) {
+      return [
+        {
+          stream: "skill_access",
+          schemaVersion: this.schemaVersion,
+          available: false,
+          reason: `no skill-access entries at ${this.accessLog}`,
+        },
+      ];
+    }
+    return [{ stream: "skill_access", schemaVersion: this.schemaVersion, available: true }];
+  }
+
+  async query(stream: TelemetryStream, range: DateRange): Promise<MetricSample[]> {
+    if (stream !== "skill_access") return [];
+    return this.read()
+      .filter((e) => inRange(e.ts, range))
+      .map((e) => ({ ts: e.ts, value: 1, labels: { skill: e.skill } }));
+  }
+}
+
+// ── operations.jsonl-derived streams ─────────────────────────────────────────
+
+export interface JournalProducerConfig {
+  /** Operations journal. Default ~/.claudeclaw/journal/operations.jsonl. */
+  journalPath?: string;
+  schemaVersion?: string;
+}
+
+/** Streams this producer can derive from the operations journal, by type match. */
+const JOURNAL_STREAMS: TelemetryStream[] = [
+  "tool_call",
+  "mode_dispatch",
+  "agent_dispatch",
+  "memory_access",
+];
+
+/**
+ * Derives the dispatch/tool/memory streams from `operations.jsonl` IF the
+ * journal carries matching event types. The reference journal records coarse
+ * operation entries (deploy, infra_fix, …) and emits none of these today, so
+ * each advertises `available:false` with a reason — declared + inactive by
+ * design. Activates automatically the day the host journals matching events.
+ */
+export class JournalTelemetryProducer implements TelemetryProvider {
+  private readonly journalPath: string;
+  private readonly schemaVersion: string;
+
+  constructor(cfg: JournalProducerConfig = {}) {
+    this.journalPath = expandHome(
+      cfg.journalPath ?? join(homedir(), ".claudeclaw", "journal", "operations.jsonl"),
+    );
+    this.schemaVersion = cfg.schemaVersion ?? TELEMETRY_CONTRACT_VERSION;
+  }
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  private readAll(): Array<Record<string, unknown>> {
+    if (!existsSync(this.journalPath)) return [];
+    let content: string;
+    try {
+      content = readFileSync(this.journalPath, "utf8");
+    } catch {
+      return [];
+    }
+    const out: Array<Record<string, unknown>> = [];
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed);
+        if (typeof obj === "object" && obj !== null) out.push(obj as Record<string, unknown>);
+      } catch {
+        /* skip */
+      }
+    }
+    return out;
+  }
+
+  /** Map one journal entry to a sample for `stream`, or null if it doesn't match. */
+  private toSample(stream: TelemetryStream, e: Record<string, unknown>): MetricSample | null {
+    const type = String(e.type ?? "");
+    const tsRaw = e.ts as string | number | undefined;
+    const ts = tsRaw ? new Date(tsRaw) : new Date();
+    if (Number.isNaN(ts.getTime())) return null;
+    const truthy = (v: unknown) => v === true;
+
+    switch (stream) {
+      case "tool_call": {
+        if (type !== "tool_call" && type !== "mcp_tool_call" && e.tool === undefined) return null;
+        const failed = e.success === false || e.ok === false || truthy(e.blocked);
+        return {
+          ts,
+          value: failed ? 1 : 0,
+          labels: {
+            server: String(e.server ?? ""),
+            tool: String(e.tool ?? ""),
+            blocked: String(truthy(e.blocked)),
+          },
+        };
+      }
+      case "mode_dispatch": {
+        if (type !== "mode_dispatch" && type !== "mode_dispatched") return null;
+        return {
+          ts,
+          value: truthy(e.reclassified) ? 1 : 0,
+          labels: {
+            mode: String(e.mode ?? ""),
+            keyword: String(e.keyword ?? ""),
+            task_class: String(e.task_class ?? ""),
+          },
+        };
+      }
+      case "agent_dispatch": {
+        if (type !== "agent_dispatch" && type !== "agent_dispatched") return null;
+        return {
+          ts,
+          value: truthy(e.reclassified) ? 1 : 0,
+          labels: { agent: String(e.agent ?? e.agent_name ?? "") },
+        };
+      }
+      case "memory_access": {
+        if (type !== "memory_access" && type !== "memory_read") return null;
+        return { ts, value: 1, labels: { file: String(e.file ?? e.path ?? "") } };
+      }
+      default:
+        return null;
+    }
+  }
+
+  capabilities(): TelemetryCapability[] {
+    const all = this.readAll();
+    return JOURNAL_STREAMS.map((stream) => {
+      const has = all.some((e) => this.toSample(stream, e) !== null);
+      if (has) return { stream, schemaVersion: this.schemaVersion, available: true };
+      return {
+        stream,
+        schemaVersion: this.schemaVersion,
+        available: false,
+        reason: existsSync(this.journalPath)
+          ? `no '${stream}' events in ${this.journalPath}`
+          : `operations journal not found at ${this.journalPath}`,
+      };
+    });
+  }
+
+  async query(stream: TelemetryStream, range: DateRange): Promise<MetricSample[]> {
+    if (!JOURNAL_STREAMS.includes(stream)) return [];
+    const out: MetricSample[] = [];
+    for (const e of this.readAll()) {
+      const s = this.toSample(stream, e);
+      if (s && inRange(s.ts, range)) out.push(s);
+    }
+    return out;
+  }
+}
+
+// ── mode_dispatch ────────────────────────────────────────────────────────────
+
+export interface ModeDispatchProducerConfig {
+  /** Dispatch journal. Default ~/.claudeclaw/journal/mode_dispatch.jsonl. */
+  journalPath?: string;
+  schemaVersion?: string;
+}
+
+interface ModeDispatchEntry {
+  ts: Date;
+  mode: string;
+  matchedKeyword: string;
+  reclassified: boolean;
+}
+
+/**
+ * Emits `mode_dispatch` from the dedicated dispatch journal written by the
+ * daemon's `recordModeDispatch` (`src/governance/mode-dispatch-journal.ts`) —
+ * one `{ ts, mode, matched_keyword, reclassified }` line per agentic-mode route.
+ * value = `reclassified ? 1 : 0`, matching ModelRoutingSubject's
+ * `routing_reclassify_rate = nonzeroRate`; mode + matched_keyword ride in labels.
+ *
+ * Inactive-with-reason until the daemon writes its first dispatch (no faked
+ * data). `JournalTelemetryProducer` still advertises mode_dispatch off the
+ * coarse operations journal as a forward-compat fallback, but the live source is
+ * disjoint (this dedicated file), so the composite never double-counts.
+ */
+export class ModeDispatchTelemetryProducer implements TelemetryProvider {
+  private readonly journalPath: string;
+  private readonly schemaVersion: string;
+
+  constructor(cfg: ModeDispatchProducerConfig = {}) {
+    this.journalPath = expandHome(cfg.journalPath ?? DEFAULT_MODE_DISPATCH_LOG);
+    this.schemaVersion = cfg.schemaVersion ?? TELEMETRY_CONTRACT_VERSION;
+  }
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  private read(): ModeDispatchEntry[] {
+    if (!existsSync(this.journalPath)) return [];
+    let content: string;
+    try {
+      content = readFileSync(this.journalPath, "utf8");
+    } catch {
+      return [];
+    }
+    const out: ModeDispatchEntry[] = [];
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed) as Record<string, unknown>;
+        if (typeof obj !== "object" || obj === null) continue;
+        const tsRaw = obj.ts as string | number | undefined;
+        const ts = tsRaw ? new Date(tsRaw) : new Date();
+        if (Number.isNaN(ts.getTime())) continue;
+        out.push({
+          ts,
+          mode: String(obj.mode ?? ""),
+          matchedKeyword: String(obj.matched_keyword ?? ""),
+          reclassified: obj.reclassified === true,
+        });
+      } catch {
+        /* skip malformed line */
+      }
+    }
+    return out;
+  }
+
+  capabilities(): TelemetryCapability[] {
+    if (this.read().length === 0) {
+      return [
+        {
+          stream: "mode_dispatch",
+          schemaVersion: this.schemaVersion,
+          available: false,
+          reason: existsSync(this.journalPath)
+            ? `no dispatch records in ${this.journalPath}`
+            : `dispatch journal not found at ${this.journalPath} (no agentic-mode route emitted yet)`,
+        },
+      ];
+    }
+    return [{ stream: "mode_dispatch", schemaVersion: this.schemaVersion, available: true }];
+  }
+
+  async query(stream: TelemetryStream, range: DateRange): Promise<MetricSample[]> {
+    if (stream !== "mode_dispatch") return [];
+    return this.read()
+      .filter((e) => inRange(e.ts, range))
+      .map((e) => ({
+        ts: e.ts,
+        value: e.reclassified ? 1 : 0,
+        labels: { mode: e.mode, matched_keyword: e.matchedKeyword },
+      }));
+  }
+}
+
+// ── template_feedback ────────────────────────────────────────────────────────
+
+export interface TemplateFeedbackProducerConfig {
+  /** Feedback log. Default ~/.config/tuner/template_feedback.jsonl. */
+  feedbackLog?: string;
+  schemaVersion?: string;
+}
+
+interface TemplateFeedbackEntry {
+  ts: Date;
+  templateId: string;
+  rating: number;
+  verdict: string;
+}
+
+/**
+ * Emits `template_feedback` from `~/.config/tuner/template_feedback.jsonl`
+ * (written by `tuner rate-template`). value = rating (1..5); template_id +
+ * verdict ride in labels. Matches PromptTemplateSubject's
+ * `template_avg_rating = median(values)` (higher_is_better).
+ *
+ * Starts inactive-with-reason (the log doesn't exist until the first rating) and
+ * activates on first `rate-template` — empty is correct, not faked.
+ */
+export class TemplateFeedbackTelemetryProducer implements TelemetryProvider {
+  private readonly feedbackLog: string;
+  private readonly schemaVersion: string;
+
+  constructor(cfg: TemplateFeedbackProducerConfig = {}) {
+    this.feedbackLog = expandHome(cfg.feedbackLog ?? DEFAULT_TEMPLATE_FEEDBACK_LOG);
+    this.schemaVersion = cfg.schemaVersion ?? TELEMETRY_CONTRACT_VERSION;
+  }
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  private read(): TemplateFeedbackEntry[] {
+    if (!existsSync(this.feedbackLog)) return [];
+    let content: string;
+    try {
+      content = readFileSync(this.feedbackLog, "utf8");
+    } catch {
+      return [];
+    }
+    const out: TemplateFeedbackEntry[] = [];
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed) as Record<string, unknown>;
+        if (typeof obj !== "object" || obj === null) continue;
+        const templateId = String(obj.template_id ?? "");
+        if (!templateId) continue;
+        const rating = Number(obj.rating);
+        if (Number.isNaN(rating)) continue;
+        const tsRaw = obj.ts as string | number | undefined;
+        const ts = tsRaw ? new Date(tsRaw) : new Date();
+        if (Number.isNaN(ts.getTime())) continue;
+        out.push({ ts, templateId, rating, verdict: String(obj.verdict ?? "") });
+      } catch {
+        /* skip malformed line */
+      }
+    }
+    return out;
+  }
+
+  capabilities(): TelemetryCapability[] {
+    if (this.read().length === 0) {
+      return [
+        {
+          stream: "template_feedback",
+          schemaVersion: this.schemaVersion,
+          available: false,
+          reason: existsSync(this.feedbackLog)
+            ? `no ratings in ${this.feedbackLog}`
+            : `no ratings yet at ${this.feedbackLog} (run 'tuner rate-template <id> <yes|yes-but|no>')`,
+        },
+      ];
+    }
+    return [{ stream: "template_feedback", schemaVersion: this.schemaVersion, available: true }];
+  }
+
+  async query(stream: TelemetryStream, range: DateRange): Promise<MetricSample[]> {
+    if (stream !== "template_feedback") return [];
+    return this.read()
+      .filter((e) => inRange(e.ts, range))
+      .map((e) => ({
+        ts: e.ts,
+        value: e.rating,
+        labels: { template_id: e.templateId, verdict: e.verdict },
+      }));
+  }
+}
+
+// ── composite ────────────────────────────────────────────────────────────────
+
+/**
+ * Composes per-stream producers into one `TelemetryProvider`. `query` simply
+ * concatenates (each producer returns `[]` for streams it doesn't own).
+ * `capabilities` resolves to one entry per contract stream, preferring an
+ * available producer; streams no producer claims are reported unavailable.
+ *
+ * Provider order matters for the unavailable-reason chosen: list the specific
+ * producers BEFORE the cost provider (which reports every non-cost stream with
+ * a generic placeholder reason) so the specific reason wins.
+ */
+export class CompositeTelemetryProvider implements TelemetryProvider, ViewManifestSource {
+  constructor(private readonly providers: TelemetryProvider[]) {}
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  capabilities(): TelemetryCapability[] {
+    const caps: TelemetryCapability[] = [];
+    for (const p of this.providers) caps.push(...p.capabilities());
+    const best = new Map<TelemetryStream, TelemetryCapability>();
+    for (const c of caps) {
+      const cur = best.get(c.stream);
+      // First writer wins; an available producer upgrades a prior unavailable.
+      if (!cur) best.set(c.stream, c);
+      else if (!cur.available && c.available) best.set(c.stream, c);
+    }
+    for (const s of TELEMETRY_STREAMS) {
+      if (!best.has(s)) {
+        best.set(s, {
+          stream: s,
+          schemaVersion: TELEMETRY_CONTRACT_VERSION,
+          available: false,
+          reason: "no producer wired for this stream",
+        });
+      }
+    }
+    return [...best.values()];
+  }
+
+  async query(
+    stream: TelemetryStream,
+    range: DateRange,
+    filters?: Record<string, string>,
+  ): Promise<MetricSample[]> {
+    const out: MetricSample[] = [];
+    for (const p of this.providers) {
+      out.push(...(await p.query(stream, range, filters)));
+    }
+    return out;
+  }
+
+  // ── ViewManifestSource ────────────────────────────────────────────────────
+  // Collect every plugin-declared page; dispatch a panel fill to the provider
+  // that declared it. Plugins without a manifest contribute nothing here — they
+  // get the universal page only.
+
+  viewManifests(): ViewManifest[] {
+    const out: ViewManifest[] = [];
+    for (const p of this.providers) {
+      const m = p.viewManifest?.();
+      if (m) out.push(m);
+    }
+    return out;
+  }
+
+  async panelData(
+    plugin: string,
+    panelId: string,
+    range: DateRange,
+  ): Promise<PanelData | undefined> {
+    for (const p of this.providers) {
+      if (p.viewManifest?.()?.plugin !== plugin) continue;
+      const d = await p.viewData?.(panelId, range);
+      if (d) return d;
+    }
+    return undefined;
+  }
+}
+
+export interface HostTelemetryConfig {
+  costDbPath?: string;
+  hooksDir?: string;
+  skillAccessLog?: string;
+  journalPath?: string;
+  /** Dedicated mode_dispatch journal. Default ~/.claudeclaw/journal/mode_dispatch.jsonl. */
+  modeDispatchLog?: string;
+  /** Template-rating log. Default ~/.config/tuner/template_feedback.jsonl. */
+  templateFeedbackLog?: string;
+  cronJournalRunner?: (args: string[]) => string;
+  /** Session-transcript root for the universal producer. Default `~/.claude/projects`. */
+  sessionProjectsDir?: string;
+  /** Hermeticity escape hatch (tests): override the cron-config presence probe. */
+  cronConfigProbe?: () => CronConfigPresence;
+  /**
+   * Phase A observability hub: path to the gateway's `mcp.tool_call` audit log.
+   * When set, the universal MCP boundary stream becomes queryable; when absent
+   * the composite advertises it unavailable (no producer wired).
+   */
+  mcpToolCallLog?: string;
+  /**
+   * Phase A observability hub: when set, the tuner declares its view-manifest
+   * (the proposals→outcomes timeline). When absent, the tuner contributes no
+   * specialized page and falls back to the universal page like any plugin.
+   */
+  tunerView?: TunerViewSources;
+}
+
+/**
+ * The reference-host telemetry surface: every feasible producer composed into
+ * one provider. Pass into `registerWisecronSubjects(registry, settings,
+ * { telemetry })` so the activation gate runs and subjects measure fitness.
+ *
+ * `SessionJsonlTelemetryProducer` is the UNIVERSAL source for the dispatch/tool/
+ * memory streams (real, abundant data on any Claude Code host). It is listed
+ * before `JournalTelemetryProducer` so its available capabilities win the
+ * per-stream merge; the journal producer stays wired only as a forward-compat
+ * fallback for the day `operations.jsonl` carries matching events (it returns
+ * `[]` for these streams on the reference host, so no double-counting).
+ * `CronRunTelemetryProducer` auto-detects its source (systemd → bus-scheduler →
+ * none) from `costDbPath`, so a host with no wisecron units still lights up.
+ *
+ * `ModeDispatchTelemetryProducer` owns `mode_dispatch` off the dedicated dispatch
+ * journal the daemon writes (`recordModeDispatch`); it is listed before the
+ * journal producer so its capability wins the merge. The two sources are
+ * disjoint (dedicated file vs operations-journal event type), so the composite
+ * never double-counts that stream either.
+ */
+export function buildHostTelemetryProvider(
+  cfg: HostTelemetryConfig = {},
+): CompositeTelemetryProvider {
+  const providers: TelemetryProvider[] = [
+    new CronRunTelemetryProducer({
+      journalRunner: cfg.cronJournalRunner,
+      costDbPath: cfg.costDbPath,
+      cronConfigProbe: cfg.cronConfigProbe,
+    }),
+    new HookExecTelemetryProducer({ hooksDir: cfg.hooksDir }),
+    new SkillAccessTelemetryProducer({ accessLog: cfg.skillAccessLog }),
+    new ModeDispatchTelemetryProducer({ journalPath: cfg.modeDispatchLog }),
+    new TemplateFeedbackTelemetryProducer({ feedbackLog: cfg.templateFeedbackLog }),
+    new SessionJsonlTelemetryProducer({ projectsDir: cfg.sessionProjectsDir }),
+    new JournalTelemetryProducer({ journalPath: cfg.journalPath }),
+    new SessionCostTelemetryProvider({ dbPath: cfg.costDbPath }),
+  ];
+  // Phase A: universal MCP boundary stream — wired only when the gateway log is
+  // configured, so existing capability tests (every stream unavailable on an
+  // empty host) stay deterministic and machine-state-independent.
+  if (cfg.mcpToolCallLog) {
+    providers.push(new McpToolCallTelemetryProducer({ logPath: cfg.mcpToolCallLog }));
+  }
+  // Phase A: the tuner declares its own page (proposals→outcomes timeline).
+  if (cfg.tunerView) {
+    providers.push(new TunerViewProvider(cfg.tunerView));
+  }
+  return new CompositeTelemetryProvider(providers);
+}

--- a/src/tuner/wisecron/line-reader.ts
+++ b/src/tuner/wisecron/line-reader.ts
@@ -1,0 +1,80 @@
+/**
+ * Bounded, synchronous, line-at-a-time file reader for the host telemetry
+ * producers.
+ *
+ * WHY NOT `readFileSync`: the telemetry producers run on the cold `capabilities()`
+ * path, which is SYNCHRONOUS by contract (the activation gate calls it sync), and
+ * on low-spec (4GB) hosts. Slurping a whole transcript / journal into one string
+ * (then a second array of parsed objects) can be tens of MB and stall the event
+ * loop or OOM. This reader instead:
+ *
+ *   - reads the file in fixed 64KB chunks with `readSync` (stays synchronous, so
+ *     it drops straight into the existing sync `scanFile`/`readAll` call sites);
+ *   - decodes only COMPLETE lines (splits on the `\n` byte and keeps the tail as
+ *     a Buffer), so a multibyte UTF-8 char that straddles a chunk boundary is
+ *     never corrupted — behaviour is identical to a whole-file read for
+ *     normal-size inputs;
+ *   - holds at most one chunk + one pending line in memory, never the whole file;
+ *   - CAPS at `maxBytes` (default 64MB): past the cap it stops reading rather than
+ *     growing without bound, and reports it via `onTruncate` so the limit is never
+ *     silent.
+ */
+
+import { closeSync, openSync, readSync } from "node:fs";
+
+const CHUNK_BYTES = 64 * 1024;
+/** Default per-file byte cap. A single transcript this large is pathological;
+ *  cap it rather than risk OOM on a 4GB box. */
+export const DEFAULT_MAX_FILE_BYTES = 64 * 1024 * 1024;
+const NEWLINE = 0x0a;
+
+export interface ForEachLineOpts {
+  /** Stop after this many bytes; the rest of the file is skipped. */
+  maxBytes?: number;
+  /** Called once (with the byte count read so far) when `maxBytes` truncates the
+   *  read, so the cap is observable instead of a silent partial scan. */
+  onTruncate?: (bytesRead: number) => void;
+}
+
+/**
+ * Invoke `onLine` for every newline-terminated line in `file`, plus a final
+ * unterminated tail if present. Synchronous. Never holds more than one chunk +
+ * one partial line. Throws on open/read failure — callers already wrap these in
+ * try/catch to tolerate one bad file.
+ */
+export function forEachLineSync(
+  file: string,
+  onLine: (line: string) => void,
+  opts: ForEachLineOpts = {},
+): void {
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_FILE_BYTES;
+  const fd = openSync(file, "r");
+  try {
+    const chunk = Buffer.allocUnsafe(CHUNK_BYTES);
+    let pending = Buffer.alloc(0);
+    let total = 0;
+    let truncated = false;
+    for (;;) {
+      const bytes = readSync(fd, chunk, 0, CHUNK_BYTES, null);
+      if (bytes <= 0) break;
+      total += bytes;
+      pending = Buffer.concat([pending, chunk.subarray(0, bytes)]);
+      let nl = pending.indexOf(NEWLINE);
+      while (nl !== -1) {
+        onLine(pending.toString("utf8", 0, nl));
+        pending = pending.subarray(nl + 1);
+        nl = pending.indexOf(NEWLINE);
+      }
+      if (total >= maxBytes) {
+        truncated = true;
+        break;
+      }
+    }
+    // Emit a final unterminated line only for a fully-read file; a truncated read
+    // may have stopped mid-line, so its tail is dropped rather than mis-parsed.
+    if (!truncated && pending.length > 0) onLine(pending.toString("utf8"));
+    if (truncated) opts.onTruncate?.(total);
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/src/tuner/wisecron/memory-signal-provider.ts
+++ b/src/tuner/wisecron/memory-signal-provider.ts
@@ -34,7 +34,8 @@ export class MemorySignalProducer implements TelemetryProvider {
   private readonly historyPath: string;
 
   constructor(cfg: { historyPath?: string } = {}) {
-    this.historyPath = cfg.historyPath ?? join(homedir(), ".config", "tuner", "memory-signal-history.jsonl");
+    this.historyPath =
+      cfg.historyPath ?? join(homedir(), ".config", "tuner", "memory-signal-history.jsonl");
   }
 
   contractVersion(): string {
@@ -58,7 +59,8 @@ export class MemorySignalProducer implements TelemetryProvider {
 
   capabilities(): TelemetryCapability[] {
     const has = this.readSamples().length > 0;
-    if (has) return [{ stream: STREAM, schemaVersion: TELEMETRY_CONTRACT_VERSION, available: true }];
+    if (has)
+      return [{ stream: STREAM, schemaVersion: TELEMETRY_CONTRACT_VERSION, available: true }];
     return [
       {
         stream: STREAM,
@@ -71,11 +73,21 @@ export class MemorySignalProducer implements TelemetryProvider {
     ];
   }
 
-  async query(stream: TelemetryStream, range: DateRange, filters?: Record<string, string>): Promise<MetricSample[]> {
+  async query(
+    stream: TelemetryStream,
+    range: DateRange,
+    filters?: Record<string, string>,
+  ): Promise<MetricSample[]> {
     if (stream !== STREAM) return [];
     const metric = filters?.metric ?? "loadMs";
     const pick = (s: RawSample): number =>
-      metric === "bytes" ? s.bytes : metric === "entries" ? s.entries : metric === "dead_ratio" ? s.deadRatio : s.loadMs;
+      metric === "bytes"
+        ? s.bytes
+        : metric === "entries"
+          ? s.entries
+          : metric === "dead_ratio"
+            ? s.deadRatio
+            : s.loadMs;
     const out: MetricSample[] = [];
     for (const s of this.readSamples()) {
       const ts = new Date(s.ts);

--- a/src/tuner/wisecron/memory-signal-provider.ts
+++ b/src/tuner/wisecron/memory-signal-provider.ts
@@ -1,0 +1,97 @@
+/**
+ * MemorySignalProducer — exposes the memory degradation signal (load latency /
+ * size / dead-entry ratio) on the host telemetry surface as the `memory_signal`
+ * stream, so it is queryable via `telemetry__query` alongside the other streams
+ * (and visible in the observability UI). Reads the sampler history written by
+ * `memory-signal.ts` (a local, tuner-side measurement — no web, no LLM).
+ *
+ * `value` defaults to load latency (ms); pass `filters.metric = bytes | entries |
+ * dead_ratio` to series a different dimension. Labels always carry all dimensions.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  type TelemetryProvider,
+  type TelemetryCapability,
+  type TelemetryStream,
+  type MetricSample,
+  type DateRange,
+  TELEMETRY_CONTRACT_VERSION,
+} from "../../skills-tuner/core/telemetry.js";
+
+const STREAM: TelemetryStream = "memory_signal";
+
+interface RawSample {
+  ts: string;
+  bytes: number;
+  entries: number;
+  deadRatio: number;
+  loadMs: number;
+}
+
+export class MemorySignalProducer implements TelemetryProvider {
+  private readonly historyPath: string;
+
+  constructor(cfg: { historyPath?: string } = {}) {
+    this.historyPath = cfg.historyPath ?? join(homedir(), ".config", "tuner", "memory-signal-history.jsonl");
+  }
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  private readSamples(): RawSample[] {
+    if (!existsSync(this.historyPath)) return [];
+    const out: RawSample[] = [];
+    for (const line of readFileSync(this.historyPath, "utf8").split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const s = JSON.parse(line) as RawSample;
+        if (typeof s.ts === "string" && typeof s.loadMs === "number") out.push(s);
+      } catch {
+        /* skip corrupt line */
+      }
+    }
+    return out;
+  }
+
+  capabilities(): TelemetryCapability[] {
+    const has = this.readSamples().length > 0;
+    if (has) return [{ stream: STREAM, schemaVersion: TELEMETRY_CONTRACT_VERSION, available: true }];
+    return [
+      {
+        stream: STREAM,
+        schemaVersion: TELEMETRY_CONTRACT_VERSION,
+        available: false,
+        reason: existsSync(this.historyPath)
+          ? "memory-signal history is empty (sampler has not recorded yet)"
+          : `memory-signal history not found at ${this.historyPath}`,
+      },
+    ];
+  }
+
+  async query(stream: TelemetryStream, range: DateRange, filters?: Record<string, string>): Promise<MetricSample[]> {
+    if (stream !== STREAM) return [];
+    const metric = filters?.metric ?? "loadMs";
+    const pick = (s: RawSample): number =>
+      metric === "bytes" ? s.bytes : metric === "entries" ? s.entries : metric === "dead_ratio" ? s.deadRatio : s.loadMs;
+    const out: MetricSample[] = [];
+    for (const s of this.readSamples()) {
+      const ts = new Date(s.ts);
+      if (Number.isNaN(ts.getTime()) || ts < range.start || ts >= range.end) continue;
+      out.push({
+        ts,
+        value: pick(s),
+        labels: {
+          metric,
+          bytes: String(s.bytes),
+          entries: String(s.entries),
+          dead_ratio: String(s.deadRatio),
+          load_ms: String(s.loadMs),
+        },
+      });
+    }
+    return out;
+  }
+}

--- a/src/tuner/wisecron/session-cost-provider.ts
+++ b/src/tuner/wisecron/session-cost-provider.ts
@@ -1,0 +1,211 @@
+/**
+ * Reference `session_cost` TelemetryProvider (OutcomeLoop Phase 1).
+ *
+ * This is a HOST-side adapter, not tuner core: it owns telemetry PRODUCTION +
+ * provenance for ONE stream (`session_cost`) by reading a per-session cost
+ * store. Subjects never see this file — they call `provider.query(...)`. The
+ * tuner core stays source-agnostic; swapping the cost store (or shipping a
+ * different host) means swapping this adapter, nothing else.
+ *
+ * Source of truth (reference deployment): a SQLite `session_costs` table with
+ * columns `date, job, model, cost_usd, *_tokens`. One row per Claude session.
+ *   - `value`  ← `cost_usd` (USD spent in the session)
+ *   - `ts`     ← `date` (day-granular; see ATTRIBUTION NOTE below)
+ *   - `labels` ← `{ job, model }`
+ *
+ * Capability detection: `session_cost` is advertised `available:true` only when
+ * the store exists AND holds rows; otherwise `available:false` with a reason,
+ * so the activation gate degrades the dependent fitness to proposal-only. Every
+ * other contract stream is advertised `available:false` (no producer in this
+ * reference host) — a customer host implements its own provider for those.
+ *
+ * ATTRIBUTION NOTE (imperfect, flagged): `job` is free-text — sometimes a clean
+ * tag (`bootstrap`, `gmail`), often a raw prompt prefix (`<channel source="cron"
+ * …>`, `Tu es l'agent …`). Exact-match label filtering is therefore brittle;
+ * subjects that need a subset (e.g. cron-origin sessions) should query broadly
+ * and post-filter on `labels.job`. And `date` is day-granular, so a window edge
+ * is rounded to the day. Both are properties of the store, not the contract.
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import {
+  type DateRange,
+  type MetricSample,
+  type TelemetryCapability,
+  type TelemetryProvider,
+  type TelemetryStream,
+  TELEMETRY_CONTRACT_VERSION,
+  TELEMETRY_STREAMS,
+} from "../../skills-tuner/core/telemetry.js";
+
+export interface SessionCostProviderConfig {
+  /** Path to the cost SQLite store. Default `~/agent/data/costs.db`. */
+  dbPath?: string;
+  /** Schema version advertised for the `session_cost` stream. */
+  schemaVersion?: string;
+}
+
+interface CostRow {
+  date: string;
+  job: string;
+  model: string;
+  cost_usd: number;
+}
+
+/** `YYYY-MM-DD` in UTC — matches the store's day-granular `date` column. */
+function toDay(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export class SessionCostTelemetryProvider implements TelemetryProvider {
+  private readonly dbPath: string;
+  private readonly schemaVersion: string;
+  /** Lazily opened, cached, read-only handle; null once we know it's absent. */
+  private db: Database | null = null;
+  private opened = false;
+
+  constructor(cfg: SessionCostProviderConfig = {}) {
+    this.dbPath = (cfg.dbPath ?? `${homedir()}/agent/data/costs.db`).replace(/^~/, homedir());
+    this.schemaVersion = cfg.schemaVersion ?? TELEMETRY_CONTRACT_VERSION;
+  }
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  /**
+   * Open (once) and return the read-only handle, or null if the store is
+   * missing/unopenable. Cached so capabilities() + query() share one probe.
+   */
+  private handle(): Database | null {
+    if (this.opened) return this.db;
+    this.opened = true;
+    if (!existsSync(this.dbPath)) {
+      this.db = null;
+      return null;
+    }
+    try {
+      this.db = new Database(this.dbPath, { readonly: true });
+    } catch {
+      this.db = null;
+    }
+    return this.db;
+  }
+
+  /** Row count in session_costs, or null if the table is absent/unreadable. */
+  private rowCount(db: Database): number | null {
+    try {
+      const r = db.query("SELECT COUNT(*) AS n FROM session_costs").get() as { n: number } | null;
+      return r ? r.n : 0;
+    } catch {
+      return null;
+    }
+  }
+
+  capabilities(): TelemetryCapability[] {
+    const db = this.handle();
+    let costCap: TelemetryCapability;
+    if (!db) {
+      costCap = {
+        stream: "session_cost",
+        schemaVersion: this.schemaVersion,
+        available: false,
+        reason: `cost store not found at ${this.dbPath}`,
+      };
+    } else {
+      const n = this.rowCount(db);
+      if (n === null) {
+        costCap = {
+          stream: "session_cost",
+          schemaVersion: this.schemaVersion,
+          available: false,
+          reason: "session_costs table missing or unreadable",
+        };
+      } else if (n === 0) {
+        costCap = {
+          stream: "session_cost",
+          schemaVersion: this.schemaVersion,
+          available: false,
+          reason: "session_costs table empty",
+        };
+      } else {
+        costCap = { stream: "session_cost", schemaVersion: this.schemaVersion, available: true };
+      }
+    }
+
+    // Every other contract stream: no producer in this reference host.
+    const others: TelemetryCapability[] = TELEMETRY_STREAMS.filter((s) => s !== "session_cost").map(
+      (stream) => ({
+        stream,
+        schemaVersion: this.schemaVersion,
+        available: false,
+        reason: "no producer wired in this reference host environment",
+      }),
+    );
+
+    return [costCap, ...others];
+  }
+
+  /**
+   * Pull samples for a stream over `[range.start, range.end)`. Only
+   * `session_cost` returns data here; any other stream yields `[]` (no producer
+   * in this host). `filters` apply exact label equality on `job` / `model` when
+   * supplied — but see ATTRIBUTION NOTE: `job` is brittle for exact match, so
+   * callers needing a subset should query broadly and post-filter.
+   */
+  async query(
+    stream: TelemetryStream,
+    range: DateRange,
+    filters?: Record<string, string>,
+  ): Promise<MetricSample[]> {
+    if (stream !== "session_cost") return [];
+    const db = this.handle();
+    if (!db) return [];
+    if (this.rowCount(db) === null) return [];
+
+    const clauses = ["date >= ?", "date < ?"];
+    const params: string[] = [toDay(range.start), toDay(range.end)];
+    if (filters?.job !== undefined) {
+      clauses.push("job = ?");
+      params.push(filters.job);
+    }
+    if (filters?.model !== undefined) {
+      clauses.push("model = ?");
+      params.push(filters.model);
+    }
+
+    let rows: CostRow[];
+    try {
+      rows = db
+        .query(
+          `SELECT date, job, model, cost_usd FROM session_costs
+           WHERE ${clauses.join(" AND ")}
+           ORDER BY date ASC`,
+        )
+        .all(...params) as CostRow[];
+    } catch {
+      return [];
+    }
+
+    return rows.map((r) => ({
+      ts: new Date(`${r.date}T00:00:00.000Z`),
+      value: typeof r.cost_usd === "number" ? r.cost_usd : Number(r.cost_usd) || 0,
+      labels: { job: r.job ?? "", model: r.model ?? "" },
+    }));
+  }
+
+  /** Release the read-only handle. Safe to call repeatedly. */
+  close(): void {
+    if (this.db) {
+      try {
+        this.db.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.db = null;
+    this.opened = false;
+  }
+}

--- a/src/tuner/wisecron/session-cost-provider.ts
+++ b/src/tuner/wisecron/session-cost-provider.ts
@@ -67,7 +67,12 @@ export class SessionCostTelemetryProvider implements TelemetryProvider {
   private opened = false;
 
   constructor(cfg: SessionCostProviderConfig = {}) {
-    this.dbPath = (cfg.dbPath ?? `${homedir()}/agent/data/costs.db`).replace(/^~/, homedir());
+    // `^~(?=/|$)` so we only expand a leading `~` that means "home" — a bare `~`
+    // or `~/...`, never `~otheruser/...` (which is a different account's home).
+    this.dbPath = (cfg.dbPath ?? `${homedir()}/agent/data/costs.db`).replace(
+      /^~(?=\/|$)/,
+      homedir(),
+    );
     this.schemaVersion = cfg.schemaVersion ?? TELEMETRY_CONTRACT_VERSION;
   }
 

--- a/src/tuner/wisecron/session-jsonl-provider.ts
+++ b/src/tuner/wisecron/session-jsonl-provider.ts
@@ -76,7 +76,7 @@ type ActiveStream = (typeof ACTIVE_STREAMS)[number];
 const AGENT_DISPATCH_TOOLS = new Set(["Agent", "Task"]);
 
 /** A Read is a memory access when its path is a CLAUDE.md file or under a memory/learnings dir. */
-const MEMORY_PATH_RE = /(?:CLAUDE\.md$|\/memory\/|simon-memory|\/learnings\/|session-state\.md$)/;
+const MEMORY_PATH_RE = /(?:CLAUDE\.md$|\/memory\/|\/learnings\/|session-state\.md$)/;
 
 export interface SessionJsonlProducerConfig {
   /** Projects dir root. Default `~/.claude/projects`. Tests pass a temp dir. */

--- a/src/tuner/wisecron/session-jsonl-provider.ts
+++ b/src/tuner/wisecron/session-jsonl-provider.ts
@@ -165,7 +165,14 @@ export class SessionJsonlTelemetryProducer implements TelemetryProvider {
       } catch {
         continue;
       }
-      this.scanFile(file, range, acc);
+      // Per-file tolerance mirrors the per-line JSON.parse skip: one unreadable
+      // or malformed transcript must never take down the whole telemetry surface
+      // (`capabilities()` is sync and feeds the activation gate).
+      try {
+        this.scanFile(file, range, acc);
+      } catch {
+        // skip a bad file
+      }
     }
 
     // Keep the memo small (different subjects use 7d/1d windows).
@@ -212,7 +219,11 @@ export class SessionJsonlTelemetryProducer implements TelemetryProvider {
       if (!ts || Number.isNaN(ts.getTime())) continue;
       if (ts.getTime() < range.start.getTime() || ts.getTime() >= range.end.getTime()) continue;
 
-      for (const block of a.message?.content ?? []) {
+      // `message.content` comes from an untrusted transcript; a non-array
+      // (e.g. `{"message":{"content":{}}}`) would make `for...of` throw. Guard
+      // so a malformed line contributes nothing instead of crashing the scan.
+      const content = Array.isArray(a.message?.content) ? a.message.content : [];
+      for (const block of content) {
         if (!block || (block as { type?: string }).type !== "tool_use") continue;
         const tu = block as AssistantToolUseBlock;
         const name = tu.name ?? "";

--- a/src/tuner/wisecron/session-jsonl-provider.ts
+++ b/src/tuner/wisecron/session-jsonl-provider.ts
@@ -41,9 +41,10 @@
  * the projects dir is absent.
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { forEachLineSync } from "./line-reader.js";
 import {
   type AssistantLine,
   type AssistantToolUseBlock,
@@ -77,6 +78,16 @@ const AGENT_DISPATCH_TOOLS = new Set(["Agent", "Task"]);
 
 /** A Read is a memory access when its path is a CLAUDE.md file or under a memory/learnings dir. */
 const MEMORY_PATH_RE = /(?:CLAUDE\.md$|\/memory\/|\/learnings\/|session-state\.md$)/;
+
+/**
+ * Cap the number of transcripts scanned per call. A busy host accumulates
+ * thousands of session files; reading every one on the cold `capabilities()`
+ * path is a synchronous event-loop stall / memory risk on a 4GB box. We scan the
+ * newest N by mtime (older files hold older events, already down-weighted by
+ * every metric's window) and `log()` when the cap truncates so the limit isn't
+ * silent.
+ */
+const MAX_FILES_PER_SCAN = 200;
 
 export interface SessionJsonlProducerConfig {
   /** Projects dir root. Default `~/.claude/projects`. Tests pass a temp dir. */
@@ -157,14 +168,33 @@ export class SessionJsonlTelemetryProducer implements TelemetryProvider {
     const acc = emptyCollected();
     const startMs = range.start.getTime();
 
+    // Gather in-window candidates with their mtime in one stat pass. A file last
+    // modified before the window starts cannot hold an in-range event (lines only
+    // append), so drop it up front without reading.
+    const candidates: Array<{ file: string; mtime: number }> = [];
     for (const file of this.sessionFiles(allowedDirPrefixes)) {
-      // A file last modified before the window starts cannot hold an in-range
-      // event (lines only append). Skip it without reading — bounds the scan.
       try {
-        if (statSync(file).mtime.getTime() < startMs) continue;
+        const mtime = statSync(file).mtime.getTime();
+        if (mtime < startMs) continue;
+        candidates.push({ file, mtime });
       } catch {
-        continue;
+        // unstattable file — skip
       }
+    }
+
+    // Bound the scan to the newest MAX_FILES_PER_SCAN by mtime so a host with
+    // thousands of sessions can't stall the sync path / exhaust memory.
+    candidates.sort((a, b) => b.mtime - a.mtime);
+    if (candidates.length > MAX_FILES_PER_SCAN) {
+      // Not silent: surface that the scan was capped.
+      console.warn(
+        `[session-jsonl] scan capped at ${MAX_FILES_PER_SCAN} of ${candidates.length} ` +
+          `in-window transcripts (newest by mtime) — older sessions skipped this call`,
+      );
+      candidates.length = MAX_FILES_PER_SCAN;
+    }
+
+    for (const { file } of candidates) {
       // Per-file tolerance mirrors the per-line JSON.parse skip: one unreadable
       // or malformed transcript must never take down the whole telemetry surface
       // (`capabilities()` is sync and feeds the activation gate).
@@ -182,42 +212,49 @@ export class SessionJsonlTelemetryProducer implements TelemetryProvider {
   }
 
   private scanFile(file: string, range: DateRange, acc: Collected): void {
-    let content: string;
-    try {
-      content = readFileSync(file, "utf8");
-    } catch {
-      return;
-    }
-
-    // First pass: map tool_use_id → is_error from tool_result blocks (which live
-    // in later user lines, not the assistant line that emitted the tool_use).
+    // Single streaming pass (bounded memory — never slurps the whole file):
+    //   - `errById` maps tool_use_id → is_error, populated from user
+    //     `tool_result` blocks (which live in later user lines than the
+    //     assistant `tool_use`), so the failure join needs the whole file first.
+    //   - `pending` holds a COMPACT record per emitted tool_use (ts + the few
+    //     fields that ride in labels), NOT the raw JSON line. Its size is the
+    //     output size — inherently O(samples) — not O(file bytes).
+    // After the stream we join `pending` against `errById` in encounter order,
+    // producing byte-for-byte the same samples the old two-pass slurp did.
     const errById = new Map<string, boolean>();
-    const lines: JsonlLine[] = [];
-    for (const raw of content.split("\n")) {
+    const pending: Array<{
+      ts: Date;
+      name: string;
+      id: string;
+      agent?: string;
+      memFile?: string;
+    }> = [];
+    const startMs = range.start.getTime();
+    const endMs = range.end.getTime();
+
+    forEachLineSync(file, (raw) => {
       const trimmed = raw.trim();
-      if (!trimmed) continue;
+      if (!trimmed) return;
       let line: JsonlLine;
       try {
         line = JSON.parse(trimmed) as JsonlLine;
       } catch {
-        continue;
+        return;
       }
-      lines.push(line);
+
       if (line.type === "user") {
         const results = extractToolResults((line as UserLine).message?.content);
         for (const r of results) {
           if (r.tool_use_id) errById.set(r.tool_use_id, r.is_error === true);
         }
+        return;
       }
-    }
+      if (line.type !== "assistant") return;
 
-    // Second pass: emit samples from assistant tool_use blocks.
-    for (const line of lines) {
-      if (line.type !== "assistant") continue;
       const a = line as AssistantLine;
       const ts = a.timestamp ? new Date(a.timestamp) : null;
-      if (!ts || Number.isNaN(ts.getTime())) continue;
-      if (ts.getTime() < range.start.getTime() || ts.getTime() >= range.end.getTime()) continue;
+      if (!ts || Number.isNaN(ts.getTime())) return;
+      if (ts.getTime() < startMs || ts.getTime() >= endMs) return;
 
       // `message.content` comes from an untrusted transcript; a non-array
       // (e.g. `{"message":{"content":{}}}`) would make `for...of` throw. Guard
@@ -227,34 +264,43 @@ export class SessionJsonlTelemetryProducer implements TelemetryProvider {
         if (!block || (block as { type?: string }).type !== "tool_use") continue;
         const tu = block as AssistantToolUseBlock;
         const name = tu.name ?? "";
-        const failed = tu.id ? errById.get(tu.id) === true : false;
-
-        // tool_call — every tool_use is one call; value carries failure.
-        acc.tool_call.push({
+        const rec: { ts: Date; name: string; id: string; agent?: string; memFile?: string } = {
           ts,
-          value: failed ? 1 : 0,
-          labels: { tool: name, server: serverOf(name), blocked: "false" },
-        });
+          name,
+          id: tu.id ?? "",
+        };
 
-        // agent_dispatch — Agent/Task invocations.
         if (AGENT_DISPATCH_TOOLS.has(name)) {
           const input = (tu.input ?? {}) as Record<string, unknown>;
-          const agent =
+          rec.agent =
             typeof input.subagent_type === "string" && input.subagent_type
               ? input.subagent_type
               : "default";
-          // value = 0: dispatch occurred; reclassification is not a transcript event.
-          acc.agent_dispatch.push({ ts, value: 0, labels: { agent } });
         }
-
-        // memory_access — Reads of CLAUDE.md / memory / learnings files.
         if (name === "Read") {
           const input = (tu.input ?? {}) as Record<string, unknown>;
           const fp = typeof input.file_path === "string" ? input.file_path : "";
-          if (fp && MEMORY_PATH_RE.test(fp)) {
-            acc.memory_access.push({ ts, value: 1, labels: { file: fp } });
-          }
+          if (fp && MEMORY_PATH_RE.test(fp)) rec.memFile = fp;
         }
+        pending.push(rec);
+      }
+    });
+
+    for (const p of pending) {
+      const failed = p.id ? errById.get(p.id) === true : false;
+      // tool_call — every tool_use is one call; value carries failure.
+      acc.tool_call.push({
+        ts: p.ts,
+        value: failed ? 1 : 0,
+        labels: { tool: p.name, server: serverOf(p.name), blocked: "false" },
+      });
+      // agent_dispatch — value = 0: dispatch occurred; reclassification is not a transcript event.
+      if (p.agent !== undefined) {
+        acc.agent_dispatch.push({ ts: p.ts, value: 0, labels: { agent: p.agent } });
+      }
+      // memory_access — Reads of CLAUDE.md / memory / learnings files.
+      if (p.memFile !== undefined) {
+        acc.memory_access.push({ ts: p.ts, value: 1, labels: { file: p.memFile } });
       }
     }
   }

--- a/src/tuner/wisecron/session-jsonl-provider.ts
+++ b/src/tuner/wisecron/session-jsonl-provider.ts
@@ -1,0 +1,304 @@
+/**
+ * Session-transcript TelemetryProvider — the UNIVERSAL host producer
+ * (OutcomeLoop Phase B, real-data wiring).
+ *
+ * Earlier producers pointed at idealized sources that don't exist on most
+ * machines (`wisecron-*` units, specific `operations.jsonl` event shapes). The
+ * abundant, universal source is the Claude Code session transcript:
+ * `~/.claude/projects/<enc-cwd>/<session-id>.jsonl`. Every session carries
+ * `tool_use` blocks, subagent (`Agent`/`Task`) dispatches and file reads. This
+ * producer reads those transcripts and derives the dispatch/tool/memory streams
+ * the subjects consume — behind the same `TelemetryProvider` contract, so the
+ * tuner still only sees `query(...)`.
+ *
+ * Parser reuse: this does NOT define a new JSONL schema parser. It consumes the
+ * Bus's authoritative line-type union + helpers (`src/bus/jsonl-line-types.ts`)
+ * — `JsonlLine`, `AssistantLine`/`UserLine`, the `tool_use` content-block shape,
+ * and `extractToolResults`. Bumping a line shape there is the single place that
+ * owns it (see that file's `SCHEMA_VERSION` note).
+ *
+ * Provenance, per stream:
+ *  - `tool_call`     ← assistant `tool_use` blocks. value = 1 if the matching
+ *                      `tool_result` (joined by `tool_use_id`) is `is_error`,
+ *                      else 0 — matches the host contract consumed by
+ *                      McpPluginSubject (`mcp_tool_failure_rate = nonzeroRate`).
+ *                      labels = { tool, server (mcp__<server>__ prefix or ""),
+ *                      blocked:"false" — transcripts don't record a block flag }.
+ *  - `agent_dispatch`← `Agent`/`Task` `tool_use` blocks. labels.agent =
+ *                      input.subagent_type (or "default"). value = 0: a transcript
+ *                      records that a subagent was dispatched, NOT whether the
+ *                      router *reclassified* it (the metric AgentSubject computes).
+ *                      So the stream activates with a real dispatch count and an
+ *                      honest reclassify_rate of 0 — never a fabricated nonzero.
+ *  - `memory_access` ← `Read` `tool_use` whose file_path is a CLAUDE.md file or
+ *                      lives under a memory/learnings dir. value = 1 per read;
+ *                      labels.file = the path (MemorySubject groups per file).
+ *  - `mode_dispatch` ← NOT derivable: routing-mode dispatch is a ClaudeClaw
+ *                      orchestration concept, not recorded in the transcript.
+ *                      Advertised available:false with a reason — no faked data.
+ *
+ * Every query returns `[]` (never throws) for a stream it does not own and when
+ * the projects dir is absent.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  type AssistantLine,
+  type AssistantToolUseBlock,
+  type JsonlLine,
+  type UserLine,
+  extractToolResults,
+} from "../../bus/jsonl-line-types.js";
+import {
+  type DateRange,
+  type MetricSample,
+  type TelemetryCapability,
+  type TelemetryProvider,
+  type TelemetryStream,
+  TELEMETRY_CONTRACT_VERSION,
+} from "../../skills-tuner/core/telemetry.js";
+import { AGENT_SESSION_DIRS_FILTER_KEY } from "../../skills-tuner/core/scope.js";
+
+/** Streams this producer owns (active + the inactive-by-design mode_dispatch). */
+const OWNED_STREAMS: TelemetryStream[] = [
+  "tool_call",
+  "agent_dispatch",
+  "memory_access",
+  "mode_dispatch",
+];
+/** Subset this producer can actually populate from a transcript. */
+const ACTIVE_STREAMS = ["tool_call", "agent_dispatch", "memory_access"] as const;
+type ActiveStream = (typeof ACTIVE_STREAMS)[number];
+
+/** Tool names that are a subagent dispatch (harness-dependent: `Agent` here, `Task` upstream). */
+const AGENT_DISPATCH_TOOLS = new Set(["Agent", "Task"]);
+
+/** A Read is a memory access when its path is a CLAUDE.md file or under a memory/learnings dir. */
+const MEMORY_PATH_RE = /(?:CLAUDE\.md$|\/memory\/|simon-memory|\/learnings\/|session-state\.md$)/;
+
+export interface SessionJsonlProducerConfig {
+  /** Projects dir root. Default `~/.claude/projects`. Tests pass a temp dir. */
+  projectsDir?: string;
+  schemaVersion?: string;
+}
+
+interface Collected {
+  tool_call: MetricSample[];
+  agent_dispatch: MetricSample[];
+  memory_access: MetricSample[];
+}
+
+function emptyCollected(): Collected {
+  return { tool_call: [], agent_dispatch: [], memory_access: [] };
+}
+
+/** Parse `mcp__<server>__<tool>` → server; non-MCP tools have no server. */
+function serverOf(toolName: string): string {
+  if (!toolName.startsWith("mcp__")) return "";
+  return toolName.split("__")[1] ?? "";
+}
+
+export class SessionJsonlTelemetryProducer implements TelemetryProvider {
+  private readonly projectsDir: string;
+  private readonly schemaVersion: string;
+  /** Memo keyed by range so the 3 active streams don't each rescan 1000+ files. */
+  private readonly memo = new Map<string, Collected>();
+
+  constructor(cfg: SessionJsonlProducerConfig = {}) {
+    this.projectsDir = cfg.projectsDir ?? join(homedir(), ".claude", "projects");
+    this.schemaVersion = cfg.schemaVersion ?? TELEMETRY_CONTRACT_VERSION;
+  }
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  /**
+   * Enumerate `<projectsDir>/<enc-cwd>/<session>.jsonl` files. When
+   * `allowedDirPrefixes` is supplied (agent scope), only project dirs whose name
+   * starts with one of the prefixes are scanned — this is how an agent-scoped
+   * query is bounded to agent sessions at the source.
+   */
+  private sessionFiles(allowedDirPrefixes?: string[]): string[] {
+    if (!existsSync(this.projectsDir)) return [];
+    const out: string[] = [];
+    let dirs: string[];
+    try {
+      dirs = readdirSync(this.projectsDir);
+    } catch {
+      return [];
+    }
+    for (const d of dirs) {
+      if (allowedDirPrefixes && !allowedDirPrefixes.some((p) => d.startsWith(p))) continue;
+      const sub = join(this.projectsDir, d);
+      let files: string[];
+      try {
+        if (!statSync(sub).isDirectory()) continue;
+        files = readdirSync(sub);
+      } catch {
+        continue;
+      }
+      for (const f of files) {
+        if (f.endsWith(".jsonl")) out.push(join(sub, f));
+      }
+    }
+    return out;
+  }
+
+  /** Derive all three active streams in a single pass over in-window sessions. */
+  private collect(range: DateRange, allowedDirPrefixes?: string[]): Collected {
+    const dirKey = allowedDirPrefixes ? allowedDirPrefixes.join(",") : "*";
+    const key = `${range.start.getTime()}|${range.end.getTime()}|${dirKey}`;
+    const cached = this.memo.get(key);
+    if (cached) return cached;
+
+    const acc = emptyCollected();
+    const startMs = range.start.getTime();
+
+    for (const file of this.sessionFiles(allowedDirPrefixes)) {
+      // A file last modified before the window starts cannot hold an in-range
+      // event (lines only append). Skip it without reading — bounds the scan.
+      try {
+        if (statSync(file).mtime.getTime() < startMs) continue;
+      } catch {
+        continue;
+      }
+      this.scanFile(file, range, acc);
+    }
+
+    // Keep the memo small (different subjects use 7d/1d windows).
+    if (this.memo.size > 8) this.memo.clear();
+    this.memo.set(key, acc);
+    return acc;
+  }
+
+  private scanFile(file: string, range: DateRange, acc: Collected): void {
+    let content: string;
+    try {
+      content = readFileSync(file, "utf8");
+    } catch {
+      return;
+    }
+
+    // First pass: map tool_use_id → is_error from tool_result blocks (which live
+    // in later user lines, not the assistant line that emitted the tool_use).
+    const errById = new Map<string, boolean>();
+    const lines: JsonlLine[] = [];
+    for (const raw of content.split("\n")) {
+      const trimmed = raw.trim();
+      if (!trimmed) continue;
+      let line: JsonlLine;
+      try {
+        line = JSON.parse(trimmed) as JsonlLine;
+      } catch {
+        continue;
+      }
+      lines.push(line);
+      if (line.type === "user") {
+        const results = extractToolResults((line as UserLine).message?.content);
+        for (const r of results) {
+          if (r.tool_use_id) errById.set(r.tool_use_id, r.is_error === true);
+        }
+      }
+    }
+
+    // Second pass: emit samples from assistant tool_use blocks.
+    for (const line of lines) {
+      if (line.type !== "assistant") continue;
+      const a = line as AssistantLine;
+      const ts = a.timestamp ? new Date(a.timestamp) : null;
+      if (!ts || Number.isNaN(ts.getTime())) continue;
+      if (ts.getTime() < range.start.getTime() || ts.getTime() >= range.end.getTime()) continue;
+
+      for (const block of a.message?.content ?? []) {
+        if (!block || (block as { type?: string }).type !== "tool_use") continue;
+        const tu = block as AssistantToolUseBlock;
+        const name = tu.name ?? "";
+        const failed = tu.id ? errById.get(tu.id) === true : false;
+
+        // tool_call — every tool_use is one call; value carries failure.
+        acc.tool_call.push({
+          ts,
+          value: failed ? 1 : 0,
+          labels: { tool: name, server: serverOf(name), blocked: "false" },
+        });
+
+        // agent_dispatch — Agent/Task invocations.
+        if (AGENT_DISPATCH_TOOLS.has(name)) {
+          const input = (tu.input ?? {}) as Record<string, unknown>;
+          const agent =
+            typeof input.subagent_type === "string" && input.subagent_type
+              ? input.subagent_type
+              : "default";
+          // value = 0: dispatch occurred; reclassification is not a transcript event.
+          acc.agent_dispatch.push({ ts, value: 0, labels: { agent } });
+        }
+
+        // memory_access — Reads of CLAUDE.md / memory / learnings files.
+        if (name === "Read") {
+          const input = (tu.input ?? {}) as Record<string, unknown>;
+          const fp = typeof input.file_path === "string" ? input.file_path : "";
+          if (fp && MEMORY_PATH_RE.test(fp)) {
+            acc.memory_access.push({ ts, value: 1, labels: { file: fp } });
+          }
+        }
+      }
+    }
+  }
+
+  capabilities(): TelemetryCapability[] {
+    // Probe a 30d lookback so a single quiet week doesn't flip a whole stream
+    // off; availability answers "can this source emit here", while fitness still
+    // measures over each metric's own (shorter) windowDays.
+    const since = new Date(Date.now() - 30 * 86_400_000);
+    const collected = this.collect({ start: since, end: new Date() });
+
+    const dirNote = existsSync(this.projectsDir)
+      ? `no matching events in ${this.projectsDir}/*/*.jsonl (last 30d)`
+      : `projects dir not found at ${this.projectsDir}`;
+
+    const caps: TelemetryCapability[] = ACTIVE_STREAMS.map((stream) => {
+      const has = collected[stream].length > 0;
+      if (has) return { stream, schemaVersion: this.schemaVersion, available: true };
+      const what =
+        stream === "tool_call"
+          ? "tool_use blocks"
+          : stream === "agent_dispatch"
+            ? "Agent/Task dispatches"
+            : "memory-file reads";
+      return {
+        stream,
+        schemaVersion: this.schemaVersion,
+        available: false,
+        reason: `no ${what} — ${dirNote}`,
+      };
+    });
+
+    // mode_dispatch: declared, inactive by design (not in the transcript).
+    caps.push({
+      stream: "mode_dispatch",
+      schemaVersion: this.schemaVersion,
+      available: false,
+      reason:
+        "routing-mode dispatch is a ClaudeClaw orchestration event, not recorded in session transcripts",
+    });
+
+    return caps;
+  }
+
+  async query(
+    stream: TelemetryStream,
+    range: DateRange,
+    filters?: Record<string, string>,
+  ): Promise<MetricSample[]> {
+    if (!OWNED_STREAMS.includes(stream)) return [];
+    if (stream === "mode_dispatch") return []; // inactive by design
+    // Agent scope hands us a comma-joined list of agent project-dir prefixes;
+    // when present we only scan transcripts under those dirs.
+    const raw = filters?.[AGENT_SESSION_DIRS_FILTER_KEY];
+    const allowedDirPrefixes = raw ? raw.split(",").filter(Boolean) : undefined;
+    return this.collect(range, allowedDirPrefixes)[stream as ActiveStream];
+  }
+}

--- a/src/tuner/wisecron/state-db.ts
+++ b/src/tuner/wisecron/state-db.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, renameSync } from "node:fs";
+import { existsSync, mkdirSync, renameSync, unlinkSync } from "node:fs";
 import { dirname } from "node:path";
 import { homedir } from "node:os";
 import type { RevisionRecord, ScheduleState, AppliedBy } from "./types.js";
@@ -180,6 +180,29 @@ CREATE INDEX IF NOT EXISTS idx_outcomes_pending ON outcomes(verdict, window_end)
 CREATE INDEX IF NOT EXISTS idx_proposals_status ON proposals(status, created_at DESC);
 `;
 
+/**
+ * Target schema version. The baseline schema above (all `CREATE TABLE IF NOT
+ * EXISTS`) is version 1. Bump this and append a migration to `MIGRATIONS` for
+ * the first change that a plain `IF NOT EXISTS` cannot express (e.g. an
+ * `ALTER TABLE ... ADD COLUMN` on a table that already exists in older DBs).
+ */
+const CURRENT_SCHEMA_VERSION = 1;
+
+/**
+ * Forward-only migrations. `MIGRATIONS[v]` upgrades a DB that is at
+ * `user_version = v` to `v + 1`. Index 0 (v0 → v1) is intentionally empty:
+ * the baseline tables are already materialised by `SCHEMA` via
+ * `IF NOT EXISTS`, so first init only needs to stamp `user_version = 1`.
+ *
+ * To add the first real migration, set `CURRENT_SCHEMA_VERSION = 2` and push a
+ * function here that runs the `ALTER TABLE`. Use only static SQL literals — no
+ * interpolated identifiers.
+ */
+const MIGRATIONS: ReadonlyArray<(db: Database) => void> = [
+  // v0 → v1: baseline schema (created by SCHEMA). No forward work required.
+  () => {},
+];
+
 export class WisecronStateDB {
   private db: Database;
   private readonly path: string;
@@ -190,6 +213,26 @@ export class WisecronStateDB {
     this.db = new Database(this.path);
     this.db.exec("PRAGMA journal_mode=WAL;");
     this.db.exec(SCHEMA);
+    this.runMigrations();
+  }
+
+  /**
+   * Apply forward-only migrations from the DB's current `user_version` up to
+   * `CURRENT_SCHEMA_VERSION`, then stamp the new version. On a fresh DB
+   * `user_version` is 0, so this simply runs the (empty) v0 → v1 step and marks
+   * the DB at version 1. Idempotent: a DB already at the target version does no
+   * work. `PRAGMA user_version` cannot be parameterized; the value written is a
+   * static integer constant, never user input.
+   */
+  private runMigrations(): void {
+    const { user_version: from } = this.db.prepare("PRAGMA user_version").get() as {
+      user_version: number;
+    };
+    if (from >= CURRENT_SCHEMA_VERSION) return;
+    for (let v = from; v < CURRENT_SCHEMA_VERSION; v++) {
+      MIGRATIONS[v]?.(this.db);
+    }
+    this.db.exec(`PRAGMA user_version = ${CURRENT_SCHEMA_VERSION};`);
   }
 
   close(): void {
@@ -458,19 +501,24 @@ export class WisecronStateDB {
 
   // ── priors (Phase 2 substrate; unused in Phase 1) ─────────────────────────
 
-  /** EWMA-update the prior for (subject, kind) with a new observed delta. */
+  /**
+   * EWMA-update the prior for (subject, kind) with a new observed delta.
+   *
+   * Done as a single atomic `INSERT ... ON CONFLICT DO UPDATE` so concurrent
+   * callers cannot lose an update via a read-modify-write race: on first insert
+   * the prior seeds to `delta` with `n = 1`; on conflict the blend
+   * `alpha*delta + (1-alpha)*ewma_delta` and `n = n + 1` are computed against
+   * the row's live values inside the statement. All inputs are `?`-bound.
+   */
   upsertPrior(subject: string, kind: string, delta: number, alpha = 0.3): void {
-    const existing = this.db
-      .prepare("SELECT ewma_delta, n FROM priors WHERE subject = ? AND kind = ?")
-      .get(subject, kind) as { ewma_delta: number; n: number } | undefined;
-    const ewma = existing ? alpha * delta + (1 - alpha) * existing.ewma_delta : delta;
-    const n = (existing?.n ?? 0) + 1;
     this.db
       .prepare(`
-      INSERT INTO priors(subject, kind, ewma_delta, n) VALUES (?, ?, ?, ?)
-      ON CONFLICT(subject, kind) DO UPDATE SET ewma_delta = excluded.ewma_delta, n = excluded.n
+      INSERT INTO priors(subject, kind, ewma_delta, n) VALUES (?, ?, ?, 1)
+      ON CONFLICT(subject, kind) DO UPDATE SET
+        ewma_delta = ? * ? + (1 - ?) * priors.ewma_delta,
+        n = priors.n + 1
     `)
-      .run(subject, kind, ewma, n);
+      .run(subject, kind, delta, alpha, delta, alpha);
   }
 
   getPrior(subject: string, kind: string): { ewma_delta: number; n: number } | null {
@@ -512,8 +560,20 @@ export class WisecronStateDB {
     } catch {
       /* ignore if missing */
     }
+    // Drop the WAL/SHM sidecars of the corrupt DB. If left behind, SQLite would
+    // treat them as belonging to the brand-new file at this.path and try to
+    // replay the stale WAL into it — resurrecting corrupt pages or failing the
+    // open. Best-effort: they may not exist (e.g. a checkpointed DB).
+    for (const sidecar of [`${this.path}-wal`, `${this.path}-shm`]) {
+      try {
+        unlinkSync(sidecar);
+      } catch {
+        /* ignore if missing */
+      }
+    }
     this.db = new Database(this.path);
     this.db.exec("PRAGMA journal_mode=WAL;");
     this.db.exec(SCHEMA);
+    this.runMigrations();
   }
 }

--- a/src/tuner/wisecron/state-db.ts
+++ b/src/tuner/wisecron/state-db.ts
@@ -1,0 +1,519 @@
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync, renameSync } from "node:fs";
+import { dirname } from "node:path";
+import { homedir } from "node:os";
+import type { RevisionRecord, ScheduleState, AppliedBy } from "./types.js";
+import type { Patch, Proposal } from "../../skills-tuner/core/types.js";
+import { ProposalSchema } from "../../skills-tuner/core/types.js";
+
+interface SubjectStateRow {
+  subject: string;
+  last_run: string;
+  next_run: string;
+  current_interval_hours: number;
+  consecutive_zero_runs: number;
+  last_proposal_count: number;
+  enabled: number;
+}
+
+interface RollbackRow {
+  id: number;
+  proposal_id: string;
+  subject: string;
+  applied_at: string;
+  forward_patch_json: string;
+  inverse_patch_json: string;
+  applied_by: string;
+  rolled_back_at: string | null;
+}
+
+export interface OutcomeRow {
+  proposal_id: string;
+  metric: string;
+  commit_sha: string | null;
+  subject: string;
+  baseline: number | null;
+  post: number | null;
+  delta: number | null;
+  window_start: string;
+  window_end: string;
+  verdict: string | null;
+}
+
+/** Persisted proposal lifecycle status. */
+export type ProposalStatus = "pending" | "applied" | "refused";
+
+interface ProposalRow {
+  id: string;
+  subject: string;
+  status: string;
+  proposal_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** A persisted proposal: the signed Proposal plus its lifecycle status. */
+export interface StoredProposal {
+  id: string;
+  subject: string;
+  status: ProposalStatus;
+  proposal: Proposal;
+  created_at: Date;
+  updated_at: Date;
+}
+
+function rowToStoredProposal(row: ProposalRow): StoredProposal {
+  return {
+    id: row.id,
+    subject: row.subject,
+    status: row.status as ProposalStatus,
+    // ProposalSchema coerces created_at (string in JSON) back to a Date so the
+    // canonical signature re-derivation (which calls created_at.toISOString())
+    // matches what was signed at persist time.
+    proposal: ProposalSchema.parse(JSON.parse(row.proposal_json)),
+    created_at: new Date(row.created_at),
+    updated_at: new Date(row.updated_at),
+  };
+}
+
+function rowToScheduleState(row: SubjectStateRow): ScheduleState {
+  return {
+    subject: row.subject,
+    last_run: new Date(row.last_run),
+    next_run: new Date(row.next_run),
+    current_interval_hours: row.current_interval_hours,
+    consecutive_zero_runs: row.consecutive_zero_runs,
+    last_proposal_count: row.last_proposal_count,
+    enabled: row.enabled === 1,
+  };
+}
+
+function rowToRevisionRecord(row: RollbackRow): RevisionRecord {
+  return {
+    id: row.id,
+    proposal_id: row.proposal_id,
+    subject: row.subject,
+    applied_at: new Date(row.applied_at),
+    forward_patch: JSON.parse(row.forward_patch_json),
+    inverse_patch: JSON.parse(row.inverse_patch_json),
+    applied_by: row.applied_by as AppliedBy,
+    rolled_back_at: row.rolled_back_at ? new Date(row.rolled_back_at) : null,
+  };
+}
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS subject_state (
+  subject TEXT PRIMARY KEY,
+  last_run TEXT NOT NULL,
+  next_run TEXT NOT NULL,
+  current_interval_hours INTEGER NOT NULL,
+  consecutive_zero_runs INTEGER NOT NULL DEFAULT 0,
+  last_proposal_count INTEGER NOT NULL DEFAULT 0,
+  enabled INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS rollback_history (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  proposal_id TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  applied_at TEXT NOT NULL,
+  forward_patch_json TEXT NOT NULL,
+  inverse_patch_json TEXT NOT NULL,
+  applied_by TEXT NOT NULL,
+  rolled_back_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS telemetry_cache (
+  subject TEXT NOT NULL,
+  observation_id TEXT NOT NULL,
+  collected_at TEXT NOT NULL,
+  data_json TEXT NOT NULL,
+  PRIMARY KEY (subject, observation_id)
+);
+
+-- OutcomeLoop ledger. One row per (proposal, metric): baseline snapshotted at
+-- apply, post/delta/verdict filled by the maturation pass once windowDays
+-- elapse. Reality correction vs spec: PK is (proposal_id, metric) — a single
+-- proposal scores several metrics — keyed on the EXISTING proposal id + its
+-- commit_sha (no separate revision_id). proposal_id is TEXT to match
+-- rollback_history. post/delta/verdict are NULL until maturation.
+CREATE TABLE IF NOT EXISTS outcomes (
+  proposal_id  TEXT NOT NULL,
+  metric       TEXT NOT NULL,
+  commit_sha   TEXT,
+  subject      TEXT NOT NULL,
+  baseline     REAL,
+  post         REAL,
+  delta        REAL,
+  window_start TEXT NOT NULL,
+  window_end   TEXT NOT NULL,
+  verdict      TEXT,
+  PRIMARY KEY (proposal_id, metric)
+);
+
+-- Proposal queue. The wisecron ProposalEngine returns proposals but does not
+-- persist them; this table is the durable approve-then-apply file the CLI/notifier
+-- drive. Signed Proposal JSON is stored verbatim so apply-time signature
+-- verification round-trips. status: pending → applied | refused.
+CREATE TABLE IF NOT EXISTS proposals (
+  id            TEXT PRIMARY KEY,
+  subject       TEXT NOT NULL,
+  status        TEXT NOT NULL DEFAULT 'pending',
+  proposal_json TEXT NOT NULL,
+  created_at    TEXT NOT NULL,
+  updated_at    TEXT NOT NULL
+);
+
+-- Phase 2 substrate (generative ranking). Empty + unused in Phase 1.
+CREATE TABLE IF NOT EXISTS priors (
+  subject    TEXT NOT NULL,
+  kind       TEXT NOT NULL,
+  ewma_delta REAL NOT NULL DEFAULT 0,
+  n          INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (subject, kind)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rollback_subject ON rollback_history(subject, applied_at DESC);
+CREATE INDEX IF NOT EXISTS idx_rollback_proposal ON rollback_history(proposal_id, applied_at DESC);
+CREATE INDEX IF NOT EXISTS idx_telemetry_collected ON telemetry_cache(subject, collected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_outcomes_pending ON outcomes(verdict, window_end);
+CREATE INDEX IF NOT EXISTS idx_proposals_status ON proposals(status, created_at DESC);
+`;
+
+export class WisecronStateDB {
+  private db: Database;
+  private readonly path: string;
+
+  constructor(dbPath: string) {
+    this.path = dbPath.replace(/^~/, homedir());
+    mkdirSync(dirname(this.path), { recursive: true });
+    this.db = new Database(this.path);
+    this.db.exec("PRAGMA journal_mode=WAL;");
+    this.db.exec(SCHEMA);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  // ── subject_state ─────────────────────────────────────────────────────────
+
+  upsertScheduleState(state: ScheduleState): void {
+    this.db
+      .prepare(`
+      INSERT INTO subject_state(
+        subject, last_run, next_run, current_interval_hours,
+        consecutive_zero_runs, last_proposal_count, enabled
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(subject) DO UPDATE SET
+        last_run = excluded.last_run,
+        next_run = excluded.next_run,
+        current_interval_hours = excluded.current_interval_hours,
+        consecutive_zero_runs = excluded.consecutive_zero_runs,
+        last_proposal_count = excluded.last_proposal_count,
+        enabled = excluded.enabled
+    `)
+      .run(
+        state.subject,
+        state.last_run.toISOString(),
+        state.next_run.toISOString(),
+        state.current_interval_hours,
+        state.consecutive_zero_runs,
+        state.last_proposal_count,
+        state.enabled ? 1 : 0,
+      );
+  }
+
+  getScheduleState(subject: string): ScheduleState | null {
+    const row = this.db.prepare("SELECT * FROM subject_state WHERE subject = ?").get(subject) as
+      | SubjectStateRow
+      | undefined;
+    return row ? rowToScheduleState(row) : null;
+  }
+
+  listScheduleStates(): ScheduleState[] {
+    const rows = this.db
+      .prepare("SELECT * FROM subject_state ORDER BY next_run ASC")
+      .all() as SubjectStateRow[];
+    return rows.map(rowToScheduleState);
+  }
+
+  setEnabled(subject: string, enabled: boolean): void {
+    this.db
+      .prepare("UPDATE subject_state SET enabled = ? WHERE subject = ?")
+      .run(enabled ? 1 : 0, subject);
+  }
+
+  // ── rollback_history ──────────────────────────────────────────────────────
+
+  recordApply(record: {
+    proposal_id: string;
+    subject: string;
+    forward_patch: Patch;
+    inverse_patch: Patch;
+    applied_by: AppliedBy;
+  }): number {
+    const result = this.db
+      .prepare(`
+      INSERT INTO rollback_history(
+        proposal_id, subject, applied_at,
+        forward_patch_json, inverse_patch_json, applied_by
+      ) VALUES (?, ?, ?, ?, ?, ?)
+    `)
+      .run(
+        record.proposal_id,
+        record.subject,
+        new Date().toISOString(),
+        JSON.stringify(record.forward_patch),
+        JSON.stringify(record.inverse_patch),
+        record.applied_by,
+      );
+    return Number(result.lastInsertRowid);
+  }
+
+  markRolledBack(revisionId: number): void {
+    this.db
+      .prepare("UPDATE rollback_history SET rolled_back_at = ? WHERE id = ?")
+      .run(new Date().toISOString(), revisionId);
+  }
+
+  getRevision(revisionId: number): RevisionRecord | null {
+    const row = this.db.prepare("SELECT * FROM rollback_history WHERE id = ?").get(revisionId) as
+      | RollbackRow
+      | undefined;
+    return row ? rowToRevisionRecord(row) : null;
+  }
+
+  listRevisionsBySubject(subject: string, limit = 50): RevisionRecord[] {
+    const rows = this.db
+      .prepare("SELECT * FROM rollback_history WHERE subject = ? ORDER BY applied_at DESC LIMIT ?")
+      .all(subject, limit) as RollbackRow[];
+    return rows.map(rowToRevisionRecord);
+  }
+
+  purgeExpiredRevisions(retentionDays: number): number {
+    const cutoff = new Date(Date.now() - retentionDays * 86_400_000).toISOString();
+    const result = this.db.prepare("DELETE FROM rollback_history WHERE applied_at < ?").run(cutoff);
+    return Number(result.changes);
+  }
+
+  /**
+   * The newest still-applied revision for a proposal (rolled_back_at IS NULL),
+   * or null if none. Used by the maturation pass to map a regressed proposal
+   * back to the revision its defensive revert must replay.
+   */
+  getActiveRevisionByProposal(proposalId: string): RevisionRecord | null {
+    const row = this.db
+      .prepare(
+        `SELECT * FROM rollback_history
+         WHERE proposal_id = ? AND rolled_back_at IS NULL
+         ORDER BY applied_at DESC LIMIT 1`,
+      )
+      .get(proposalId) as RollbackRow | undefined;
+    return row ? rowToRevisionRecord(row) : null;
+  }
+
+  // ── proposals queue ───────────────────────────────────────────────────────
+
+  /**
+   * Persist a signed proposal as `pending`. Idempotent on re-run: an existing
+   * row (any status) is left untouched, so re-running a cron cycle never
+   * resurrects an applied/refused proposal or clobbers its status.
+   */
+  persistProposal(proposal: Proposal): void {
+    const now = new Date().toISOString();
+    this.db
+      .prepare(`
+      INSERT INTO proposals(id, subject, status, proposal_json, created_at, updated_at)
+      VALUES (?, ?, 'pending', ?, ?, ?)
+      ON CONFLICT(id) DO NOTHING
+    `)
+      .run(String(proposal.id), proposal.subject, JSON.stringify(proposal), now, now);
+  }
+
+  listProposals(status?: ProposalStatus): StoredProposal[] {
+    const rows = (
+      status
+        ? this.db
+            .prepare("SELECT * FROM proposals WHERE status = ? ORDER BY created_at DESC")
+            .all(status)
+        : this.db.prepare("SELECT * FROM proposals ORDER BY created_at DESC").all()
+    ) as ProposalRow[];
+    return rows.map(rowToStoredProposal);
+  }
+
+  getStoredProposal(id: string): StoredProposal | null {
+    const row = this.db.prepare("SELECT * FROM proposals WHERE id = ?").get(id) as
+      | ProposalRow
+      | undefined;
+    return row ? rowToStoredProposal(row) : null;
+  }
+
+  setProposalStatus(id: string, status: ProposalStatus): void {
+    this.db
+      .prepare("UPDATE proposals SET status = ?, updated_at = ? WHERE id = ?")
+      .run(status, new Date().toISOString(), id);
+  }
+
+  // ── telemetry_cache ───────────────────────────────────────────────────────
+
+  cacheTelemetry(subject: string, observationId: string, data: unknown): void {
+    this.db
+      .prepare(`
+      INSERT INTO telemetry_cache(subject, observation_id, collected_at, data_json)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(subject, observation_id) DO UPDATE SET
+        collected_at = excluded.collected_at,
+        data_json = excluded.data_json
+    `)
+      .run(subject, observationId, new Date().toISOString(), JSON.stringify(data));
+  }
+
+  recentTelemetry(
+    subject: string,
+    sinceIso: string,
+  ): Array<{ observation_id: string; data: unknown }> {
+    const rows = this.db
+      .prepare(`
+      SELECT observation_id, data_json FROM telemetry_cache
+      WHERE subject = ? AND collected_at >= ?
+      ORDER BY collected_at DESC
+    `)
+      .all(subject, sinceIso) as Array<{ observation_id: string; data_json: string }>;
+    return rows.map((r) => ({ observation_id: r.observation_id, data: JSON.parse(r.data_json) }));
+  }
+
+  // ── outcomes ledger (OutcomeLoop) ─────────────────────────────────────────
+
+  /**
+   * Snapshot the baseline fitness for one (proposal, metric) at apply time.
+   * Idempotent: re-snapshotting the same key refreshes baseline + window,
+   * leaving post/delta/verdict untouched.
+   */
+  snapshotBaseline(row: {
+    proposal_id: string;
+    metric: string;
+    commit_sha?: string;
+    subject: string;
+    baseline: number;
+    window_start: Date;
+    window_end: Date;
+  }): void {
+    this.db
+      .prepare(`
+      INSERT INTO outcomes(
+        proposal_id, metric, commit_sha, subject, baseline, window_start, window_end
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(proposal_id, metric) DO UPDATE SET
+        commit_sha = excluded.commit_sha,
+        subject = excluded.subject,
+        baseline = excluded.baseline,
+        window_start = excluded.window_start,
+        window_end = excluded.window_end
+    `)
+      .run(
+        row.proposal_id,
+        row.metric,
+        row.commit_sha ?? null,
+        row.subject,
+        row.baseline,
+        row.window_start.toISOString(),
+        row.window_end.toISOString(),
+      );
+  }
+
+  /** Fill post / delta / verdict once a window matures. */
+  finalizeOutcome(row: {
+    proposal_id: string;
+    metric: string;
+    post: number;
+    delta: number;
+    verdict: string;
+  }): void {
+    this.db
+      .prepare(`
+      UPDATE outcomes SET post = ?, delta = ?, verdict = ?
+      WHERE proposal_id = ? AND metric = ?
+    `)
+      .run(row.post, row.delta, row.verdict, row.proposal_id, row.metric);
+  }
+
+  getOutcomes(proposalId: string): OutcomeRow[] {
+    return this.db
+      .prepare("SELECT * FROM outcomes WHERE proposal_id = ? ORDER BY metric ASC")
+      .all(proposalId) as OutcomeRow[];
+  }
+
+  /**
+   * Outcomes whose verdict is still NULL and whose window_end is at or before
+   * `asOf` — i.e. ready for the maturation pass to compute post/delta/verdict.
+   */
+  listMaturableOutcomes(asOf: Date): OutcomeRow[] {
+    return this.db
+      .prepare(
+        "SELECT * FROM outcomes WHERE verdict IS NULL AND window_end <= ? ORDER BY window_end ASC",
+      )
+      .all(asOf.toISOString()) as OutcomeRow[];
+  }
+
+  // ── priors (Phase 2 substrate; unused in Phase 1) ─────────────────────────
+
+  /** EWMA-update the prior for (subject, kind) with a new observed delta. */
+  upsertPrior(subject: string, kind: string, delta: number, alpha = 0.3): void {
+    const existing = this.db
+      .prepare("SELECT ewma_delta, n FROM priors WHERE subject = ? AND kind = ?")
+      .get(subject, kind) as { ewma_delta: number; n: number } | undefined;
+    const ewma = existing ? alpha * delta + (1 - alpha) * existing.ewma_delta : delta;
+    const n = (existing?.n ?? 0) + 1;
+    this.db
+      .prepare(`
+      INSERT INTO priors(subject, kind, ewma_delta, n) VALUES (?, ?, ?, ?)
+      ON CONFLICT(subject, kind) DO UPDATE SET ewma_delta = excluded.ewma_delta, n = excluded.n
+    `)
+      .run(subject, kind, ewma, n);
+  }
+
+  getPrior(subject: string, kind: string): { ewma_delta: number; n: number } | null {
+    const row = this.db
+      .prepare("SELECT ewma_delta, n FROM priors WHERE subject = ? AND kind = ?")
+      .get(subject, kind) as { ewma_delta: number; n: number } | undefined;
+    return row ?? null;
+  }
+
+  // ── lifecycle / migration ────────────────────────────────────────────────
+
+  static fileExists(dbPath: string): boolean {
+    return existsSync(dbPath.replace(/^~/, homedir()));
+  }
+
+  /**
+   * On corruption detected at open time, backup + recreate fresh schema.
+   * Reset subject_state to defaults; rollback_history is lost (acceptable —
+   * archived audit log on disk has the trace).
+   *
+   * **Best-effort contract.** This call closes the bad connection, renames
+   * the corrupt file to `*.corrupt-<ISO>`, and opens a fresh DB. Both
+   * `subject_state` and `rollback_history` are reset; the only durable trace
+   * of pre-corruption applies is the appended audit log on disk. Operators
+   * who need rollback history that survives a corruption event should back
+   * up `~/.config/tuner/wisecron.db` periodically (e.g. via a daily cron
+   * snapshot to a side directory).
+   */
+  recover(): void {
+    try {
+      this.db.close();
+    } catch {
+      /* ignore */
+    }
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const backup = `${this.path}.corrupt-${ts}`;
+    try {
+      renameSync(this.path, backup);
+    } catch {
+      /* ignore if missing */
+    }
+    this.db = new Database(this.path);
+    this.db.exec("PRAGMA journal_mode=WAL;");
+    this.db.exec(SCHEMA);
+  }
+}

--- a/src/tuner/wisecron/telemetry-mcp.ts
+++ b/src/tuner/wisecron/telemetry-mcp.ts
@@ -254,11 +254,17 @@ export class McpTelemetryProvider implements TelemetryProvider {
         ...(filters ? { filters } : {}),
       })) as QueryResult | undefined;
       if (!res || !Array.isArray(res.samples)) return [];
-      return res.samples.map((s) => ({
-        ts: new Date(s.ts),
-        value: s.value,
-        ...(s.labels ? { labels: s.labels } : {}),
-      }));
+      // The wire payload is untrusted (a remote host / transport-unwrap). Drop
+      // samples with a malformed timestamp (→ Invalid Date) or a non-finite value
+      // (NaN/Infinity) rather than propagating them into fitness math.
+      const out: MetricSample[] = [];
+      for (const s of res.samples) {
+        const ts = new Date(s.ts);
+        if (Number.isNaN(ts.getTime())) continue;
+        if (typeof s.value !== "number" || !Number.isFinite(s.value)) continue;
+        out.push({ ts, value: s.value, ...(s.labels ? { labels: s.labels } : {}) });
+      }
+      return out;
     } catch {
       return [];
     }

--- a/src/tuner/wisecron/telemetry-mcp.ts
+++ b/src/tuner/wisecron/telemetry-mcp.ts
@@ -1,7 +1,7 @@
 /**
  * Telemetry over the MCP bridge — the single auditable telemetry surface.
  *
- * Per `~/simon-memory/decisions/tuner-outcome-loop.md` ("host exposes ONE
+ * Host-provided telemetry contract (option A) — the host exposes ONE
  * telemetry surface over the MCP bridge"), the HOST produces telemetry and
  * serves it as two MCP tools; the TUNER consumes it THROUGH those tools and
  * never reads journalctl/files in-process. This module has the two halves:

--- a/src/tuner/wisecron/telemetry-mcp.ts
+++ b/src/tuner/wisecron/telemetry-mcp.ts
@@ -1,0 +1,266 @@
+/**
+ * Telemetry over the MCP bridge — the single auditable telemetry surface.
+ *
+ * Per `~/simon-memory/decisions/tuner-outcome-loop.md` ("host exposes ONE
+ * telemetry surface over the MCP bridge"), the HOST produces telemetry and
+ * serves it as two MCP tools; the TUNER consumes it THROUGH those tools and
+ * never reads journalctl/files in-process. This module has the two halves:
+ *
+ *   HOST side  — `registerHostTelemetryTools(bridge, { provider, audit })`
+ *     registers `telemetry__capabilities` + `telemetry__query` on the
+ *     PluginMcpBridge, backed by an in-process `TelemetryProvider` (the
+ *     reference-host producer `buildHostTelemetryProvider()`). Every served
+ *     query appends a `telemetry_query` record to the tamper-evident AuditLog,
+ *     so the provenance of each measured number is in the chain (on top of the
+ *     bridge's own invoke audit).
+ *
+ *   TUNER side — `McpTelemetryProvider` implements `TelemetryProvider` by
+ *     calling those two tools through a `TelemetryMcpClient`. It talks MCP only.
+ *     Backed in-process by `bridgeToolCaller(bridge)`, or over a real MCP
+ *     transport by `mcpClientToolCaller(client)`. Degrades gracefully: an
+ *     unreachable endpoint yields empty capabilities (every stream → proposal-
+ *     only) and empty query results, never a throw.
+ */
+
+import { z } from "zod";
+import type { PluginMcpBridge } from "../../plugins/mcp-bridge.js";
+import type { AuditLog } from "../../skills-tuner/core/audit-log.js";
+import {
+  type DateRange,
+  type MetricSample,
+  type TelemetryCapability,
+  type TelemetryProvider,
+  type TelemetryStream,
+  TELEMETRY_CONTRACT_VERSION,
+  TELEMETRY_STREAMS,
+} from "../../skills-tuner/core/telemetry.js";
+
+// ── Wire contract ────────────────────────────────────────────────────────────
+
+/** Bridge pluginId for the host telemetry surface (FQN prefix `telemetry__`). */
+export const TELEMETRY_PLUGIN_ID = "telemetry";
+export const TELEMETRY_CAPABILITIES_TOOL = `${TELEMETRY_PLUGIN_ID}__capabilities`;
+export const TELEMETRY_QUERY_TOOL = `${TELEMETRY_PLUGIN_ID}__query`;
+
+/** Wire shape of a sample: `ts` is ISO-8601 over the boundary, Date in memory. */
+interface WireSample {
+  ts: string;
+  value: number;
+  labels?: Record<string, string>;
+}
+
+interface CapabilitiesResult {
+  contractVersion: string;
+  capabilities: TelemetryCapability[];
+}
+
+interface QueryResult {
+  stream: TelemetryStream;
+  contractVersion: string;
+  samples: WireSample[];
+}
+
+const QueryArgsSchema = z.object({
+  stream: z.enum(TELEMETRY_STREAMS),
+  start: z.string(),
+  end: z.string(),
+  filters: z.record(z.string(), z.string()).optional(),
+});
+
+// ── HOST side ──────────────────────────────────────────────────────────────--
+
+export interface RegisterHostTelemetryOpts {
+  /** The in-process producer that actually reads the host's sources. */
+  provider: TelemetryProvider;
+  /** Tamper-evident chain. When supplied, every served query is recorded. */
+  audit?: AuditLog;
+}
+
+/**
+ * Register the host telemetry surface on the MCP bridge. Idempotent per bridge
+ * for the same pluginId — re-registration first unregisters the prior tools.
+ * Returns the FQNs registered.
+ */
+export function registerHostTelemetryTools(
+  bridge: PluginMcpBridge,
+  opts: RegisterHostTelemetryOpts,
+): { capabilitiesTool: string; queryTool: string } {
+  const { provider, audit } = opts;
+
+  // Re-register cleanly so a served process can rebuild the surface.
+  bridge.unregisterPlugin(TELEMETRY_PLUGIN_ID);
+
+  bridge.registerPluginTool(TELEMETRY_PLUGIN_ID, {
+    name: "capabilities",
+    description:
+      "Telemetry contract: which streams the host advertises in this environment, " +
+      "with availability + schema version. No args.",
+    schema: z.object({}),
+    handler: (): CapabilitiesResult => ({
+      contractVersion: provider.contractVersion(),
+      capabilities: provider.capabilities(),
+    }),
+  });
+
+  bridge.registerPluginTool(TELEMETRY_PLUGIN_ID, {
+    name: "query",
+    description:
+      "Pull telemetry samples for one stream over a half-open [start,end) window, " +
+      "optionally filtered by labels. start/end are ISO-8601 timestamps.",
+    schema: QueryArgsSchema,
+    handler: async (args: z.infer<typeof QueryArgsSchema>): Promise<QueryResult> => {
+      const range: DateRange = { start: new Date(args.start), end: new Date(args.end) };
+      if (Number.isNaN(range.start.getTime()) || Number.isNaN(range.end.getTime())) {
+        throw new Error(`invalid range: start=${args.start} end=${args.end}`);
+      }
+      const samples = await provider.query(args.stream, range, args.filters);
+      // Provenance into the tamper-evident chain: which stream, which window,
+      // how many samples answered the measurement, at which schema version.
+      audit?.append({
+        event: "telemetry_query",
+        detail: {
+          stream: args.stream,
+          window_start: range.start.toISOString(),
+          window_end: range.end.toISOString(),
+          ...(args.filters ? { filters: args.filters } : {}),
+          sample_count: samples.length,
+          contract_version: provider.contractVersion(),
+        },
+      });
+      return {
+        stream: args.stream,
+        contractVersion: provider.contractVersion(),
+        samples: samples.map((s) => ({
+          ts: s.ts.toISOString(),
+          value: s.value,
+          ...(s.labels ? { labels: s.labels } : {}),
+        })),
+      };
+    },
+  });
+
+  return { capabilitiesTool: TELEMETRY_CAPABILITIES_TOOL, queryTool: TELEMETRY_QUERY_TOOL };
+}
+
+// ── TUNER side ─────────────────────────────────────────────────────────────--
+
+/**
+ * The transport the tuner uses to reach the host telemetry tools. `callTool`
+ * resolves to the tool handler's RETURN VALUE (already a JS object) — adapters
+ * normalise away any transport envelope. Throws are caught by the provider and
+ * degrade to empty.
+ */
+export interface TelemetryMcpClient {
+  callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
+}
+
+/** In-process caller: invoke through the bridge (HMAC-signed + invoke-audited). */
+export function bridgeToolCaller(bridge: PluginMcpBridge): TelemetryMcpClient {
+  return {
+    callTool: (name, args) => bridge.invokeTool(name, args),
+  };
+}
+
+/** Minimal shape of the MCP SDK Client `callTool` we depend on. */
+interface McpSdkClientLike {
+  callTool(params: { name: string; arguments?: Record<string, unknown> }): Promise<unknown>;
+}
+
+/**
+ * Caller over a real MCP transport. Unwraps the standard
+ * `{ content: [{ type: "text", text }], isError? }` envelope that
+ * `mcp-server.ts` emits and re-parses the JSON the host serialised.
+ */
+export function mcpClientToolCaller(client: McpSdkClientLike): TelemetryMcpClient {
+  return {
+    async callTool(name, args) {
+      const res = (await client.callTool({ name, arguments: args })) as {
+        content?: Array<{ type?: string; text?: string }>;
+        isError?: boolean;
+      };
+      const text = res?.content?.find((c) => c.type === "text")?.text;
+      if (res?.isError) {
+        throw new Error(text ?? `MCP tool ${name} returned isError`);
+      }
+      if (text === undefined) {
+        throw new Error(`MCP tool ${name} returned no text content`);
+      }
+      return JSON.parse(text);
+    },
+  };
+}
+
+/**
+ * `TelemetryProvider` that reads the host telemetry surface over the MCP
+ * bridge. `capabilities()` is synchronous (the activation gate calls it sync),
+ * so capabilities are fetched once via `connect()` and cached; before connect,
+ * or if the endpoint is unreachable, the cache is empty and every stream-based
+ * metric degrades to proposal-only — exactly the absent-host behaviour.
+ */
+export class McpTelemetryProvider implements TelemetryProvider {
+  private cachedCapabilities: TelemetryCapability[] = [];
+  private cachedContractVersion = TELEMETRY_CONTRACT_VERSION;
+  private connected = false;
+
+  constructor(private readonly client: TelemetryMcpClient) {}
+
+  /**
+   * Fetch + cache capabilities from the host over MCP. Call once at wire time
+   * before the activation gate runs. Never throws — a failure leaves the cache
+   * empty (degrade to proposal-only) and is reported in the return value.
+   */
+  async connect(): Promise<{ ok: boolean; reason?: string }> {
+    try {
+      const res = (await this.client.callTool(TELEMETRY_CAPABILITIES_TOOL, {})) as
+        | CapabilitiesResult
+        | undefined;
+      if (!res || !Array.isArray(res.capabilities)) {
+        return { ok: false, reason: "telemetry capabilities endpoint returned no capabilities" };
+      }
+      this.cachedCapabilities = res.capabilities;
+      if (typeof res.contractVersion === "string") {
+        this.cachedContractVersion = res.contractVersion;
+      }
+      this.connected = true;
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, reason: (e as Error).message };
+    }
+  }
+
+  /** True once `connect()` has populated the capability cache. */
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  contractVersion(): string {
+    return this.cachedContractVersion;
+  }
+
+  capabilities(): TelemetryCapability[] {
+    return this.cachedCapabilities;
+  }
+
+  async query(
+    stream: TelemetryStream,
+    range: DateRange,
+    filters?: Record<string, string>,
+  ): Promise<MetricSample[]> {
+    try {
+      const res = (await this.client.callTool(TELEMETRY_QUERY_TOOL, {
+        stream,
+        start: range.start.toISOString(),
+        end: range.end.toISOString(),
+        ...(filters ? { filters } : {}),
+      })) as QueryResult | undefined;
+      if (!res || !Array.isArray(res.samples)) return [];
+      return res.samples.map((s) => ({
+        ts: new Date(s.ts),
+        value: s.value,
+        ...(s.labels ? { labels: s.labels } : {}),
+      }));
+    } catch {
+      return [];
+    }
+  }
+}

--- a/src/tuner/wisecron/telemetry-mcp.ts
+++ b/src/tuner/wisecron/telemetry-mcp.ts
@@ -58,6 +58,9 @@ interface QueryResult {
   stream: TelemetryStream;
   contractVersion: string;
   samples: WireSample[];
+  /** True when the range was clamped and/or the sample array was capped (below).
+   *  Absent means the full requested window is represented. */
+  truncated?: boolean;
 }
 
 const QueryArgsSchema = z.object({
@@ -66,6 +69,19 @@ const QueryArgsSchema = z.object({
   end: z.string(),
   filters: z.record(z.string(), z.string()).optional(),
 });
+
+const DAY_MS = 86_400_000;
+/**
+ * Resource guards for the socket-exposed `telemetry__query`. Both are CLAMP,
+ * not reject, so a slightly-too-wide query still returns useful bounded data
+ * (flagged `truncated`) instead of erroring.
+ *  - MAX window: an unbounded [2020,2030) range would pull all history into one
+ *    in-memory MCP response. Cap it; keep the most recent window.
+ *  - MAX samples: cap the returned array regardless of window so a dense stream
+ *    can't blow the response size either.
+ */
+export const MAX_QUERY_WINDOW_DAYS = 90;
+export const MAX_QUERY_SAMPLES = 5_000;
 
 // ── HOST side ──────────────────────────────────────────────────────────────--
 
@@ -109,13 +125,30 @@ export function registerHostTelemetryTools(
       "optionally filtered by labels. start/end are ISO-8601 timestamps.",
     schema: QueryArgsSchema,
     handler: async (args: z.infer<typeof QueryArgsSchema>): Promise<QueryResult> => {
-      const range: DateRange = { start: new Date(args.start), end: new Date(args.end) };
-      if (Number.isNaN(range.start.getTime()) || Number.isNaN(range.end.getTime())) {
+      const start = new Date(args.start);
+      const end = new Date(args.end);
+      if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
         throw new Error(`invalid range: start=${args.start} end=${args.end}`);
       }
-      const samples = await provider.query(args.stream, range, args.filters);
-      // Provenance into the tamper-evident chain: which stream, which window,
-      // how many samples answered the measurement, at which schema version.
+      // Guard the window: clamp anything wider than MAX_QUERY_WINDOW_DAYS to the
+      // most-recent slice so a runaway [2020,2030) can't pull all history into
+      // one in-memory response.
+      let truncated = false;
+      let effectiveStart = start;
+      if (end.getTime() - start.getTime() > MAX_QUERY_WINDOW_DAYS * DAY_MS) {
+        effectiveStart = new Date(end.getTime() - MAX_QUERY_WINDOW_DAYS * DAY_MS);
+        truncated = true;
+      }
+      const range: DateRange = { start: effectiveStart, end };
+      let samples = await provider.query(args.stream, range, args.filters);
+      // Guard the response size: cap the array regardless of window.
+      if (samples.length > MAX_QUERY_SAMPLES) {
+        samples = samples.slice(0, MAX_QUERY_SAMPLES);
+        truncated = true;
+      }
+      // Provenance into the tamper-evident chain: which stream, which (clamped)
+      // window, how many samples answered the measurement, whether it was
+      // truncated, at which schema version.
       audit?.append({
         event: "telemetry_query",
         detail: {
@@ -124,6 +157,7 @@ export function registerHostTelemetryTools(
           window_end: range.end.toISOString(),
           ...(args.filters ? { filters: args.filters } : {}),
           sample_count: samples.length,
+          ...(truncated ? { truncated: true } : {}),
           contract_version: provider.contractVersion(),
         },
       });
@@ -135,6 +169,7 @@ export function registerHostTelemetryTools(
           value: s.value,
           ...(s.labels ? { labels: s.labels } : {}),
         })),
+        ...(truncated ? { truncated: true } : {}),
       };
     },
   });

--- a/src/tuner/wisecron/tuner-view-provider.ts
+++ b/src/tuner/wisecron/tuner-view-provider.ts
@@ -11,10 +11,12 @@
 
 import {
   type DateRange,
+  type MetricSample,
   type PanelData,
   type TelemetryCapability,
   TELEMETRY_CONTRACT_VERSION,
   type TelemetryProvider,
+  type TelemetryStream,
   type ViewManifest,
 } from "../../skills-tuner/core/telemetry.js";
 import type { ProposalsStore } from "../../skills-tuner/storage/proposals.js";
@@ -42,7 +44,14 @@ export class TunerViewProvider implements TelemetryProvider {
     return [];
   }
 
-  async query(): Promise<never[]> {
+  // View-only provider: it serves panels (getView), not metric streams, but
+  // implements the full TelemetryProvider contract so it composes uniformly.
+  // query() therefore matches the interface signature and returns no samples.
+  async query(
+    _stream: TelemetryStream,
+    _range: DateRange,
+    _filters?: Record<string, string>,
+  ): Promise<MetricSample[]> {
     return [];
   }
 

--- a/src/tuner/wisecron/tuner-view-provider.ts
+++ b/src/tuner/wisecron/tuner-view-provider.ts
@@ -96,9 +96,18 @@ export class TunerViewProvider implements TelemetryProvider {
 
       const id = String(rec.proposal.id);
       const outcomes = this.sources.outcomesFor(id);
-      // Prefer a matured outcome (non-null verdict); else the first row so the
-      // timeline still shows the pending change with delta/verdict blank.
-      const outcome = outcomes.find((o) => o.verdict !== null) ?? outcomes[0];
+      // A proposal can have several matured outcomes (target + guardrails).
+      // getOutcomes orders by metric ASC, so `find(verdict != null)` would surface
+      // whichever metric sorts first alphabetically — often a neutral guardrail
+      // rather than the metric that drove the decision. Prefer a DECISIVE verdict
+      // (improved/regressed) so the panel shows the outcome that actually
+      // determined the change; else any matured row; else the first (pending) row
+      // so a not-yet-matured change still appears with delta/verdict blank.
+      const matured = outcomes.filter((o) => o.verdict !== null);
+      const outcome =
+        matured.find((o) => o.verdict === "improved" || o.verdict === "regressed") ??
+        matured[0] ??
+        outcomes[0];
 
       rows.push({
         ts: rec.ts,

--- a/src/tuner/wisecron/tuner-view-provider.ts
+++ b/src/tuner/wisecron/tuner-view-provider.ts
@@ -1,0 +1,107 @@
+/**
+ * The tuner DECLARES its own observability page — the hub does not hardcode it.
+ *
+ * This is the first specialized page: a `timeline` of applied tuning proposals
+ * mapped to their measured outcomes (subject → {change, delta, verdict, branch,
+ * commit, ts}), sourced from the EXISTING surfaces — the proposals ledger
+ * (`proposals.jsonl`) joined to the outcomes table (wisecron.db) and the
+ * hash-chained audit trail. It implements only the view side of the telemetry
+ * contract (`viewManifest`/`viewData`); it advertises no streams.
+ */
+
+import {
+  type DateRange,
+  type PanelData,
+  type TelemetryCapability,
+  TELEMETRY_CONTRACT_VERSION,
+  type TelemetryProvider,
+  type ViewManifest,
+} from "../../skills-tuner/core/telemetry.js";
+import type { ProposalsStore } from "../../skills-tuner/storage/proposals.js";
+import type { OutcomeRow } from "./state-db.js";
+
+export const TUNER_PLUGIN = "tuner";
+export const TUNER_TIMELINE_PANEL = "tuner.timeline";
+
+export interface TunerViewSources {
+  /** The applied/created/refused proposal ledger. */
+  proposals: ProposalsStore;
+  /** Outcome rows for a proposal_id — bind `WisecronStateDB.getOutcomes`. */
+  outcomesFor: (proposalId: string) => OutcomeRow[];
+}
+
+export class TunerViewProvider implements TelemetryProvider {
+  constructor(private readonly sources: TunerViewSources) {}
+
+  contractVersion(): string {
+    return TELEMETRY_CONTRACT_VERSION;
+  }
+
+  /** No streams — this provider is view-only. */
+  capabilities(): TelemetryCapability[] {
+    return [];
+  }
+
+  async query(): Promise<never[]> {
+    return [];
+  }
+
+  viewManifest(): ViewManifest {
+    return {
+      plugin: TUNER_PLUGIN,
+      schemaVersion: "1.0.0",
+      metrics: [
+        {
+          name: "applied_proposals",
+          unit: "count",
+          direction: "neutral",
+          description: "Tuning changes applied in the window",
+        },
+        {
+          name: "improved_rate",
+          unit: "ratio",
+          direction: "up_good",
+          description: "Share of matured outcomes judged 'improved'",
+        },
+      ],
+      panels: [
+        {
+          id: TUNER_TIMELINE_PANEL,
+          kind: "timeline",
+          title: "Tuning proposals → outcomes",
+          columns: ["ts", "subject", "change", "delta", "verdict", "branch", "commit"],
+        },
+      ],
+    };
+  }
+
+  async viewData(panelId: string, range: DateRange): Promise<PanelData | undefined> {
+    if (panelId !== TUNER_TIMELINE_PANEL) return undefined;
+
+    const rows: Array<Record<string, unknown>> = [];
+    for (const rec of this.sources.proposals.readAll()) {
+      if (rec.event !== "applied") continue;
+      const ts = new Date(rec.ts);
+      if (Number.isNaN(ts.getTime())) continue;
+      if (ts < range.start || ts >= range.end) continue;
+
+      const id = String(rec.proposal.id);
+      const outcomes = this.sources.outcomesFor(id);
+      // Prefer a matured outcome (non-null verdict); else the first row so the
+      // timeline still shows the pending change with delta/verdict blank.
+      const outcome = outcomes.find((o) => o.verdict !== null) ?? outcomes[0];
+
+      rows.push({
+        ts: rec.ts,
+        subject: rec.proposal.subject,
+        change: `${rec.proposal.kind}: ${rec.applied_target_path ?? rec.proposal.target_path}`,
+        delta: outcome?.delta ?? null,
+        verdict: outcome?.verdict ?? null,
+        branch: `tune/proposal-${rec.proposal.id}`,
+        commit: rec.commit_sha ?? outcome?.commit_sha ?? null,
+      });
+    }
+    rows.sort((a, b) => String(b.ts).localeCompare(String(a.ts)));
+    return { panelId, rows };
+  }
+}

--- a/src/tuner/wisecron/types.ts
+++ b/src/tuner/wisecron/types.ts
@@ -157,7 +157,10 @@ export const WisecronSettingsSchema = z.object({
     .record(
       z.string(),
       z.object({
-        enabled: z.boolean(),
+        // Not required: the reader treats a missing `enabled` as enabled
+        // (`subjects?.[name]?.enabled !== false`), so default it to match rather
+        // than force every listed subject to spell it out (schema/reader parity).
+        enabled: z.boolean().default(true),
         /** Per-subject scope override. Falls back to the global `scope` when omitted. */
         scope: z.enum(SCOPES).optional(),
         /**

--- a/src/tuner/wisecron/types.ts
+++ b/src/tuner/wisecron/types.ts
@@ -1,0 +1,186 @@
+import { z } from "zod";
+import type { Patch, Proposal, UnsignedProposal } from "../../skills-tuner/core/types.js";
+import type { RiskTier } from "../../skills-tuner/core/interfaces.js";
+import { SCOPES } from "../../skills-tuner/core/scope.js";
+
+// ── Adaptive scheduling ─────────────────────────────────────────────────────
+
+export const ScheduleStateSchema = z.object({
+  subject: z.string(),
+  last_run: z.coerce.date(),
+  next_run: z.coerce.date(),
+  current_interval_hours: z.number().int().min(1).max(168),
+  consecutive_zero_runs: z.number().int().min(0),
+  last_proposal_count: z.number().int().min(0),
+  enabled: z.boolean(),
+});
+export type ScheduleState = z.infer<typeof ScheduleStateSchema>;
+
+export const INITIAL_INTERVAL_HOURS = 24;
+export const MAX_INTERVAL_HOURS = 168;
+export const HIGH_RISK_OBSERVATION_WINDOW_MS = 5 * 60 * 1000;
+
+// ── Rollback history ────────────────────────────────────────────────────────
+
+export const AppliedBy = z.enum(["cli", "telegram", "auto-revert", "mcp", "research"]);
+export type AppliedBy = z.infer<typeof AppliedBy>;
+
+export const RevisionRecordSchema = z.object({
+  id: z.number().int(),
+  proposal_id: z.string(),
+  subject: z.string(),
+  applied_at: z.coerce.date(),
+  forward_patch: z.object({
+    target_path: z.string(),
+    kind: z.string(),
+    applied_content: z.string(),
+  }),
+  inverse_patch: z.object({
+    target_path: z.string(),
+    kind: z.string(),
+    applied_content: z.string(),
+  }),
+  applied_by: AppliedBy,
+  rolled_back_at: z.coerce.date().nullable(),
+});
+export type RevisionRecord = z.infer<typeof RevisionRecordSchema>;
+
+// ── Subject contract extension ──────────────────────────────────────────────
+//
+// All 8 new wisecron subjects implement this surface on top of TunableSubject.
+// `apply()` must return a Patch (existing TunableSubject contract). `revert()`
+// is wisecron-specific — it consumes the inverse_patch persisted in
+// rollback_history.
+
+export interface RevertibleSubject {
+  readonly name: string;
+  readonly risk_tier: RiskTier;
+  revert(inversePatch: Patch): Promise<void>;
+}
+
+// ── Proposal lifecycle ──────────────────────────────────────────────────────
+
+export interface ProposalSummary {
+  proposal: Proposal;
+  subject: string;
+  risk_tier: RiskTier;
+  diff_preview: string;
+}
+
+export interface ProposalCycleResult {
+  subject: string;
+  observations: number;
+  clusters: number;
+  proposals: UnsignedProposal[];
+  duration_ms: number;
+}
+
+// ── Apply pipeline ──────────────────────────────────────────────────────────
+
+export interface ApplyOutcome {
+  revision: RevisionRecord;
+  observation_window_armed: boolean;
+  auto_reverted: boolean;
+  audit_event_id: string;
+}
+
+export interface ObservationWindowResult {
+  reverted: boolean;
+  reason: string | null;
+  errors_detected: string[];
+}
+
+// ── External (subprocess-backed) subjects ───────────────────────────────────
+//
+// A subject whose logic lives in an out-of-process program speaking the
+// ExternalProcessSubject JSON-RPC protocol. ClaudeClaw stays GENERIC: the code
+// hardcodes no specific external program. Operators declare their own under
+// `wisecron.external_subjects` in their PRIVATE config.yaml (command + cwd +
+// allowedRoots + fitnessSignals). This keeps the upstream-shippable code free of
+// any one operator's tool while still enabling subprocess subjects.
+
+/** Mirrors `Metric` in ../../skills-tuner/core/telemetry.ts. `source` is a
+ *  TelemetryStream name or the literal "artifact" — kept as a free string so
+ *  new streams need no schema bump; the activation gate degrades unknowns. */
+export const MetricConfigSchema = z.object({
+  name: z.string(),
+  source: z.string(),
+  kind: z.enum(["verifiable", "judge", "proxy_state"]).default("verifiable"),
+  direction: z.enum(["lower_is_better", "higher_is_better"]),
+  windowDays: z.number().int().min(0),
+  guardrails: z.array(z.string()).optional(),
+});
+
+export const ExternalSubjectSettingsSchema = z.object({
+  /** Unique subject name (registry key). */
+  name: z.string(),
+  /** Enabled flag (parallels per-subject enabled). */
+  enabled: z.boolean().default(true),
+  /** argv of the subprocess; command[0] is the executable. */
+  command: z.array(z.string()).min(1),
+  /** Working directory for the subprocess. */
+  cwd: z.string().optional(),
+  /** Extra environment variables merged over the parent process env. */
+  env: z.record(z.string(), z.string()).optional(),
+  /** Write-zone allowlist for apply() patches (REQUIRED before any apply). */
+  allowedRoots: z.array(z.string()).optional(),
+  riskTier: z.enum(["low", "medium", "high", "critical"]).optional(),
+  autoMergeDefault: z.boolean().optional(),
+  supportsCreation: z.boolean().optional(),
+  orphanMinObservations: z.number().int().min(0).optional(),
+  timeoutMs: z.number().int().min(1).optional(),
+  /** Opaque config object forwarded verbatim in every RPC envelope. */
+  config: z.record(z.string(), z.unknown()).optional(),
+  /** Static fitness declaration (sync, no RPC) — see ExternalProcessConfig. */
+  fitnessSignals: z.array(MetricConfigSchema).optional(),
+});
+export type ExternalSubjectSettings = z.infer<typeof ExternalSubjectSettingsSchema>;
+
+// ── Wisecron settings (extends TunerConfig.wisecron section) ────────────────
+
+export const WisecronSettingsSchema = z.object({
+  enabled: z.boolean().default(false),
+  /**
+   * Global tuning scope for the wisecron-managed subjects (mirrors
+   * TunerConfig.scope for this subject set). `all` reads every stream unfiltered;
+   * `agent` restricts each subject to agent-originated telemetry. Override per
+   * subject via `subjects.<name>.scope`. See ../../skills-tuner/core/scope.ts.
+   */
+  scope: z.enum(SCOPES).default("all"),
+  db_path: z.string().default("~/.config/tuner/wisecron.db"),
+  systemd_unit_prefix: z.string().default("wisecron-"),
+  initial_interval_hours: z.number().int().min(1).default(INITIAL_INTERVAL_HOURS),
+  max_interval_hours: z.number().int().min(1).default(MAX_INTERVAL_HOURS),
+  llm_model_for_propose: z.string().default("claude-sonnet-4-6"),
+  llm_call_path: z.enum(["direct-sdk", "llm-router"]).default("direct-sdk"),
+  subjects: z
+    .record(
+      z.string(),
+      z.object({
+        enabled: z.boolean(),
+        /** Per-subject scope override. Falls back to the global `scope` when omitted. */
+        scope: z.enum(SCOPES).optional(),
+        /**
+         * Per-subject ctor overrides. Forwarded verbatim to the subject's
+         * constructor opts (e.g. `{ hooksDir: '~/agent/hooks' }`). Keys recognised
+         * are subject-specific — see each subject's `*SubjectConfig` interface and
+         * the wisecron README "Per-subject config" table.
+         */
+        config: z.record(z.string(), z.unknown()).optional(),
+      }),
+    )
+    .default({}),
+  rollback: z
+    .object({
+      retention_days: z.number().int().min(1).default(90),
+      require_confirm_on_rollback: z.boolean().default(true),
+    })
+    .default({}),
+  /**
+   * Subprocess-backed subjects (ExternalProcessSubject). Empty by default, so
+   * the generic upstream build registers none. Operators add their own in their
+   * private config.yaml. See ExternalSubjectSettingsSchema.
+   */
+  external_subjects: z.array(ExternalSubjectSettingsSchema).default([]),
+});
+export type WisecronSettings = z.infer<typeof WisecronSettingsSchema>;


### PR DESCRIPTION
**Draft — the read-only measurement brick from the #275 staging (extends #116).**

Per your #275 note ("host-telemetry over MCP first — read-only, non-mutating, builds on the telemetry already in main, a clean easy-to-review first PR"), this is exactly that brick. No OutcomeLoop, no mutating `tuner__*` gate — those are the next PR (model-routing subject first).

## What it adds
A telemetry surface on the existing `PluginMcpBridge`:
- `telemetry__capabilities` + `telemetry__query` (host side, `registerHostTelemetryTools`)
- `McpTelemetryProvider` — the tuner-side **consumer, bundled in the same diff** (talks MCP only; in-process via `bridgeToolCaller` or over a real transport). Graceful degradation: an unreachable endpoint → empty capabilities/results, never a throw.
- Every served query appends a `telemetry_query` record to the tamper-evident `AuditLog` — provenance for each measured number.

Builds on what main already ships: `governance/telemetry.ts`, `orchestrator/telemetry.ts`, `plugins/mcp-bridge.ts`.

## Coverage — one stream per tunable subject
So every subject can measure fitness (the whole point of the loop that comes next):

| stream | feeds subject |
|---|---|
| `mode_dispatch` | model-routing *(the loop's first subject)* |
| `tool_call` | mcp-plugin |
| `memory_access` | memory |
| `hook_exec` | hooks |
| `cron_run` + `session_cost` | scheduler/cron |
| `template_feedback` | prompt-template |
| `agent_dispatch` | agents |
| `mcp.tool_call` | universal per-plugin gateway hub (auto-discovery) |
| `skill_access` | skill usage |

Each reference producer owns one stream, reads a single real source, and advertises `available:false` + reason when the source is absent — **declared-but-inactive by design, never faked data.**

## Scope / what's deliberately NOT here
- The `OutcomeLoop` and the **mutating `tuner__*` gate** (`serveTunerOverMcp`) — next brick.
- The end-to-end-over-real-transport test ships with that brick; the in-process bridge tests here cover the host + client contract.

## Tests
55 pass — host register, in-process client round-trip, graceful degradation, audit provenance/chain, per-producer derivation + availability. Fixtures use now-relative windows so the `capabilities()` 30-day wall-clock probe never drifts.

Marking draft for your read on shape/placement before I polish (notably: these land under `tuner/wisecron/` + `skills-tuner/core/` matching the current tree — happy to relocate if you'd prefer a different home as part of the skills-tuner→wisecron consolidation we discussed in #275).
