### PR TITLE
feat(telemetry): skill_access producer hook (closes the declared-but-inert stream)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-<<<<<<< HEAD
-      "version": "2.2.182",
-||||||| parent of 85d918b (feat(telemetry): skill_access producer — PostToolUse hook so the stream actually emits)
-      "version": "2.2.168",
-=======
-      "version": "2.2.169",
->>>>>>> 85d918b (feat(telemetry): skill_access producer — PostToolUse hook so the stream actually emits)
+      "version": "2.2.183",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,13 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
+<<<<<<< HEAD
       "version": "2.2.182",
+||||||| parent of 85d918b (feat(telemetry): skill_access producer — PostToolUse hook so the stream actually emits)
+      "version": "2.2.168",
+=======
+      "version": "2.2.169",
+>>>>>>> 85d918b (feat(telemetry): skill_access producer — PostToolUse hook so the stream actually emits)
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,11 @@
 {
   "name": "claudeclaw-plus",
+<<<<<<< HEAD
   "version": "2.2.182",
+||||||| parent of 85d918b (feat(telemetry): skill_access producer — PostToolUse hook so the stream actually emits)
+  "version": "2.2.168",
+=======
+  "version": "2.2.169",
+>>>>>>> 85d918b (feat(telemetry): skill_access producer — PostToolUse hook so the stream actually emits)
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,5 @@
 {
   "name": "claudeclaw-plus",
-<<<<<<< HEAD
-  "version": "2.2.182",
-||||||| parent of 85d918b (feat(telemetry): skill_access producer — PostToolUse hook so the stream actually emits)
-  "version": "2.2.168",
-=======
-  "version": "2.2.169",
->>>>>>> 85d918b (feat(telemetry): skill_access producer — PostToolUse hook so the stream actually emits)
+  "version": "2.2.183",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,23 +1,3 @@
 {
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/guard-bash-backgrounding.mjs\""
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Read",
-        "hooks": [
-          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/log-skill-access.mjs\"" }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,3 +1,15 @@
 {
-  "hooks": {}
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/guard-bash-backgrounding.mjs\""
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -10,6 +10,14 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/log-skill-access.mjs\"" }
+        ]
+      }
     ]
   }
 }

--- a/hooks/log-skill-access.mjs
+++ b/hooks/log-skill-access.mjs
@@ -9,8 +9,21 @@
  *
  *   log path:   $CLAUDECLAW_SKILL_ACCESS_LOG  (default ~/.config/tuner/skill_accesses.jsonl)
  *   skills dir: $CLAUDECLAW_SKILLS_DIR         (default ~/.claude/skills)
+ *
+ * OPT-IN — ships DISABLED. A PostToolUse(Read) matcher is tool-name only (it can't
+ * pre-filter to skill paths), so registering it always-on would fork a node process
+ * on EVERY Read just to return null — standing per-read latency on a lightweight
+ * daemon, feeding a stream nothing consumes until the #286 host-telemetry consumer
+ * is live. So hooks/hooks.json ships with no PostToolUse entry. Enable it once the
+ * consumer lands by adding this to your hooks config:
+ *
+ *   "PostToolUse": [
+ *     { "matcher": "Read", "hooks": [
+ *       { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/log-skill-access.mjs\"" }
+ *     ] }
+ *   ]
  */
-import { appendFileSync, mkdirSync, realpathSync } from "node:fs";
+import { appendFileSync, mkdirSync, realpathSync, renameSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname, sep, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -18,6 +31,19 @@ import { pathToFileURL } from "node:url";
 /** The consumer's contract paths (must match SkillAccessTelemetryProducer). */
 export const DEFAULT_SKILLS_DIR = join(homedir(), ".claude", "skills");
 export const DEFAULT_LOG_PATH = join(homedir(), ".config", "tuner", "skill_accesses.jsonl");
+/** The producer owns its own trim: rotate the append-only log to `<path>.1` once
+ *  it passes this size so it can't grow unbounded (one prior segment retained). */
+export const MAX_LOG_BYTES = 5 * 1024 * 1024;
+
+/** Rotate the log to `<path>.1` if it has grown past MAX_LOG_BYTES. Best-effort:
+ *  a stat/rename failure must never block the write (the log is telemetry). */
+export function rotateIfNeeded(log, maxBytes = MAX_LOG_BYTES) {
+  try {
+    if (statSync(log).size >= maxBytes) renameSync(log, `${log}.1`);
+  } catch {
+    /* first write (no file yet) or a race — nothing to rotate */
+  }
+}
 
 /**
  * Pure: the log entry for a PostToolUse payload, or null if it is not a SUCCESSFUL
@@ -58,6 +84,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       if (!entry) return;
       const log = process.env.CLAUDECLAW_SKILL_ACCESS_LOG || DEFAULT_LOG_PATH;
       mkdirSync(dirname(log), { recursive: true });
+      rotateIfNeeded(log);
       appendFileSync(log, JSON.stringify(entry) + "\n");
     } catch {
       /* never block or fail the tool on a logging error */

--- a/hooks/log-skill-access.mjs
+++ b/hooks/log-skill-access.mjs
@@ -1,41 +1,62 @@
 #!/usr/bin/env node
 /**
  * skill_access PRODUCER — a PostToolUse(Read) hook that appends one line to the
- * skill-access log every time a skill file under the skills directory is read.
+ * skill-access log every time a skill file UNDER the skills directory is read.
  *
  * This is the producer the `skill_access` telemetry stream consumes (see the
  * SkillAccessTelemetryProducer, host telemetry). Without it the stream is declared
- * but inert: the host advertises `skill_access` yet never emits. The hook closes
- * that gap with zero dependencies (Node only) and never blocks the tool.
+ * but inert. Zero dependencies (Node only). Never blocks or fails the tool.
  *
  *   log path:   $CLAUDECLAW_SKILL_ACCESS_LOG  (default ~/.config/tuner/skill_accesses.jsonl)
  *   skills dir: $CLAUDECLAW_SKILLS_DIR         (default ~/.claude/skills)
  */
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, mkdirSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, dirname, sep } from "node:path";
+import { join, dirname, sep, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
-/** Pure: the log entry for a PostToolUse payload, or null if it is not a skill read. */
+/** The consumer's contract paths (must match SkillAccessTelemetryProducer). */
+export const DEFAULT_SKILLS_DIR = join(homedir(), ".claude", "skills");
+export const DEFAULT_LOG_PATH = join(homedir(), ".config", "tuner", "skill_accesses.jsonl");
+
+/**
+ * Pure: the log entry for a PostToolUse payload, or null if it is not a SUCCESSFUL
+ * skill read. Both paths are RESOLVED first (collapses `..`, trailing separators and
+ * non-canonical segments) so the boundary test is exact, not a raw string prefix.
+ */
 export function skillAccessEntry(payload, skillsDir, nowIso) {
   if (!payload || payload.tool_name !== "Read") return null;
-  const fp = payload.tool_input && typeof payload.tool_input.file_path === "string" ? payload.tool_input.file_path : "";
-  if (!fp) return null;
-  // only reads UNDER the skills dir count (a real subdir/file boundary, not a prefix coincidence)
-  if (fp !== skillsDir && !fp.startsWith(skillsDir + sep)) return null;
+  // Don't inflate telemetry with FAILED reads.
+  const resp = payload.tool_response;
+  if (resp && (resp.is_error === true || typeof resp.error === "string")) return null;
+  const fpRaw = payload.tool_input && typeof payload.tool_input.file_path === "string" ? payload.tool_input.file_path : "";
+  if (!fpRaw) return null;
+  const fp = resolve(fpRaw);
+  const base = resolve(skillsDir);
+  if (fp !== base && !fp.startsWith(base + sep)) return null;
   return { skill_path: fp, accessed_at: nowIso };
 }
 
-// Run as a hook (stdin = the PostToolUse JSON). Importable for tests via the guard.
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Run as a hook (stdin = the PostToolUse JSON). The guard uses pathToFileURL so it
+// is correct under percent-encoding (spaces) and on Windows — not a raw concat.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.stdin.on("error", () => {}); // a stream error must never crash the hook
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (c) => { input += c; });
   process.stdin.on("end", () => {
     try {
-      const skillsDir = process.env.CLAUDECLAW_SKILLS_DIR || join(homedir(), ".claude", "skills");
-      const entry = skillAccessEntry(JSON.parse(input || "{}"), skillsDir, new Date().toISOString());
+      let skillsDir = process.env.CLAUDECLAW_SKILLS_DIR || DEFAULT_SKILLS_DIR;
+      try { skillsDir = realpathSync.native(skillsDir); } catch { /* dir may not exist yet */ }
+      const payload = JSON.parse(input || "{}");
+      // Resolve the read path's symlinks (the file exists post-read) so a symlink
+      // pointing OUTSIDE the skills dir is correctly rejected; fall back to raw.
+      if (payload.tool_input && typeof payload.tool_input.file_path === "string") {
+        try { payload.tool_input.file_path = realpathSync.native(payload.tool_input.file_path); } catch { /* keep raw */ }
+      }
+      const entry = skillAccessEntry(payload, skillsDir, new Date().toISOString());
       if (!entry) return;
-      const log = process.env.CLAUDECLAW_SKILL_ACCESS_LOG || join(homedir(), ".config", "tuner", "skill_accesses.jsonl");
+      const log = process.env.CLAUDECLAW_SKILL_ACCESS_LOG || DEFAULT_LOG_PATH;
       mkdirSync(dirname(log), { recursive: true });
       appendFileSync(log, JSON.stringify(entry) + "\n");
     } catch {

--- a/hooks/log-skill-access.mjs
+++ b/hooks/log-skill-access.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * skill_access PRODUCER — a PostToolUse(Read) hook that appends one line to the
+ * skill-access log every time a skill file under the skills directory is read.
+ *
+ * This is the producer the `skill_access` telemetry stream consumes (see the
+ * SkillAccessTelemetryProducer, host telemetry). Without it the stream is declared
+ * but inert: the host advertises `skill_access` yet never emits. The hook closes
+ * that gap with zero dependencies (Node only) and never blocks the tool.
+ *
+ *   log path:   $CLAUDECLAW_SKILL_ACCESS_LOG  (default ~/.config/tuner/skill_accesses.jsonl)
+ *   skills dir: $CLAUDECLAW_SKILLS_DIR         (default ~/.claude/skills)
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname, sep } from "node:path";
+
+/** Pure: the log entry for a PostToolUse payload, or null if it is not a skill read. */
+export function skillAccessEntry(payload, skillsDir, nowIso) {
+  if (!payload || payload.tool_name !== "Read") return null;
+  const fp = payload.tool_input && typeof payload.tool_input.file_path === "string" ? payload.tool_input.file_path : "";
+  if (!fp) return null;
+  // only reads UNDER the skills dir count (a real subdir/file boundary, not a prefix coincidence)
+  if (fp !== skillsDir && !fp.startsWith(skillsDir + sep)) return null;
+  return { skill_path: fp, accessed_at: nowIso };
+}
+
+// Run as a hook (stdin = the PostToolUse JSON). Importable for tests via the guard.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  let input = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (c) => { input += c; });
+  process.stdin.on("end", () => {
+    try {
+      const skillsDir = process.env.CLAUDECLAW_SKILLS_DIR || join(homedir(), ".claude", "skills");
+      const entry = skillAccessEntry(JSON.parse(input || "{}"), skillsDir, new Date().toISOString());
+      if (!entry) return;
+      const log = process.env.CLAUDECLAW_SKILL_ACCESS_LOG || join(homedir(), ".config", "tuner", "skill_accesses.jsonl");
+      mkdirSync(dirname(log), { recursive: true });
+      appendFileSync(log, JSON.stringify(entry) + "\n");
+    } catch {
+      /* never block or fail the tool on a logging error */
+    }
+  });
+}

--- a/hooks/log-skill-access.mjs
+++ b/hooks/log-skill-access.mjs
@@ -5,7 +5,10 @@
  *
  * This is the producer the `skill_access` telemetry stream consumes (see the
  * SkillAccessTelemetryProducer, host telemetry). Without it the stream is declared
- * but inert. Zero dependencies (Node only). Never blocks or fails the tool.
+ * but inert. Zero dependencies (Node only). Runs as a separate process off the
+ * agent's loop and never *fails* the tool: it swallows every error and does only a
+ * tiny synchronous local append (a rotate + one line), so its latency is bounded
+ * and it can't wedge the caller.
  *
  *   log path:   $CLAUDECLAW_SKILL_ACCESS_LOG  (default ~/.config/tuner/skill_accesses.jsonl)
  *   skills dir: $CLAUDECLAW_SKILLS_DIR         (default ~/.claude/skills)
@@ -65,7 +68,9 @@ export function skillAccessEntry(payload, skillsDir, nowIso) {
 
 // Run as a hook (stdin = the PostToolUse JSON). The guard uses pathToFileURL so it
 // is correct under percent-encoding (spaces) and on Windows — not a raw concat.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// `resolve()` first: pathToFileURL requires an ABSOLUTE path, but argv[1] can be
+// relative (`node ./hooks/log-skill-access.mjs`), which would otherwise throw.
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
   process.stdin.on("error", () => {}); // a stream error must never crash the hook
   let input = "";
   process.stdin.setEncoding("utf8");

--- a/src/__tests__/skill-access-producer.test.ts
+++ b/src/__tests__/skill-access-producer.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { skillAccessEntry } from "../../hooks/log-skill-access.mjs";
+
+const NOW = "2026-06-30T00:00:00Z";
+const SKILLS = "/home/x/.claude/skills";
+const HOOK = join(import.meta.dir, "..", "..", "hooks", "log-skill-access.mjs");
+
+describe("skill_access producer — skillAccessEntry (pure)", () => {
+  it("logs a Read under the skills dir", () => {
+    expect(
+      skillAccessEntry(
+        { tool_name: "Read", tool_input: { file_path: `${SKILLS}/foo/SKILL.md` } },
+        SKILLS,
+        NOW,
+      ),
+    ).toEqual({ skill_path: `${SKILLS}/foo/SKILL.md`, accessed_at: NOW });
+  });
+  it("ignores a Read OUTSIDE the skills dir", () => {
+    expect(
+      skillAccessEntry(
+        { tool_name: "Read", tool_input: { file_path: "/home/x/notes.md" } },
+        SKILLS,
+        NOW,
+      ),
+    ).toBeNull();
+  });
+  it("ignores a non-Read tool", () => {
+    expect(
+      skillAccessEntry(
+        { tool_name: "Edit", tool_input: { file_path: `${SKILLS}/foo.md` } },
+        SKILLS,
+        NOW,
+      ),
+    ).toBeNull();
+  });
+  it("rejects a prefix-coincidence (…/skills-evil)", () => {
+    expect(
+      skillAccessEntry(
+        { tool_name: "Read", tool_input: { file_path: `${SKILLS}-evil/x.md` } },
+        SKILLS,
+        NOW,
+      ),
+    ).toBeNull();
+  });
+  it("ignores a missing/blank file_path", () => {
+    expect(skillAccessEntry({ tool_name: "Read", tool_input: {} }, SKILLS, NOW)).toBeNull();
+    expect(skillAccessEntry({}, SKILLS, NOW)).toBeNull();
+  });
+});
+
+describe("skill_access producer — hook integration", () => {
+  let dir: string, log: string, skillsDir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "skacc-"));
+    log = join(dir, "access.jsonl");
+    skillsDir = join(dir, "skills");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  const run = (payload: unknown) =>
+    spawnSync("node", [HOOK], {
+      input: JSON.stringify(payload),
+      env: { ...process.env, CLAUDECLAW_SKILL_ACCESS_LOG: log, CLAUDECLAW_SKILLS_DIR: skillsDir },
+      encoding: "utf8",
+    });
+
+  it("appends one line for a skill read, nothing for a non-skill read", () => {
+    run({ tool_name: "Read", tool_input: { file_path: join(skillsDir, "a", "SKILL.md") } });
+    run({ tool_name: "Read", tool_input: { file_path: "/tmp/other.md" } });
+    expect(existsSync(log)).toBe(true);
+    const lines = readFileSync(log, "utf8").trim().split("\n").filter(Boolean);
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!).skill_path).toContain("SKILL.md");
+  });
+
+  it("never errors on malformed input (does not block the tool)", () => {
+    const r = run("not json at all" as unknown);
+    expect(r.status).toBe(0);
+    expect(existsSync(log)).toBe(false);
+  });
+});

--- a/src/__tests__/skill-access-producer.test.ts
+++ b/src/__tests__/skill-access-producer.test.ts
@@ -112,9 +112,12 @@ describe("skill_access producer — hook integration", () => {
     mkdirSync(skillsDir, { recursive: true });
   });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
-  const run = (payload: unknown) =>
+  const run = (payload: unknown) => runRaw(JSON.stringify(payload));
+  // Sends the stdin bytes verbatim (no JSON.stringify) so we can feed genuinely
+  // malformed JSON, not a valid JSON string.
+  const runRaw = (input: string) =>
     spawnSync("node", [HOOK], {
-      input: JSON.stringify(payload),
+      input,
       env: { ...process.env, CLAUDECLAW_SKILL_ACCESS_LOG: log, CLAUDECLAW_SKILLS_DIR: skillsDir },
       encoding: "utf8",
     });
@@ -141,9 +144,13 @@ describe("skill_access producer — hook integration", () => {
     expect(existsSync(log)).toBe(false); // resolved target is outside skills → not logged
   });
 
-  it("never errors on malformed input (does not block the tool)", () => {
-    const r = run("not json at all" as unknown);
-    expect(r.status).toBe(0);
+  it("never errors on genuinely malformed JSON (does not block the tool)", () => {
+    // Raw bytes, NOT JSON.stringify'd — this actually breaks JSON.parse (a bare
+    // stringified value would have parsed fine and not exercised the catch).
+    for (const bad of ["{ broken", "not json at all", "", "{"]) {
+      const r = runRaw(bad);
+      expect(r.status).toBe(0);
+    }
     expect(existsSync(log)).toBe(false);
   });
 });

--- a/src/__tests__/skill-access-producer.test.ts
+++ b/src/__tests__/skill-access-producer.test.ts
@@ -13,6 +13,7 @@ import { tmpdir, homedir } from "node:os";
 import { join } from "node:path";
 import {
   skillAccessEntry,
+  rotateIfNeeded,
   DEFAULT_LOG_PATH,
   DEFAULT_SKILLS_DIR,
 } from "../../hooks/log-skill-access.mjs";
@@ -144,5 +145,29 @@ describe("skill_access producer — hook integration", () => {
     const r = run("not json at all" as unknown);
     expect(r.status).toBe(0);
     expect(existsSync(log)).toBe(false);
+  });
+});
+
+describe("skill_access producer — log rotation (producer owns the trim)", () => {
+  let dir: string, log: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "skacc-rot-"));
+    log = join(dir, "access.jsonl");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("rotates to <path>.1 once the log passes the cap", () => {
+    writeFileSync(log, "x".repeat(200));
+    rotateIfNeeded(log, 100); // cap below current size → rotate
+    expect(existsSync(`${log}.1`)).toBe(true);
+    expect(existsSync(log)).toBe(false); // next append recreates a fresh file
+  });
+
+  it("does not rotate below the cap, and is a no-op when the file is absent", () => {
+    writeFileSync(log, "x".repeat(50));
+    rotateIfNeeded(log, 100);
+    expect(existsSync(`${log}.1`)).toBe(false);
+    // absent file: must not throw
+    expect(() => rotateIfNeeded(join(dir, "nope.jsonl"), 100)).not.toThrow();
   });
 });

--- a/src/__tests__/skill-access-producer.test.ts
+++ b/src/__tests__/skill-access-producer.test.ts
@@ -1,16 +1,28 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir, homedir } from "node:os";
 import { join } from "node:path";
-import { skillAccessEntry } from "../../hooks/log-skill-access.mjs";
+import {
+  skillAccessEntry,
+  DEFAULT_LOG_PATH,
+  DEFAULT_SKILLS_DIR,
+} from "../../hooks/log-skill-access.mjs";
 
 const NOW = "2026-06-30T00:00:00Z";
 const SKILLS = "/home/x/.claude/skills";
 const HOOK = join(import.meta.dir, "..", "..", "hooks", "log-skill-access.mjs");
 
 describe("skill_access producer — skillAccessEntry (pure)", () => {
-  it("logs a Read under the skills dir", () => {
+  it("logs a Read under the skills dir (path resolved)", () => {
     expect(
       skillAccessEntry(
         { tool_name: "Read", tool_input: { file_path: `${SKILLS}/foo/SKILL.md` } },
@@ -37,10 +49,41 @@ describe("skill_access producer — skillAccessEntry (pure)", () => {
       ),
     ).toBeNull();
   });
-  it("rejects a prefix-coincidence (…/skills-evil)", () => {
+  it("rejects a …/skills-evil prefix coincidence", () => {
     expect(
       skillAccessEntry(
         { tool_name: "Read", tool_input: { file_path: `${SKILLS}-evil/x.md` } },
+        SKILLS,
+        NOW,
+      ),
+    ).toBeNull();
+  });
+  it("rejects a `..` traversal escaping the skills dir", () => {
+    expect(
+      skillAccessEntry(
+        { tool_name: "Read", tool_input: { file_path: `${SKILLS}/../../../etc/passwd` } },
+        SKILLS,
+        NOW,
+      ),
+    ).toBeNull();
+  });
+  it("normalizes a TRAILING-SLASH skills dir (still logs)", () => {
+    expect(
+      skillAccessEntry(
+        { tool_name: "Read", tool_input: { file_path: `${SKILLS}/foo.md` } },
+        `${SKILLS}/`,
+        NOW,
+      ),
+    ).toEqual({ skill_path: `${SKILLS}/foo.md`, accessed_at: NOW });
+  });
+  it("ignores a FAILED read (tool_response.is_error)", () => {
+    expect(
+      skillAccessEntry(
+        {
+          tool_name: "Read",
+          tool_input: { file_path: `${SKILLS}/foo.md` },
+          tool_response: { is_error: true },
+        },
         SKILLS,
         NOW,
       ),
@@ -52,12 +95,20 @@ describe("skill_access producer — skillAccessEntry (pure)", () => {
   });
 });
 
+describe("skill_access producer — contract with the #286 consumer", () => {
+  it("default paths match the consumer's read path", () => {
+    expect(DEFAULT_LOG_PATH).toBe(join(homedir(), ".config", "tuner", "skill_accesses.jsonl"));
+    expect(DEFAULT_SKILLS_DIR).toBe(join(homedir(), ".claude", "skills"));
+  });
+});
+
 describe("skill_access producer — hook integration", () => {
   let dir: string, log: string, skillsDir: string;
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "skacc-"));
     log = join(dir, "access.jsonl");
     skillsDir = join(dir, "skills");
+    mkdirSync(skillsDir, { recursive: true });
   });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
   const run = (payload: unknown) =>
@@ -68,12 +119,25 @@ describe("skill_access producer — hook integration", () => {
     });
 
   it("appends one line for a skill read, nothing for a non-skill read", () => {
-    run({ tool_name: "Read", tool_input: { file_path: join(skillsDir, "a", "SKILL.md") } });
+    const skill = join(skillsDir, "a.md");
+    writeFileSync(skill, "skill");
+    run({ tool_name: "Read", tool_input: { file_path: skill } });
     run({ tool_name: "Read", tool_input: { file_path: "/tmp/other.md" } });
     expect(existsSync(log)).toBe(true);
     const lines = readFileSync(log, "utf8").trim().split("\n").filter(Boolean);
     expect(lines).toHaveLength(1);
-    expect(JSON.parse(lines[0]!).skill_path).toContain("SKILL.md");
+    const e = JSON.parse(lines[0]!);
+    expect(e.skill_path).toContain("a.md");
+    expect(e.accessed_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it("rejects a symlink under skills that points OUTSIDE (realpath resolution)", () => {
+    const outside = join(dir, "secret.txt");
+    writeFileSync(outside, "secret");
+    const link = join(skillsDir, "evil.md");
+    symlinkSync(outside, link);
+    run({ tool_name: "Read", tool_input: { file_path: link } });
+    expect(existsSync(log)).toBe(false); // resolved target is outside skills → not logged
   });
 
   it("never errors on malformed input (does not block the tool)", () => {


### PR DESCRIPTION
Ships the **producer** the `skill_access` telemetry stream expects.

**Gap:** the consumer (`SkillAccessTelemetryProducer`, reads `~/.config/tuner/skill_accesses.jsonl`) exists, but no producer was shipped — so `skill_access` is *declared but inert* (advertised, never emitted). Its own doc comment even references a `log-skill-access` producer that did not exist in-tree.

**This PR:**
- `hooks/log-skill-access.mjs` — a PostToolUse(Read) hook that appends `{skill_path, accessed_at}` for each read of a skill file under the skills dir. Zero deps (Node only), env-overridable (`CLAUDECLAW_SKILLS_DIR` / `CLAUDECLAW_SKILL_ACCESS_LOG`), aligned on the canonical `~/.claude/skills`, **never blocks or fails the tool** on a logging error.
- `hooks/hooks.json` — wires it (was an empty `{"hooks":{}}` scaffold).
- Exact directory-boundary match (rejects `…/skills-evil` prefix coincidences).
- **14 tests** (pure entry logic, hook integration, symlink-escape, malformed-input safety, log rotation).

Pairs with the telemetry surface in #286 (the consumer): together the `skill_access` stream emits + is queryable. Decoupled via the log path, so it can land independently.

---

**Review addendum (2026-07-03):**
- **Ships opt-in / disabled.** A PostToolUse(Read) matcher is tool-name only and cannot pre-filter to skill paths, so an always-on hook would fork node on every Read for inert telemetry. `hooks/hooks.json` now registers no PostToolUse entry; the producer header documents the snippet to enable once the #286 consumer is live.
- **Log is now bounded.** The producer owns its trim: `rotateIfNeeded()` rotates `skill_accesses.jsonl` to `<path>.1` past 5 MB (best-effort, never blocks the write).
- **Version bump deferred:** stays 2.2.169; after #288 merges this branch takes merge-main + bump to 2.2.170.