### PR TITLE
feat(tuner): governed plugin-only boundary — mcp_plugin install + technique registry [#275, stacked on #287]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.180",
+      "version": "2.2.181",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.180",
+  "version": "2.2.181",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/docs/capability-gap-detection.md
+++ b/docs/capability-gap-detection.md
@@ -1,0 +1,101 @@
+# Capability-gap detection → approved plugin install
+
+Status: **Draft design + evidence note** for #275 (companion to `memory-subject-validation.md`). Part of the governed plugin-only boundary (#290): the tuner detects a capability the operator repeatedly **needs but doesn't have**, and offers to install it — only ever as a **human-gated, reversible plugin install** from an **operator-approved list**.
+
+Canonical example: the operator keeps asking research questions with no web-search tool → *"you asked N research questions with no search tool — install Brave Search (or Perplexity)."*
+
+---
+
+## 1. The core safety property: NEED is internal, OFFER is approved
+
+The whole design turns on separating two things:
+
+- **NEED** — what the operator lacks — is derived **only from their own behaviour** (session transcripts = trusted internal data). **No external source can inject a need.** A poisoned web page or marketplace entry can never make the tuner claim you need something.
+- **OFFER** — what to install — comes from the **approved technique-plugin registry** (`lookupCapability`), a curated allow-list the operator controls. The tuner recommends a *vetted* capability, never arbitrary code.
+
+So the blast radius of any external manipulation is zero for the *need*, and bounded to the *approved list* for the *offer*.
+
+---
+
+## 2. Detection method + the metric
+
+`detectCapabilityGaps()` scans session transcripts and reports, per capability:
+
+| field | meaning |
+|---|---|
+| `unmetIntentCount` | intent prompts that occurred in sessions where **no satisfying tool** was ever used |
+| `sessionsScanned` / `sessionsWithGap` | denominator / how many sessions showed the gap |
+| `examples` | a few example prompts (for the proposal + app display) |
+
+A capability is a `CapabilitySpec { capability, intent: RegExp[], tools: RegExp[] }`. `web_search` ships built-in (research-intent patterns in EN + FR; satisfying tools = brave/perplexity/tavily/web_search/web_fetch/…). The detector is **deterministic + heuristic** — a *signal* ("you asked N research questions with no search tool"), not a proof. **The number carries the argument; the human decides.** It never throws (malformed lines / missing dirs are skipped), and ignores oversized system/harness prompts (`MAX_PROMPT_CHARS`) so only natural asks count.
+
+**The success metric (rail-#1 style, outcome-defined):** after an approved install, the same intent should start routing **through the new tool** — measure *adoption* (the tool gets used for those asks) and the unmet count drops. If the installed capability is never used, the OutcomeLoop flags it for removal. Never "N proposals generated."
+
+---
+
+## 3. Evidence (honest before/after)
+
+Run on this operator's real transcripts (159 sessions):
+
+- **web_search gap = 0.** Correctly finds **no** gap — this operator already has Brave + a web-research tool, so the tuner **does not** recommend what they already have. This is the governance win: **no over-recommendation.**
+- The mechanism itself is proven by unit tests: it fires on a synthetic session with research intent + no tool, stays silent when a satisfying tool is present or when there is no research intent, and is injection/robustness-safe (malformed lines, missing dirs).
+
+So the demonstrated property here is **precision** (no false recommendation on a well-equipped operator), with the firing behaviour proven by controlled cases. On an *under-equipped* operator the same metric surfaces the genuine need with a number.
+
+---
+
+## 4. The approved, modifiable list (governance)
+
+The registry (`technique-plugin-registry.ts`) is the allow-list of what the tuner may ever recommend:
+
+- **Built-in seeds** ship `verified: false` — they demonstrate the path (Brave, Perplexity for `web_search`) but are **never auto-trusted**; `lookupCapability` hides them from recommendations unless explicitly surfaced as *UNVERIFIED*.
+- **Operator file** `~/.config/tuner/technique-plugins.json` — the operator curates real, pinned, `verified: true` entries. **This is the approved list.** Operator entries override seeds on id collision.
+- A capability with no approved entry → **no offer** (the tuner stays silent rather than guess).
+
+This is the exact shape a regulated operator wants: *the tuner can only ever propose from a list I control, and even then it's gated and reversible.*
+
+---
+
+## 5. App display (control-plane)
+
+For each detected gap the app should show:
+
+- **Headline** — `"Capability gap: web_search — 12 unmet research asks across 5 sessions"`.
+- **Evidence** — the example prompts (why it thinks so), the sessions/denominator.
+- **Offer** — the approved plugin options (`brave-search`, `perplexity-ask`), each with: source (pinned package/repo), `verified` badge (approved vs UNVERIFIED), the exact `mcpServers` entry that would be written, and required secrets (e.g. `BRAVE_API_KEY`).
+- **Actions** — Approve (→ gated, confined install), Refuse, Discuss (inject to the agent session). Post-install: an **adoption** readout (is the new tool actually being used?).
+
+---
+
+## 6. Parameters to display + configure
+
+| parameter | what it controls | default |
+|---|---|---|
+| `capabilitySpecs` | which capabilities are watched + their intent/tool patterns | `web_search` built-in |
+| `MAX_PROMPT_CHARS` | max length of a "natural ask" (filters system/harness prompts) | 400 |
+| `since` / window | how far back transcripts are scanned | all / configurable |
+| gap threshold | minimum `unmetIntentCount` before a proposal is raised | operator-set |
+| approved registry path | the operator allow-list file | `~/.config/tuner/technique-plugins.json` |
+| `includeUnverified` | whether UNVERIFIED seeds may be surfaced (shown flagged) | false |
+
+All are config, not code — consistent with the plugin-only boundary (the tuner tunes config/data/plugins, never engine code).
+
+---
+
+## 7. Prompts (tunable)
+
+Two LLM touch-points, both optional and out-of-band (detection itself is regex-deterministic):
+
+1. **Intent classifier (optional upgrade)** — instead of / alongside regex, an LLM can label a prompt as "research intent" for fuzzier coverage. Prompt is fixed; the transcript text is **data, never instructions** (injection-safe extraction).
+2. **Proposal rendering** — turns a gap + approved offer into the operator-facing message ("you asked N research questions… install X"). This is a `prompt_template` the operator can tune (tone, language — FR/EN), separate from the detection logic.
+
+Keeping detection deterministic and only the *phrasing* LLM-tuned means the security-critical path has no model in it.
+
+---
+
+## 8. Safety summary
+
+- Need from **behaviour only** (no external injection vector for the need).
+- Offer from an **operator-approved allow-list** (vetted, pinned, `verified`).
+- Install = **gated + confined + reversible** plugin (mcp-plugin-subject, #290) — never auto-run, never engine code.
+- Detection is **deterministic**; any LLM use is confined to phrasing and to structured, injection-safe extraction.

--- a/src/tuner/__tests__/wisecron/capability-gap.test.ts
+++ b/src/tuner/__tests__/wisecron/capability-gap.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectCapabilityGaps } from "../../wisecron/capability-gap.js";
+import { lookupCapability } from "../../wisecron/technique-plugin-registry.js";
+
+let dir: string;
+const userLine = (text: string) =>
+  JSON.stringify({ type: "user", message: { role: "user", content: text } });
+const toolLine = (name: string) =>
+  JSON.stringify({
+    type: "assistant",
+    message: { role: "assistant", content: [{ type: "tool_use", name }] },
+  });
+function session(file: string, lines: string[]): void {
+  const sdir = join(dir, "proj");
+  mkdirSync(sdir, { recursive: true });
+  writeFileSync(join(sdir, file), `${lines.join("\n")}\n`);
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "capgap-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("detectCapabilityGaps", () => {
+  it("flags research-intent prompts in a session with no search tool", () => {
+    session("a.jsonl", [
+      userLine("what's the latest version of bun"),
+      userLine("can you google it for me"),
+    ]);
+    const [gap] = detectCapabilityGaps({ transcriptDirs: [dir] });
+    expect(gap.capability).toBe("web_search");
+    expect(gap.unmetIntentCount).toBe(2);
+    expect(gap.sessionsWithGap).toBe(1);
+    expect(gap.examples.length).toBe(2);
+  });
+
+  it("does NOT flag when a satisfying tool was used in the session", () => {
+    session("b.jsonl", [
+      userLine("what's the latest version of bun"),
+      toolLine("brave_web_search"),
+    ]);
+    const [gap] = detectCapabilityGaps({ transcriptDirs: [dir] });
+    expect(gap.unmetIntentCount).toBe(0);
+    expect(gap.sessionsWithGap).toBe(0);
+  });
+
+  it("does NOT flag a session with no research intent", () => {
+    session("c.jsonl", [userLine("rename this variable to totalCount")]);
+    const [gap] = detectCapabilityGaps({ transcriptDirs: [dir] });
+    expect(gap.unmetIntentCount).toBe(0);
+  });
+
+  it("ignores malformed lines and missing dirs without throwing", () => {
+    session("d.jsonl", ["not json {{{", userLine("look it up online please")]);
+    const gaps = detectCapabilityGaps({ transcriptDirs: [dir, join(dir, "does-not-exist")] });
+    expect(gaps[0].unmetIntentCount).toBe(1);
+  });
+});
+
+describe("lookupCapability (approved-list gate)", () => {
+  it("returns nothing for an unverified seed by default (approved-only)", () => {
+    // Brave/Perplexity seeds ship verified:false → not surfaced unless approved.
+    expect(lookupCapability("web_search", { registryPath: join(dir, "none.json") })).toHaveLength(
+      0,
+    );
+  });
+
+  it("surfaces seeds when includeUnverified is set (shown as UNVERIFIED)", () => {
+    const got = lookupCapability("web_search", {
+      registryPath: join(dir, "none.json"),
+      includeUnverified: true,
+    });
+    expect(got.map((e) => e.pluginId).sort()).toEqual(["brave-search", "perplexity-ask"]);
+  });
+
+  it("returns an operator-approved (verified) entry", () => {
+    const opFile = join(dir, "op.json");
+    writeFileSync(
+      opFile,
+      JSON.stringify([
+        {
+          technique: "web-search",
+          capability: "web_search",
+          pluginId: "brave-search",
+          manager: "npm",
+          source: "@modelcontextprotocol/server-brave-search@0.6.2",
+          server: { command: "npx", args: ["-y", "@modelcontextprotocol/server-brave-search"] },
+          description: "Brave web search",
+          verified: true,
+        },
+      ]),
+    );
+    const got = lookupCapability("web_search", { registryPath: opFile });
+    expect(got).toHaveLength(1);
+    expect(got[0].pluginId).toBe("brave-search");
+    expect(got[0].verified).toBe(true);
+  });
+});

--- a/src/tuner/__tests__/wisecron/capability-gap.test.ts
+++ b/src/tuner/__tests__/wisecron/capability-gap.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { detectCapabilityGaps } from "../../wisecron/capability-gap.js";
 import { lookupCapability } from "../../wisecron/technique-plugin-registry.js";
+import { McpPluginSubject } from "../../subjects/mcp-plugin-subject.js";
 
 let dir: string;
 const userLine = (text: string) =>
@@ -74,6 +75,55 @@ describe("lookupCapability (approved-list gate)", () => {
       includeUnverified: true,
     });
     expect(got.map((e) => e.pluginId).sort()).toEqual(["brave-search", "perplexity-ask"]);
+  });
+
+  it("wires a detected gap through mcp_plugin into an install proposal", async () => {
+    const noRegistry = join(dir, "no-registry.json");
+    const sub = new McpPluginSubject({
+      auditReader: () => [],
+      registryPath: noRegistry,
+      gapDetector: () => [
+        {
+          capability: "web_search",
+          unmetIntentCount: 5,
+          sessionsScanned: 10,
+          sessionsWithGap: 3,
+          examples: ["what's the latest bun version"],
+        },
+      ],
+    });
+    const obs = await sub.collectObservations(new Date(0));
+    const capObs = obs.filter(
+      (o) => (o.metadata as Record<string, unknown>).kind === "capability_gap",
+    );
+    expect(capObs).toHaveLength(1);
+    const clusters = await sub.detectProblems(obs);
+    const gapCluster = clusters.find((c) => c.id.startsWith("mcp-capability-gap"));
+    expect(gapCluster).toBeDefined();
+    const prop = await sub.proposeChange(gapCluster as NonNullable<typeof gapCluster>);
+    // No approved entry → seeds surface as UNVERIFIED install options carrying an install spec.
+    expect(prop.alternatives.some((a) => a.id.startsWith("install:"))).toBe(true);
+    expect(prop.alternatives.some((a) => a.diff_or_content.includes("install-plugin"))).toBe(true);
+  });
+
+  it("does not raise a gap observation below the min threshold", async () => {
+    const sub = new McpPluginSubject({
+      auditReader: () => [],
+      capabilityGapMin: 10,
+      gapDetector: () => [
+        {
+          capability: "web_search",
+          unmetIntentCount: 2,
+          sessionsScanned: 5,
+          sessionsWithGap: 1,
+          examples: [],
+        },
+      ],
+    });
+    const obs = await sub.collectObservations(new Date(0));
+    expect(
+      obs.filter((o) => (o.metadata as Record<string, unknown>).kind === "capability_gap"),
+    ).toHaveLength(0);
   });
 
   it("returns an operator-approved (verified) entry", () => {

--- a/src/tuner/__tests__/wisecron/subjects/mcp-plugin-guards.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/mcp-plugin-guards.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isSafeGitUrl,
+  isSafeNpmSpec,
+  defaultAuditReader,
+} from "../../../subjects/mcp-plugin-subject.js";
+
+// The first line of defense before the registry gate — worth its own suite.
+describe("isSafeGitUrl", () => {
+  it("accepts a plain https git url", () => {
+    expect(isSafeGitUrl("https://github.com/qdrant/mcp-server-qdrant")).toBe(true);
+  });
+
+  it("rejects non-https schemes (file/ssh/scp-style/http)", () => {
+    for (const bad of [
+      "file:///etc/passwd",
+      "ssh://git@github.com/owner/repo",
+      "git@github.com:owner/repo.git", // scp-style, not a valid https URL
+      "http://github.com/o/r",
+      "",
+      "not a url",
+    ]) {
+      expect(isSafeGitUrl(bad)).toBe(false);
+    }
+  });
+
+  it("rejects SSRF-ish hosts (loopback, private ranges, cloud metadata, IPv6)", () => {
+    for (const bad of [
+      "https://localhost/o/r",
+      "https://127.0.0.1/o/r",
+      "https://10.0.0.5/o/r",
+      "https://192.168.1.1/o/r",
+      "https://172.16.0.1/o/r",
+      "https://169.254.169.254/latest/meta-data", // cloud metadata endpoint
+      "https://[::1]/o/r",
+    ]) {
+      expect(isSafeGitUrl(bad)).toBe(false);
+    }
+  });
+});
+
+describe("isSafeNpmSpec", () => {
+  it("accepts a plain name / scoped name / name@version", () => {
+    expect(isSafeNpmSpec("mcp-server-qdrant")).toBe(true);
+    expect(isSafeNpmSpec("mcp-server-qdrant@1.2.3")).toBe(true);
+    expect(isSafeNpmSpec("@scope/pkg@1.0.0")).toBe(true);
+  });
+
+  it("rejects leading-flag, path, url and shell-metachar specs", () => {
+    for (const bad of [
+      "--registry=http://evil", // flag injection (leading '-')
+      "../../etc/passwd", // path traversal (leading '.')
+      ".hidden",
+      "http://evil/pkg.tgz", // url scheme
+      "pkg; rm -rf /", // shell metachar in the name part
+      "pkg$(whoami)",
+      "pkg`id`",
+      "pkg && curl evil",
+      "",
+    ]) {
+      expect(isSafeNpmSpec(bad)).toBe(false);
+    }
+  });
+});
+
+describe("defaultAuditReader — timestamp windowing", () => {
+  it("skips lines with a missing or unparseable ts so they can't accumulate forever", () => {
+    const dir = mkdtempSync(join(tmpdir(), "audit-ts-"));
+    const p = join(dir, "operations.jsonl");
+    const since = new Date("2026-01-01T00:00:00.000Z");
+    writeFileSync(
+      p,
+      `${[
+        JSON.stringify({ type: "mcp_tool_call", tool: "a", ts: "2026-06-01T00:00:00.000Z" }), // in window
+        JSON.stringify({ type: "mcp_tool_call", tool: "b" }), // NO ts → must be skipped
+        JSON.stringify({ type: "mcp_tool_call", tool: "c", ts: "not-a-date" }), // bad ts → skipped
+        JSON.stringify({ type: "mcp_tool_call", tool: "d", ts: "2020-01-01T00:00:00.000Z" }), // pre-window
+      ].join("\n")}\n`,
+    );
+    const events = defaultAuditReader(p, since);
+    rmSync(dir, { recursive: true, force: true });
+    // Only the genuinely in-window record survives.
+    expect(events.map((e) => e.tool)).toEqual(["a"]);
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/mcp-plugin-install.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/mcp-plugin-install.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { McpPluginSubject, type PluginInstaller } from "../../../subjects/mcp-plugin-subject.js";
+import type { Proposal } from "../../../../skills-tuner/core/types.js";
+
+let tmpRoot: string;
+let settingsPath: string;
+let pluginsDir: string;
+let installerCalls: Array<{ manager: string; source: string; destDir: string }>;
+
+/** Fake installer: records the call and drops a marker file in destDir (success). */
+const okInstaller: PluginInstaller = (s) => {
+  installerCalls.push(s);
+  mkdirSync(s.destDir, { recursive: true });
+  writeFileSync(join(s.destDir, "INSTALLED"), s.source);
+  return { ok: true, output: "ok" };
+};
+const failInstaller: PluginInstaller = (s) => {
+  installerCalls.push(s);
+  return { ok: false, output: "boom" };
+};
+
+function installProposal(target: string, pluginId = "mcp-server-qdrant"): Proposal {
+  const spec = {
+    op: "install-plugin",
+    pluginId,
+    manager: "git",
+    source: "https://github.com/qdrant/mcp-server-qdrant",
+    server: { command: "uvx", args: ["mcp-server-qdrant"] },
+  };
+  return {
+    id: 1,
+    cluster_id: "c",
+    subject: "mcp_plugin",
+    kind: "patch",
+    target_path: target,
+    alternatives: [
+      {
+        id: "install-plugin",
+        label: "install",
+        diff_or_content: JSON.stringify(spec),
+        tradeoff: "",
+      },
+    ],
+    pattern_signature: "plugin-install:test",
+    created_at: new Date(),
+  } as unknown as Proposal;
+}
+
+function subject(installer: PluginInstaller) {
+  return new McpPluginSubject({ settingsPath, managedPluginsDir: pluginsDir, installer });
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "mcpinst-"));
+  settingsPath = join(tmpRoot, "settings.json");
+  pluginsDir = join(tmpRoot, "plugins");
+  installerCalls = [];
+});
+afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+describe("McpPluginSubject — real plugin install (confined + reversible)", () => {
+  it("installs into the managed dir + registers the server in settings + records a manifest", async () => {
+    writeFileSync(settingsPath, JSON.stringify({ allowedTools: ["x"] }));
+    const sub = subject(okInstaller);
+    const patch = await sub.apply(installProposal(settingsPath), "install-plugin");
+
+    expect(installerCalls).toHaveLength(1);
+    expect(existsSync(join(pluginsDir, "mcp-server-qdrant", "INSTALLED"))).toBe(true);
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(settings.mcpServers["mcp-server-qdrant"]).toEqual({
+      command: "uvx",
+      args: ["mcp-server-qdrant"],
+    });
+    expect(settings.allowedTools).toEqual(["x"]); // pre-existing config preserved
+    expect(patch.kind).toBe("plugin_install");
+    const manifest = JSON.parse(readFileSync(join(pluginsDir, "installed.json"), "utf8"));
+    expect(manifest[0].pluginId).toBe("mcp-server-qdrant");
+  });
+
+  it("install FAILURE → throws, settings untouched, dir cleaned (no dangling entry)", async () => {
+    writeFileSync(settingsPath, JSON.stringify({ allowedTools: [] }));
+    const sub = subject(failInstaller);
+    await expect(sub.apply(installProposal(settingsPath), "install-plugin")).rejects.toThrow(
+      /install failed/,
+    );
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(settings.mcpServers).toBeUndefined();
+    expect(existsSync(join(pluginsDir, "mcp-server-qdrant"))).toBe(false);
+  });
+
+  it("revert restores settings AND uninstalls the plugin dir (reconcile)", async () => {
+    writeFileSync(settingsPath, JSON.stringify({ allowedTools: [] }));
+    const sub = subject(okInstaller);
+    const inverseContent = await sub.snapshotInverse(settingsPath); // pre-install snapshot
+    await sub.apply(installProposal(settingsPath), "install-plugin");
+    expect(existsSync(join(pluginsDir, "mcp-server-qdrant"))).toBe(true);
+
+    await sub.revert({
+      target_path: settingsPath,
+      kind: "plugin_install_inverse",
+      applied_content: inverseContent,
+    });
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(settings.mcpServers).toBeUndefined(); // entry gone
+    expect(existsSync(join(pluginsDir, "mcp-server-qdrant"))).toBe(false); // uninstalled
+    expect(JSON.parse(readFileSync(join(pluginsDir, "installed.json"), "utf8"))).toEqual([]);
+  });
+
+  it("CONFINEMENT: apply refuses a target_path that is not the managed settings", async () => {
+    const sub = subject(okInstaller);
+    const foreign = join(tmpRoot, "evil", "engine.ts");
+    await expect(sub.apply(installProposal(foreign), "install-plugin")).rejects.toThrow(
+      /not the managed settings/,
+    );
+    expect(installerCalls).toHaveLength(0); // never ran the installer
+  });
+
+  it("CONFINEMENT: a traversal pluginId is sanitized, install stays inside managed dir", async () => {
+    writeFileSync(settingsPath, JSON.stringify({}));
+    const sub = subject(okInstaller);
+    await sub.apply(installProposal(settingsPath, "../../etc/evil"), "install-plugin");
+    // destDir was sanitized to a single safe segment under pluginsDir
+    const dest = installerCalls[0]!.destDir;
+    expect(dest.startsWith(join(pluginsDir) + "/")).toBe(true);
+    expect(dest).not.toContain("..");
+  });
+
+  it("the allowedTools path still works + is also confined", async () => {
+    writeFileSync(settingsPath, JSON.stringify({ allowedTools: [] }));
+    const sub = subject(okInstaller);
+    const p = {
+      id: 2,
+      cluster_id: "c",
+      subject: "mcp_plugin",
+      kind: "patch",
+      target_path: settingsPath,
+      alternatives: [
+        {
+          id: "a",
+          label: "l",
+          diff_or_content: JSON.stringify({ allowedTools: ["y"] }),
+          tradeoff: "",
+        },
+      ],
+      pattern_signature: "s",
+      created_at: new Date(),
+    } as unknown as Proposal;
+    const patch = await sub.apply(p, "a");
+    expect(JSON.parse(patch.applied_content).allowedTools).toEqual(["y"]);
+    expect(installerCalls).toHaveLength(0); // not an install
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/mcp-plugin-install.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/mcp-plugin-install.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, mkdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  existsSync,
+  mkdirSync,
+  symlinkSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { McpPluginSubject, type PluginInstaller } from "../../../subjects/mcp-plugin-subject.js";
@@ -112,6 +120,63 @@ describe("McpPluginSubject — real plugin install (confined + reversible)", () 
       /approved registry/,
     );
     expect(installerCalls).toHaveLength(0); // never reached the installer
+  });
+
+  it("SYMLINK: refuses to install when the managed plugins dir is a symlink out of the surface", async () => {
+    writeFileSync(settingsPath, JSON.stringify({ allowedTools: [] }));
+    // Plant a symlink AT the managed dir pointing outside the managed surface.
+    const outside = join(tmpRoot, "outside");
+    mkdirSync(outside, { recursive: true });
+    symlinkSync(outside, pluginsDir);
+    await expect(
+      subject(okInstaller).apply(installProposal(settingsPath), "install-plugin"),
+    ).rejects.toThrow(/symlink/);
+    // Nothing was written through the symlink, and the installer never ran.
+    expect(existsSync(join(outside, "mcp-server-qdrant"))).toBe(false);
+    expect(installerCalls).toHaveLength(0);
+  });
+
+  it("VERIFIED: an unverified registry entry is rejected at apply (belt-and-braces)", async () => {
+    writeFileSync(settingsPath, JSON.stringify({ allowedTools: [] }));
+    const spec = {
+      op: "install-plugin",
+      pluginId: "mcp-server-qdrant",
+      manager: "git",
+      source: "https://github.com/qdrant/mcp-server-qdrant",
+      server: { command: "uvx", args: ["mcp-server-qdrant"] },
+    };
+    // Registry entry matches the spec EXACTLY but is unverified.
+    writeFileSync(
+      registryPath,
+      JSON.stringify([
+        {
+          technique: "test",
+          capability: "test",
+          pluginId: spec.pluginId,
+          manager: spec.manager,
+          source: spec.source,
+          server: spec.server,
+          description: "unverified seed",
+          verified: false,
+        },
+      ]),
+    );
+    const proposal = {
+      id: 2,
+      cluster_id: "c",
+      subject: "mcp_plugin",
+      kind: "patch",
+      target_path: settingsPath,
+      alternatives: [
+        { id: "install-plugin", label: "x", diff_or_content: JSON.stringify(spec), tradeoff: "" },
+      ],
+      pattern_signature: "x",
+      created_at: new Date(),
+    } as unknown as Proposal;
+    await expect(subject(okInstaller).apply(proposal, "install-plugin")).rejects.toThrow(
+      /unverified/i,
+    );
+    expect(installerCalls).toHaveLength(0);
   });
 
   it("installs into the managed dir + registers the server in settings + records a manifest", async () => {

--- a/src/tuner/__tests__/wisecron/subjects/mcp-plugin-install.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/mcp-plugin-install.test.ts
@@ -8,6 +8,7 @@ import type { Proposal } from "../../../../skills-tuner/core/types.js";
 let tmpRoot: string;
 let settingsPath: string;
 let pluginsDir: string;
+let registryPath: string;
 let installerCalls: Array<{ manager: string; source: string; destDir: string }>;
 
 /** Fake installer: records the call and drops a marker file in destDir (success). */
@@ -30,6 +31,22 @@ function installProposal(target: string, pluginId = "mcp-server-qdrant"): Propos
     source: "https://github.com/qdrant/mcp-server-qdrant",
     server: { command: "uvx", args: ["mcp-server-qdrant"] },
   };
+  // Approve this exact spec in the operator registry (apply-time gate M1).
+  writeFileSync(
+    registryPath,
+    JSON.stringify([
+      {
+        technique: "test",
+        capability: "test",
+        pluginId,
+        manager: spec.manager,
+        source: spec.source,
+        server: spec.server,
+        description: "test entry",
+        verified: true,
+      },
+    ]),
+  );
   return {
     id: 1,
     cluster_id: "c",
@@ -50,18 +67,53 @@ function installProposal(target: string, pluginId = "mcp-server-qdrant"): Propos
 }
 
 function subject(installer: PluginInstaller) {
-  return new McpPluginSubject({ settingsPath, managedPluginsDir: pluginsDir, installer });
+  return new McpPluginSubject({
+    settingsPath,
+    managedPluginsDir: pluginsDir,
+    installer,
+    registryPath,
+  });
 }
 
 beforeEach(() => {
   tmpRoot = mkdtempSync(join(tmpdir(), "mcpinst-"));
   settingsPath = join(tmpRoot, "settings.json");
   pluginsDir = join(tmpRoot, "plugins");
+  registryPath = join(tmpRoot, "registry.json");
+  writeFileSync(registryPath, "[]");
   installerCalls = [];
 });
 afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
 
 describe("McpPluginSubject — real plugin install (confined + reversible)", () => {
+  it("M1: an off-registry install spec is REJECTED at apply (approved-list gate)", async () => {
+    writeFileSync(settingsPath, JSON.stringify({ allowedTools: [] }));
+    // Empty registry ("[]") + a hand-crafted proposal that does NOT register itself.
+    const spec = {
+      op: "install-plugin",
+      pluginId: "evil-plugin",
+      manager: "git",
+      source: "https://github.com/attacker/evil",
+      server: { command: "node", args: ["evil.js"] },
+    };
+    const proposal = {
+      id: 9,
+      cluster_id: "c",
+      subject: "mcp_plugin",
+      kind: "patch",
+      target_path: settingsPath,
+      alternatives: [
+        { id: "install-plugin", label: "x", diff_or_content: JSON.stringify(spec), tradeoff: "" },
+      ],
+      pattern_signature: "x",
+      created_at: new Date(),
+    } as unknown as Proposal;
+    await expect(subject(okInstaller).apply(proposal, "install-plugin")).rejects.toThrow(
+      /approved registry/,
+    );
+    expect(installerCalls).toHaveLength(0); // never reached the installer
+  });
+
   it("installs into the managed dir + registers the server in settings + records a manifest", async () => {
     writeFileSync(settingsPath, JSON.stringify({ allowedTools: ["x"] }));
     const sub = subject(okInstaller);

--- a/src/tuner/__tests__/wisecron/subjects/mcp-plugin-subject.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/mcp-plugin-subject.test.ts
@@ -1,0 +1,437 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { McpPluginSubject } from "../../../subjects/mcp-plugin-subject.js";
+import type { Observation, Patch, Proposal } from "../../../../skills-tuner/core/types.js";
+
+let tmpRoot: string;
+let auditPath: string;
+let settingsPath: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "mcpsubj-"));
+  auditPath = join(tmpRoot, "operations.jsonl");
+  settingsPath = join(tmpRoot, "settings.json");
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("McpPluginSubject — identity", () => {
+  it('name === "mcp_plugin", risk_tier === "medium"', () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    expect(s.name).toBe("mcp_plugin");
+    expect(s.risk_tier).toBe("medium");
+  });
+});
+
+describe("McpPluginSubject — collectObservations", () => {
+  it("streams operations.jsonl filtering type=mcp_tool_call", async () => {
+    const events = [
+      { type: "mcp_tool_call", server: "foo", tool: "bar", success: true, ts: Date.now() },
+      { type: "other", server: "foo", tool: "bar", ts: Date.now() }, // ignored
+      { type: "mcp_tool_call", server: "foo", tool: "bar", success: false, ts: Date.now() },
+    ];
+    const s = new McpPluginSubject({
+      auditLog: auditPath,
+      settingsPath,
+      auditReader: () => events,
+    });
+    const obs = await s.collectObservations(new Date(0));
+    expect(obs.length).toBe(1);
+    expect(obs[0]?.metadata.calls).toBe(2);
+  });
+
+  it("aggregates call_count + success_rate + blocked_count per (server, tool)", async () => {
+    const now = Date.now();
+    const events = [
+      { type: "mcp_tool_call", server: "s", tool: "t", success: true, ts: now },
+      { type: "mcp_tool_call", server: "s", tool: "t", success: false, blocked: true, ts: now },
+      { type: "mcp_tool_call", server: "s", tool: "t", success: true, ts: now },
+    ];
+    const s = new McpPluginSubject({
+      auditLog: auditPath,
+      settingsPath,
+      auditReader: () => events,
+    });
+    const obs = await s.collectObservations(new Date(0));
+    expect(obs[0]?.metadata.calls).toBe(3);
+    expect(obs[0]?.metadata.success_rate).toBeCloseTo(2 / 3, 2);
+    expect(obs[0]?.metadata.blocked).toBe(1);
+  });
+
+  it("returns empty when no audit events", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath, auditReader: () => [] });
+    expect(await s.collectObservations(new Date(0))).toEqual([]);
+  });
+});
+
+describe("McpPluginSubject — detectProblems", () => {
+  it("flags broken tools (calls > 100 && success < 0.5)", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const obs: Observation[] = [
+      {
+        session_id: "t",
+        observed_at: new Date(),
+        signal_type: "correction",
+        verbatim: "{}",
+        metadata: {
+          subject: "mcp_plugin",
+          server: "s",
+          tool: "t",
+          calls: 150,
+          success_rate: 0.3,
+          blocked: 0,
+          trust_score: 0,
+          age_days: 1,
+        },
+      },
+    ];
+    const clusters = await s.detectProblems(obs);
+    expect(clusters.some((c) => c.id === "mcp-broken")).toBe(true);
+  });
+
+  it("flags dead tools (zero calls last 90d)", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const obs: Observation[] = [
+      {
+        session_id: "t",
+        observed_at: new Date(),
+        signal_type: "orphan",
+        verbatim: "{}",
+        metadata: {
+          subject: "mcp_plugin",
+          server: "s",
+          tool: "t",
+          calls: 5,
+          success_rate: 1,
+          blocked: 0,
+          trust_score: 0,
+          age_days: 120,
+        },
+      },
+    ];
+    const clusters = await s.detectProblems(obs);
+    expect(clusters.some((c) => c.id === "mcp-dead")).toBe(true);
+  });
+
+  it("flags blocked tools with high trust score", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const obs: Observation[] = [
+      {
+        session_id: "t",
+        observed_at: new Date(),
+        signal_type: "repeated_trigger",
+        verbatim: "{}",
+        metadata: {
+          subject: "mcp_plugin",
+          server: "s",
+          tool: "t",
+          calls: 10,
+          success_rate: 1,
+          blocked: 5,
+          trust_score: 0.9,
+          age_days: 1,
+        },
+      },
+    ];
+    const clusters = await s.detectProblems(obs);
+    expect(clusters.some((c) => c.id === "mcp-blocked-allow")).toBe(true);
+  });
+});
+
+describe("McpPluginSubject — apply / validate", () => {
+  it("apply preserves stable JSON key order", async () => {
+    writeFileSync(settingsPath, JSON.stringify({ b: 1, a: 2, allowedTools: ["x"] }), "utf8");
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "mcp_plugin",
+      kind: "patch",
+      target_path: settingsPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "sig",
+      alternatives: [
+        {
+          id: "remove-tool",
+          label: "l",
+          tradeoff: "",
+          diff_or_content: JSON.stringify({ zlast: 1, allowedTools: [], aFirst: "first" }),
+        },
+      ],
+    };
+    await s.apply(proposal, "remove-tool");
+    const written = readFileSync(settingsPath, "utf8");
+    const keys = Object.keys(JSON.parse(written));
+    expect(keys).toEqual(["aFirst", "allowedTools", "zlast"]);
+    expect(existsSync(`${settingsPath}.bak`)).toBe(true);
+  });
+
+  it("validate parses applied_content as JSON", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const bad = await s.validate({
+      target_path: settingsPath,
+      kind: "patch",
+      applied_content: "not-json",
+    });
+    expect(bad.valid).toBe(false);
+  });
+
+  it("validate rejects allowedTools not a string array", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const r1 = await s.validate({
+      target_path: settingsPath,
+      kind: "patch",
+      applied_content: '{"allowedTools": "not-an-array"}',
+    });
+    expect(r1.valid).toBe(false);
+
+    const r2 = await s.validate({
+      target_path: settingsPath,
+      kind: "patch",
+      applied_content: '{"allowedTools": [1, 2, 3]}',
+    });
+    expect(r2.valid).toBe(false);
+  });
+
+  it("validate accepts a well-formed settings object", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const r = await s.validate({
+      target_path: settingsPath,
+      kind: "patch",
+      applied_content: '{"allowedTools": ["a", "b"]}',
+    });
+    expect(r.valid).toBe(true);
+  });
+});
+
+describe("McpPluginSubject — revert", () => {
+  it("writes inverse JSON back to target_path", async () => {
+    writeFileSync(settingsPath, '{"a":2}', "utf8");
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const inverse: Patch = {
+      target_path: settingsPath,
+      kind: "patch",
+      applied_content: '{\n  "a": 1\n}',
+    };
+    await s.revert(inverse);
+    expect(readFileSync(settingsPath, "utf8")).toBe('{\n  "a": 1\n}');
+  });
+
+  it("revert throws on malformed inverse content", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const inverse: Patch = { target_path: settingsPath, kind: "patch", applied_content: "bogus" };
+    await expect(s.revert(inverse)).rejects.toThrow();
+  });
+});
+
+// ── Pass B: edges, idempotency, guardrails ─────────────────────────────────
+
+describe("McpPluginSubject — Pass B: edges", () => {
+  it("validate: empty string fails JSON parse with clear reason", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const r = await s.validate({ target_path: settingsPath, kind: "patch", applied_content: "" });
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/JSON/);
+  });
+
+  it("validate: top-level array rejected (must be object)", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const r = await s.validate({
+      target_path: settingsPath,
+      kind: "patch",
+      applied_content: "[1,2,3]",
+    });
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/object/);
+  });
+
+  it("validate: allowedTools with non-string entry rejected", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const r = await s.validate({
+      target_path: settingsPath,
+      kind: "patch",
+      applied_content: '{"allowedTools": ["ok", 42]}',
+    });
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/strings/);
+  });
+
+  it("apply: missing alternative id → clear error", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "mcp_plugin",
+      kind: "patch",
+      target_path: settingsPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "s",
+      alternatives: [{ id: "real", label: "", tradeoff: "", diff_or_content: '{"a":1}' }],
+    };
+    await expect(s.apply(proposal, "wrong")).rejects.toThrow(/alternative/);
+  });
+});
+
+describe("McpPluginSubject — Pass B: idempotency", () => {
+  it("apply same alt twice → stable bytes (parse+stableJson normalises)", async () => {
+    writeFileSync(settingsPath, '{"a":1}', "utf8");
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "mcp_plugin",
+      kind: "patch",
+      target_path: settingsPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "s",
+      alternatives: [{ id: "a", label: "", tradeoff: "", diff_or_content: '{"b":2,"a":1}' }],
+    };
+    const patch1 = await s.apply(proposal, "a");
+    const after1 = readFileSync(settingsPath, "utf8");
+    const patch2 = await s.apply(proposal, "a");
+    expect(readFileSync(settingsPath, "utf8")).toBe(after1);
+    expect(patch2.applied_content).toBe(patch1.applied_content);
+  });
+
+  it("revert same inverse twice → no double-mutation", async () => {
+    writeFileSync(settingsPath, '{"a":2}', "utf8");
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const inverse: Patch = {
+      target_path: settingsPath,
+      kind: "patch",
+      applied_content: '{"a":1}',
+    };
+    await s.revert(inverse);
+    const after1 = readFileSync(settingsPath, "utf8");
+    await s.revert(inverse);
+    expect(readFileSync(settingsPath, "utf8")).toBe(after1);
+  });
+});
+
+describe("McpPluginSubject — Pass B: validate/apply symmetry", () => {
+  it("apply roundtrip: produced Patch validates clean", async () => {
+    writeFileSync(settingsPath, "{}", "utf8");
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "mcp_plugin",
+      kind: "patch",
+      target_path: settingsPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "s",
+      alternatives: [
+        { id: "a", label: "", tradeoff: "", diff_or_content: '{"allowedTools":["x"]}' },
+      ],
+    };
+    const patch = await s.apply(proposal, "a");
+    const v = await s.validate(patch);
+    expect(v.valid).toBe(true);
+  });
+
+  it("apply throws on malformed JSON in alt content (mirrors validate rejection)", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "mcp_plugin",
+      kind: "patch",
+      target_path: settingsPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "s",
+      alternatives: [{ id: "a", label: "", tradeoff: "", diff_or_content: "not-json" }],
+    };
+    await expect(s.apply(proposal, "a")).rejects.toThrow();
+  });
+});
+
+describe("McpPluginSubject — Pass B: risk_tier guardrails", () => {
+  it("risk_tier is medium — no observation window in ApplyPipeline", () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    expect(s.risk_tier).toBe("medium");
+    expect(s.auto_merge_default).toBe(false);
+  });
+});
+
+describe("McpPluginSubject — healthCheck", () => {
+  it("returns producer_found=false when auditLog does not exist", async () => {
+    const s = new McpPluginSubject({ auditLog: join(tmpRoot, "missing.jsonl") });
+    const h = await s.healthCheck!();
+    expect(h.producer_found).toBe(false);
+    expect(h.reason).toMatch(/auditLog does not exist/);
+  });
+
+  it("returns producer_found=false when no events in 7d window", async () => {
+    writeFileSync(auditPath, "", "utf8");
+    const s = new McpPluginSubject({
+      auditLog: auditPath,
+      auditReader: () => [],
+    });
+    const h = await s.healthCheck!();
+    expect(h.producer_found).toBe(false);
+    expect(h.reason).toMatch(/no audit events/);
+  });
+
+  it("returns match_rate=0 with reason when audit log has events but none are mcp_tool_call", async () => {
+    writeFileSync(auditPath, "{}\n", "utf8");
+    const s = new McpPluginSubject({
+      auditLog: auditPath,
+      auditReader: () => [{ type: "skill_run" }, { type: "session_start" }],
+    });
+    const h = await s.healthCheck!();
+    expect(h.producer_found).toBe(true);
+    expect(h.sample_event_match_rate).toBe(0);
+    expect(h.reason).toMatch(/instrumentation missing/);
+  });
+
+  it("returns match_rate>0 when mcp_tool_call entries are present", async () => {
+    writeFileSync(auditPath, "{}\n", "utf8");
+    const s = new McpPluginSubject({
+      auditLog: auditPath,
+      auditReader: () => [{ type: "mcp_tool_call", server: "s", tool: "t" }, { type: "skill_run" }],
+    });
+    const h = await s.healthCheck!();
+    expect(h.producer_found).toBe(true);
+    expect(h.sample_event_match_rate).toBe(0.5);
+  });
+});
+
+describe("McpPluginSubject — healthProbe (post-apply artifact check)", () => {
+  it("valid JSON settings with allowedTools[] → failed:false", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    writeFileSync(settingsPath, JSON.stringify({ allowedTools: ["mcp__a__b"] }), "utf8");
+    const probe = await s.healthProbe!(settingsPath);
+    expect(probe.failed).toBe(false);
+    expect(probe.errors).toEqual([]);
+  });
+
+  it("malformed JSON → failed:true + errors", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    writeFileSync(settingsPath, "{ not json", "utf8");
+    const probe = await s.healthProbe!(settingsPath);
+    expect(probe.failed).toBe(true);
+    expect(probe.errors.length).toBeGreaterThan(0);
+  });
+
+  it("schema regression (allowedTools not an array) → failed:true", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    writeFileSync(settingsPath, JSON.stringify({ allowedTools: "nope" }), "utf8");
+    const probe = await s.healthProbe!(settingsPath);
+    expect(probe.failed).toBe(true);
+  });
+
+  it("settings file absent after apply → not a break", async () => {
+    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath });
+    const probe = await s.healthProbe!(settingsPath);
+    expect(probe.failed).toBe(false);
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/mcp-plugin-subject.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/mcp-plugin-subject.test.ts
@@ -38,6 +38,10 @@ describe("McpPluginSubject — collectObservations", () => {
       auditLog: auditPath,
       settingsPath,
       auditReader: () => events,
+      // Stub the capability-gap detector so the test is hermetic: the default
+      // scans real ~/.claude/projects transcripts, which is slow (times out on
+      // a dev box) and non-deterministic (real gaps would inflate obs count).
+      gapDetector: () => [],
     });
     const obs = await s.collectObservations(new Date(0));
     expect(obs.length).toBe(1);
@@ -55,6 +59,7 @@ describe("McpPluginSubject — collectObservations", () => {
       auditLog: auditPath,
       settingsPath,
       auditReader: () => events,
+      gapDetector: () => [],
     });
     const obs = await s.collectObservations(new Date(0));
     expect(obs[0]?.metadata.calls).toBe(3);
@@ -63,7 +68,12 @@ describe("McpPluginSubject — collectObservations", () => {
   });
 
   it("returns empty when no audit events", async () => {
-    const s = new McpPluginSubject({ auditLog: auditPath, settingsPath, auditReader: () => [] });
+    const s = new McpPluginSubject({
+      auditLog: auditPath,
+      settingsPath,
+      auditReader: () => [],
+      gapDetector: () => [],
+    });
     expect(await s.collectObservations(new Date(0))).toEqual([]);
   });
 });

--- a/src/tuner/__tests__/wisecron/technique-plugin-registry.test.ts
+++ b/src/tuner/__tests__/wisecron/technique-plugin-registry.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  lookupPlugin,
+  loadOperatorEntries,
+  BUILTIN_REGISTRY,
+  type PluginEntry,
+} from "../../wisecron/technique-plugin-registry.js";
+
+let tmpRoot: string;
+let regPath: string;
+const VALID: PluginEntry = {
+  technique: "my-technique",
+  pluginId: "my-plugin",
+  manager: "npm",
+  source: "my-plugin@1.0.0",
+  server: { command: "npx", args: ["-y", "my-plugin"] },
+  description: "x",
+  verified: true,
+};
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "tpr-"));
+  regPath = join(tmpRoot, "technique-plugins.json");
+});
+afterEach(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+describe("technique-plugin-registry", () => {
+  it("resolves a built-in seed by technique", () => {
+    const e = lookupPlugin("vectorized-retrieval", { registryPath: regPath });
+    expect(e?.pluginId).toBe("mcp-server-qdrant");
+    expect(e?.verified).toBe(false); // seeds are unverified by contract
+  });
+
+  it("returns null for an unmapped technique (→ caller emits detect-only)", () => {
+    expect(lookupPlugin("no-such-technique", { registryPath: regPath })).toBeNull();
+  });
+
+  it("loads operator entries and they win over a same-id built-in", () => {
+    const override: PluginEntry = {
+      ...VALID,
+      pluginId: "mcp-server-qdrant",
+      technique: "vectorized-retrieval",
+      verified: true,
+    };
+    writeFileSync(regPath, JSON.stringify([override]));
+    const e = lookupPlugin("vectorized-retrieval", { registryPath: regPath });
+    expect(e?.verified).toBe(true); // operator override applied
+    expect(e?.source).toBe("my-plugin@1.0.0");
+  });
+
+  it("adds a brand-new operator technique", () => {
+    writeFileSync(regPath, JSON.stringify([VALID]));
+    expect(lookupPlugin("my-technique", { registryPath: regPath })?.pluginId).toBe("my-plugin");
+  });
+
+  it("malformed registry file → [] (never throws)", () => {
+    writeFileSync(regPath, "{ not json");
+    expect(loadOperatorEntries(regPath)).toEqual([]);
+  });
+
+  it("filters out structurally-invalid operator entries", () => {
+    writeFileSync(regPath, JSON.stringify([{ technique: "t", pluginId: "p" }, VALID]));
+    const all = loadOperatorEntries(regPath);
+    expect(all).toHaveLength(1);
+    expect(all[0]!.pluginId).toBe("my-plugin");
+  });
+
+  it("rejects an unknown manager", () => {
+    writeFileSync(regPath, JSON.stringify([{ ...VALID, manager: "curl-pipe-bash" }]));
+    expect(loadOperatorEntries(regPath)).toEqual([]);
+  });
+
+  it("built-in seeds are all unverified (forces a human verify at the gate)", () => {
+    expect(BUILTIN_REGISTRY.every((e) => e.verified === false)).toBe(true);
+  });
+});

--- a/src/tuner/subjects/mcp-plugin-subject.ts
+++ b/src/tuner/subjects/mcp-plugin-subject.ts
@@ -1,0 +1,788 @@
+import { existsSync, copyFileSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { BaseSubject } from "../../skills-tuner/subjects/base.js";
+import { sanitizeObservationContent } from "../../skills-tuner/core/security.js";
+import type { LLMClient } from "../../skills-tuner/core/llm.js";
+import type {
+  Cluster,
+  Observation,
+  Patch,
+  Proposal,
+  UnsignedProposal,
+  ValidationResult,
+} from "../../skills-tuner/core/types.js";
+import type { RevertibleSubject } from "../wisecron/types.js";
+import type { DateRange, Metric, TelemetryProvider } from "../../skills-tuner/core/telemetry.js";
+import { ARTIFACT_SOURCE } from "../../skills-tuner/core/telemetry.js";
+import { nonzeroRate } from "../../skills-tuner/core/aggregate.js";
+
+const BROKEN_MIN_CALLS = 100;
+const BROKEN_SUCCESS_RATE = 0.5;
+const DEAD_WINDOW_DAYS = 90;
+const TRUST_BLOCKED_THRESHOLD = 0.7;
+
+/** Install subprocess wall-clock cap. */
+const INSTALL_TIMEOUT_MS = 120_000;
+/** Cap captured install output so a chatty installer cannot blow memory. */
+const INSTALL_MAX_BUFFER = 8 * 1024 * 1024;
+/** The `op` discriminator that marks an alternative as a NEW-plugin install. */
+const INSTALL_OP = "install-plugin";
+
+/**
+ * A structured, gated plugin-install request. Carried verbatim as the
+ * alternative's `diff_or_content` (JSON). The proactive cycle builds it from a
+ * technique→plugin registry entry; `apply()` performs the confined install then
+ * writes `settingsAfter`. This is the ONLY way an architectural capability
+ * enters the system — as an installed plugin, never as engine code.
+ */
+export interface PluginInstallSpec {
+  op: typeof INSTALL_OP;
+  /** mcpServers key + managed install-dir name. */
+  pluginId: string;
+  manager: "npm" | "git";
+  /** npm package spec or https git clone URL. */
+  source: string;
+  /** The MCP server entry to register under settings.mcpServers[pluginId]. */
+  server: { command: string; args: string[] };
+}
+
+/** One row of the managed install manifest (what the tuner installed). */
+interface ManifestEntry {
+  pluginId: string;
+  installDir: string;
+  manager: "npm" | "git";
+  source: string;
+  installedAt: string;
+}
+
+/** Injectable installer (real = spawnSync). Returns ok + captured output. */
+export type PluginInstaller = (spec: {
+  manager: "npm" | "git";
+  source: string;
+  destDir: string;
+}) => { ok: boolean; output: string };
+
+interface ToolStats {
+  server: string;
+  tool: string;
+  calls: number;
+  successes: number;
+  blocked: number;
+  lastCallAt: Date | null;
+  trustScore: number;
+}
+
+/**
+ * McpPluginSubject — wisecron-managed MCP plugin allowedTools tuner (MEDIUM).
+ */
+export interface McpPluginSubjectConfig {
+  llm?: LLMClient;
+  /** Operations audit log. Default: ~/.claudeclaw/journal/operations.jsonl. */
+  auditLog?: string;
+  /** Optional MCP settings path (target_path for proposals). */
+  settingsPath?: string;
+  /** Injected event reader for tests. */
+  auditReader?: (path: string, since: Date) => Array<Record<string, unknown>>;
+  /** Confined dir where the tuner installs plugins. Default: ~/.config/tuner/plugins. */
+  managedPluginsDir?: string;
+  /** Injected installer for tests (default = real spawnSync git/npm). */
+  installer?: PluginInstaller;
+}
+
+export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
+  readonly name = "mcp_plugin";
+  readonly risk_tier = "medium" as const;
+  readonly auto_merge_default = false;
+  // Supports creating a NEW capability — but ONLY as a confined plugin install,
+  // never as engine code (the hard boundary).
+  readonly supports_creation = true;
+
+  private readonly llm?: LLMClient;
+  private readonly auditLog: string;
+  private readonly settingsPath: string;
+  private readonly auditReader: (path: string, since: Date) => Array<Record<string, unknown>>;
+  private readonly managedPluginsDir: string;
+  private readonly manifestPath: string;
+  private readonly installer: PluginInstaller;
+
+  constructor(opts: McpPluginSubjectConfig = {}) {
+    super();
+    this.llm = opts.llm;
+    this.auditLog = expandHome(
+      opts.auditLog ?? join(homedir(), ".claudeclaw", "journal", "operations.jsonl"),
+    );
+    this.settingsPath = expandHome(
+      opts.settingsPath ?? join(homedir(), ".claude", "settings.json"),
+    );
+    this.auditReader = opts.auditReader ?? defaultAuditReader;
+    this.managedPluginsDir = expandHome(
+      opts.managedPluginsDir ?? join(homedir(), ".config", "tuner", "plugins"),
+    );
+    this.manifestPath = join(this.managedPluginsDir, "installed.json");
+    this.installer = opts.installer ?? defaultInstaller;
+  }
+
+  async collectObservations(since: Date): Promise<Observation[]> {
+    const events = this.auditReader(this.auditLog, since);
+    if (events.length === 0) return [];
+
+    const stats = new Map<string, ToolStats>();
+    for (const ev of events) {
+      if (ev.type !== "mcp_tool_call") continue;
+      const server = String(ev.server ?? "unknown");
+      const tool = String(ev.tool ?? "unknown");
+      const key = `${server}::${tool}`;
+      let s = stats.get(key);
+      if (!s) {
+        s = {
+          server,
+          tool,
+          calls: 0,
+          successes: 0,
+          blocked: 0,
+          lastCallAt: null,
+          trustScore: Number(ev.trust_score ?? 0),
+        };
+        stats.set(key, s);
+      }
+      s.calls += 1;
+      if (ev.success === true || ev.ok === true) s.successes += 1;
+      if (ev.blocked === true) s.blocked += 1;
+      const ts = ev.ts;
+      const tsDate = typeof ts === "string" || typeof ts === "number" ? new Date(ts) : null;
+      if (tsDate && (!s.lastCallAt || tsDate > s.lastCallAt)) s.lastCallAt = tsDate;
+      if (typeof ev.trust_score === "number") s.trustScore = ev.trust_score as number;
+    }
+
+    const now = new Date();
+    const observations: Observation[] = [];
+    for (const s of stats.values()) {
+      const successRate = s.calls === 0 ? 1 : s.successes / s.calls;
+      const ageDays = s.lastCallAt
+        ? (now.getTime() - s.lastCallAt.getTime()) / 86_400_000
+        : Infinity;
+
+      observations.push({
+        session_id: `mcp-${s.server}-${s.tool}-${now.getTime()}`,
+        observed_at: now,
+        signal_type:
+          s.calls >= BROKEN_MIN_CALLS && successRate < BROKEN_SUCCESS_RATE
+            ? "correction"
+            : s.blocked > 0 && s.trustScore > TRUST_BLOCKED_THRESHOLD
+              ? "repeated_trigger"
+              : "orphan",
+        verbatim: sanitizeObservationContent(
+          JSON.stringify({
+            server: s.server,
+            tool: s.tool,
+            calls: s.calls,
+            success_rate: Math.round(successRate * 100) / 100,
+            blocked: s.blocked,
+            trust_score: s.trustScore,
+            age_days: Number.isFinite(ageDays) ? Math.round(ageDays) : null,
+          }),
+          500,
+        ),
+        metadata: {
+          subject: "mcp_plugin",
+          server: s.server,
+          tool: s.tool,
+          calls: s.calls,
+          success_rate: successRate,
+          blocked: s.blocked,
+          trust_score: s.trustScore,
+          age_days: Number.isFinite(ageDays) ? ageDays : null,
+        },
+      });
+    }
+    return observations;
+  }
+
+  async detectProblems(observations: Observation[]): Promise<Cluster[]> {
+    if (observations.length === 0) return [];
+    const broken: Observation[] = [];
+    const dead: Observation[] = [];
+    const blockedAllow: Observation[] = [];
+
+    for (const obs of observations) {
+      const meta = obs.metadata as Record<string, unknown>;
+      const calls = (meta.calls as number) ?? 0;
+      const successRate = (meta.success_rate as number) ?? 1;
+      const blocked = (meta.blocked as number) ?? 0;
+      const trust = (meta.trust_score as number) ?? 0;
+      const ageDays = meta.age_days as number | null;
+
+      if (calls >= BROKEN_MIN_CALLS && successRate < BROKEN_SUCCESS_RATE) broken.push(obs);
+      else if (calls === 0 || (ageDays !== null && ageDays > DEAD_WINDOW_DAYS)) dead.push(obs);
+      else if (blocked > 0 && trust > TRUST_BLOCKED_THRESHOLD) blockedAllow.push(obs);
+    }
+
+    const clusters: Cluster[] = [];
+    if (broken.length > 0) clusters.push(makeCluster("mcp-broken", broken, 0.2, "negative"));
+    if (dead.length > 0) clusters.push(makeCluster("mcp-dead", dead, 0.0, "neutral"));
+    if (blockedAllow.length > 0)
+      clusters.push(makeCluster("mcp-blocked-allow", blockedAllow, 0.6, "neutral"));
+    return clusters;
+  }
+
+  async proposeChange(cluster: Cluster): Promise<UnsignedProposal> {
+    const firstObs = cluster.observations[0];
+    if (!firstObs) throw new Error("mcp-plugin-subject.proposeChange: cluster empty");
+    const meta = firstObs.metadata as Record<string, unknown>;
+    const server = meta.server as string;
+    const tool = meta.tool as string;
+
+    let settings: Record<string, unknown> = { allowedTools: [] };
+    if (existsSync(this.settingsPath)) {
+      try {
+        settings = JSON.parse(readFileSync(this.settingsPath, "utf8"));
+      } catch {
+        /* keep default */
+      }
+    }
+
+    const allowed = Array.isArray(settings.allowedTools)
+      ? [...(settings.allowedTools as string[])]
+      : [];
+    const removeTool = `mcp__${server}__${tool}`;
+    const removed = allowed.filter((t) => t !== removeTool);
+    const added = allowed.includes(removeTool) ? allowed : [...allowed, removeTool];
+    const disabledServer = {
+      ...settings,
+      mcpServers: {
+        ...((settings.mcpServers as Record<string, unknown>) ?? {}),
+        [server]: { disabled: true },
+      },
+    };
+
+    return {
+      id: Date.now(),
+      cluster_id: cluster.id,
+      subject: "mcp_plugin",
+      kind: "patch",
+      target_path: this.settingsPath,
+      alternatives: [
+        {
+          id: "remove-tool",
+          label: `Remove ${removeTool} from allowedTools`,
+          diff_or_content: stableJson({ ...settings, allowedTools: removed }),
+          tradeoff: "Stops dead calls; reversible.",
+        },
+        {
+          id: "add-tool",
+          label: `Add ${removeTool} to allowedTools`,
+          diff_or_content: stableJson({ ...settings, allowedTools: added }),
+          tradeoff: "Unblocks high-trust tool; widens surface.",
+        },
+        {
+          id: "disable-server",
+          label: `Disable MCP server ${server}`,
+          diff_or_content: stableJson(disabledServer),
+          tradeoff: "Heavy-handed; cuts all tools from that server.",
+        },
+      ],
+      pattern_signature: `mcp_plugin:${cluster.id}:${server}:${tool}`,
+      created_at: new Date(),
+    };
+  }
+
+  async apply(proposal: Proposal, alternativeId: string): Promise<Patch> {
+    const alt = proposal.alternatives.find((a) => a.id === alternativeId);
+    if (!alt) throw new Error(`mcp-plugin-subject.apply: alternative ${alternativeId} not found`);
+    // Confinement: the only file this subject may ever write is its managed
+    // settings — never engine code or anything outside it.
+    this.assertManagedSettings(proposal.target_path);
+
+    const parsed = JSON.parse(alt.diff_or_content);
+    // ── NEW-plugin install path (architectural capability as a confined plugin) ──
+    if (isInstallSpec(parsed)) {
+      return this.applyInstall(parsed, proposal.target_path);
+    }
+
+    // ── allowedTools / disable-server path (existing behaviour) ─────────────────
+    // Parse + restringify to guarantee stable key order even if alt source skipped it.
+    const normalized = stableJson(parsed);
+    if (existsSync(proposal.target_path)) {
+      copyFileSync(proposal.target_path, `${proposal.target_path}.bak`);
+    }
+    writeFileSync(proposal.target_path, normalized, "utf8");
+    return {
+      target_path: proposal.target_path,
+      kind: "patch",
+      applied_content: normalized,
+    };
+  }
+
+  /**
+   * Install a NEW plugin (confined + reversible), then write the settings that
+   * register it. Order matters: install FIRST — if it fails we throw before
+   * touching settings, so a failed install never leaves a dangling mcpServers
+   * entry. On success we record a manifest row so revert can uninstall.
+   */
+  private applyInstall(spec: PluginInstallSpec, settingsTarget: string): Patch {
+    const destDir = this.pluginDir(spec.pluginId);
+    this.assertInsidePlugins(destDir);
+
+    // Compute the post-install settings: current settings + the new server entry.
+    // The subject OWNS the settings shape; the proposer only supplies the server.
+    let settings: Record<string, unknown> = {};
+    if (existsSync(settingsTarget)) {
+      try {
+        settings = JSON.parse(readFileSync(settingsTarget, "utf8"));
+      } catch {
+        settings = {};
+      }
+    }
+    const normalizedSettings = stableJson({
+      ...settings,
+      mcpServers: {
+        ...((settings.mcpServers as Record<string, unknown>) ?? {}),
+        [spec.pluginId]: { command: spec.server.command, args: spec.server.args },
+      },
+    });
+
+    // Clean any stale dir from a previous failed attempt, then install.
+    if (existsSync(destDir)) rmSync(destDir, { recursive: true, force: true });
+    mkdirSync(destDir, { recursive: true });
+    const res = this.installer({ manager: spec.manager, source: spec.source, destDir });
+    if (!res.ok) {
+      rmSync(destDir, { recursive: true, force: true });
+      throw new Error(
+        `mcp-plugin-subject.applyInstall: install failed for ${spec.pluginId}: ${res.output.slice(0, 300)}`,
+      );
+    }
+
+    // Register the server in settings (.bak first), then record the manifest.
+    if (existsSync(settingsTarget)) copyFileSync(settingsTarget, `${settingsTarget}.bak`);
+    writeFileSync(settingsTarget, normalizedSettings, "utf8");
+    this.recordInstall({
+      pluginId: spec.pluginId,
+      installDir: destDir,
+      manager: spec.manager,
+      source: spec.source,
+      installedAt: new Date().toISOString(),
+    });
+
+    return {
+      target_path: settingsTarget,
+      kind: "plugin_install",
+      applied_content: normalizedSettings,
+    };
+  }
+
+  /**
+   * Pre-apply snapshot the pipeline persists as the inverse patch: the CURRENT
+   * settings content. On revert we write this back AND reconcile the install
+   * manifest (any tuner-installed plugin no longer present in the restored
+   * settings is uninstalled) — so an install fully rolls back.
+   */
+  async snapshotInverse(target: string): Promise<string> {
+    this.assertManagedSettings(target);
+    return existsSync(target) ? readFileSync(target, "utf8") : "{}";
+  }
+
+  async validate(patch: Patch): Promise<ValidationResult> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(patch.applied_content);
+    } catch (e) {
+      return { valid: false, reason: `not valid JSON: ${(e as Error).message}` };
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return { valid: false, reason: "JSON must be an object" };
+    }
+    const obj = parsed as Record<string, unknown>;
+    if ("allowedTools" in obj) {
+      if (!Array.isArray(obj.allowedTools)) {
+        return { valid: false, reason: "allowedTools must be an array" };
+      }
+      if (!(obj.allowedTools as unknown[]).every((t) => typeof t === "string")) {
+        return { valid: false, reason: "allowedTools must contain only strings" };
+      }
+    }
+    return { valid: true };
+  }
+
+  /**
+   * Observation-window health probe (MEDIUM risk). Runs AFTER apply: re-reads
+   * the just-applied settings file and re-runs validate() — the allowlist /
+   * config must still be valid JSON and `allowedTools` (if present) a string[].
+   * Failed on malformed JSON or a schema regression. Artifact-based +
+   * deterministic. A file gone from disk is not a break.
+   */
+  async healthProbe(target: string): Promise<{ failed: boolean; errors: string[] }> {
+    if (!existsSync(target)) return { failed: false, errors: [] };
+    let content: string;
+    try {
+      content = readFileSync(target, "utf8");
+    } catch (e) {
+      return {
+        failed: true,
+        errors: [`unreadable settings: ${(e as Error).message.slice(0, 120)}`],
+      };
+    }
+    const validation = await this.validate({
+      target_path: target,
+      kind: "patch",
+      applied_content: content,
+    });
+    return validation.valid
+      ? { failed: false, errors: [] }
+      : { failed: true, errors: [validation.reason ?? "validation failed"] };
+  }
+
+  async revert(inversePatch: Patch): Promise<void> {
+    this.assertManagedSettings(inversePatch.target_path);
+    // Roundtrip parse to keep formatting stable + reject malformed inputs early.
+    const restored = JSON.parse(inversePatch.applied_content) as Record<string, unknown>;
+    writeFileSync(inversePatch.target_path, inversePatch.applied_content, "utf8");
+    // Reconcile installs: uninstall any tuner-installed plugin that the restored
+    // settings no longer reference (so reverting an install also removes it).
+    this.reconcileManifest(restored);
+  }
+
+  // ── Install confinement + manifest (the reversibility spine) ─────────────────
+
+  private pluginDir(pluginId: string): string {
+    return join(this.managedPluginsDir, sanitizePluginId(pluginId));
+  }
+
+  /** The only writable file: the managed settings. Anything else → throw. */
+  private assertManagedSettings(target: string): void {
+    if (resolve(target) !== resolve(this.settingsPath)) {
+      throw new Error(`target_path is not the managed settings file: ${target}`);
+    }
+  }
+
+  /** Installs may only ever land inside the managed plugins dir. */
+  private assertInsidePlugins(target: string): void {
+    const root = resolve(this.managedPluginsDir);
+    const resolved = resolve(target);
+    if (resolved !== root && !resolved.startsWith(`${root}/`)) {
+      throw new Error(`install path outside managedPluginsDir: ${target}`);
+    }
+  }
+
+  private readManifest(): ManifestEntry[] {
+    if (!existsSync(this.manifestPath)) return [];
+    try {
+      const parsed = JSON.parse(readFileSync(this.manifestPath, "utf8"));
+      return Array.isArray(parsed) ? (parsed as ManifestEntry[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private writeManifest(entries: ManifestEntry[]): void {
+    mkdirSync(this.managedPluginsDir, { recursive: true });
+    writeFileSync(this.manifestPath, stableJson(entries), "utf8");
+  }
+
+  private recordInstall(entry: ManifestEntry): void {
+    const entries = this.readManifest().filter((e) => e.pluginId !== entry.pluginId);
+    entries.push(entry);
+    this.writeManifest(entries);
+  }
+
+  /** Uninstall (rm managed dir, confined) every manifest plugin absent from `settings.mcpServers`. */
+  private reconcileManifest(settings: Record<string, unknown>): void {
+    const servers = (settings.mcpServers as Record<string, unknown> | undefined) ?? {};
+    const keep: ManifestEntry[] = [];
+    for (const e of this.readManifest()) {
+      if (e.pluginId in servers) {
+        keep.push(e);
+        continue;
+      }
+      // Orphaned → uninstall, but ONLY inside the managed dir.
+      try {
+        this.assertInsidePlugins(e.installDir);
+        rmSync(e.installDir, { recursive: true, force: true });
+      } catch {
+        // Confinement violation or fs error → drop the row but never rm outside.
+      }
+    }
+    this.writeManifest(keep);
+  }
+
+  async healthCheck(): Promise<{
+    producer_found: boolean;
+    sample_event_match_rate: number;
+    reason?: string;
+  }> {
+    if (!existsSync(this.auditLog)) {
+      return {
+        producer_found: false,
+        sample_event_match_rate: 0,
+        reason: `auditLog does not exist: ${this.auditLog}`,
+      };
+    }
+    const since = new Date(Date.now() - 7 * 86_400_000);
+    let events: Array<Record<string, unknown>>;
+    try {
+      events = this.auditReader(this.auditLog, since);
+    } catch (e) {
+      return {
+        producer_found: false,
+        sample_event_match_rate: 0,
+        reason: `auditReader failed: ${(e as Error).message.slice(0, 120)}`,
+      };
+    }
+    if (events.length === 0) {
+      return {
+        producer_found: false,
+        sample_event_match_rate: 0,
+        reason: `no audit events in last 7d at ${this.auditLog}`,
+      };
+    }
+    const mcpCalls = events.filter((e) => e.type === "mcp_tool_call").length;
+    return {
+      producer_found: true,
+      sample_event_match_rate: mcpCalls / events.length,
+      reason:
+        mcpCalls === 0
+          ? `${events.length} audit events but 0 mcp_tool_call entries — instrumentation missing?`
+          : undefined,
+    };
+  }
+
+  /**
+   * OutcomeLoop fitness for the mcp_plugin subject (MEDIUM risk).
+   *
+   * Target — `mcp_tool_failure_rate` (Tier 1, `tool_call`): fraction of MCP tool
+   * calls that failed or were blocked over the window. Lower is better. The
+   * gameable shortcut is to empty `allowedTools` (no calls → no failures), so it
+   * is guarded by `mcp_allowed_tool_count` (Tier 1b artifact, higher_is_better) —
+   * a failure-rate drop achieved by removing tools regresses the guardrail.
+   * `mcp_allowed_tool_defect_count` (Tier 1b artifact): always-on scan of the
+   * managed settings for duplicate / empty allowlist entries.
+   */
+  fitnessSignals(): Metric[] {
+    return [
+      {
+        name: "mcp_tool_failure_rate",
+        source: "tool_call",
+        kind: "verifiable",
+        direction: "lower_is_better",
+        windowDays: 7,
+        guardrails: ["mcp_allowed_tool_count"],
+      },
+      {
+        name: "mcp_allowed_tool_defect_count",
+        source: ARTIFACT_SOURCE,
+        kind: "verifiable",
+        direction: "lower_is_better",
+        windowDays: 1,
+      },
+      {
+        name: "mcp_allowed_tool_count",
+        source: ARTIFACT_SOURCE,
+        kind: "verifiable",
+        direction: "higher_is_better",
+        windowDays: 7,
+      },
+    ];
+  }
+
+  /**
+   * Telemetry read ONLY via `provider.query("tool_call", …)`; failure rate is a
+   * rate (outlier-robust by construction), not a sum. The artifact metrics scan
+   * the managed settings file directly and are omitted only when that file is
+   * absent (an empty/absent `allowedTools` legitimately measures as 0).
+   */
+  async measureFitness(
+    range: DateRange,
+    provider: TelemetryProvider,
+  ): Promise<Record<string, number>> {
+    const out: Record<string, number> = {};
+
+    // ── Tier 1: tool_call stream (value 1 = failed/blocked, 0 = ok) ─────────
+    const samples = await provider.query("tool_call", range);
+    if (samples.length > 0) {
+      out.mcp_tool_failure_rate = nonzeroRate(samples.map((s) => s.value));
+    }
+
+    // ── Tier 1b: artifact scan of allowedTools ──────────────────────────────
+    const scan = this.scanAllowedTools();
+    if (scan !== null) {
+      out.mcp_allowed_tool_count = scan.count;
+      out.mcp_allowed_tool_defect_count = scan.defects;
+    }
+
+    return out;
+  }
+
+  /**
+   * Scan the managed settings `allowedTools`. defects = duplicate + empty
+   * entries. Returns null when the settings file is absent (metric doesn't
+   * measure); an existing file with no `allowedTools` measures as `{0,0}`.
+   */
+  private scanAllowedTools(): { count: number; defects: number } | null {
+    if (!existsSync(this.settingsPath)) return null;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(readFileSync(this.settingsPath, "utf8"));
+    } catch {
+      return null;
+    }
+    const allowed = Array.isArray(parsed.allowedTools) ? (parsed.allowedTools as unknown[]) : [];
+    const seen = new Set<string>();
+    let defects = 0;
+    for (const t of allowed) {
+      if (typeof t !== "string" || t.trim().length === 0) {
+        defects += 1;
+        continue;
+      }
+      if (seen.has(t)) defects += 1;
+      else seen.add(t);
+    }
+    return { count: allowed.length, defects };
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function expandHome(p: string): string {
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+function isInstallSpec(v: unknown): v is PluginInstallSpec {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  const server = o.server as Record<string, unknown> | undefined;
+  return (
+    o.op === INSTALL_OP &&
+    typeof o.pluginId === "string" &&
+    (o.manager === "npm" || o.manager === "git") &&
+    typeof o.source === "string" &&
+    typeof server === "object" &&
+    server !== null &&
+    typeof server.command === "string" &&
+    Array.isArray(server.args) &&
+    server.args.every((a) => typeof a === "string")
+  );
+}
+
+/** Plugin id → safe single dir segment (no traversal, no separators, no dot-runs). */
+function sanitizePluginId(id: string): string {
+  const safe = id
+    .replace(/[^A-Za-z0-9._@-]/g, "_") // drop separators + anything exotic
+    .replace(/\.{2,}/g, ".") // collapse dot-runs so no ".." can ever appear
+    .replace(/^\.+/, "_"); // never start with a dot
+  if (!safe) throw new Error(`unusable pluginId: ${id}`);
+  return safe;
+}
+
+/** https git URL only — blocks file://, ssh, shell metachars, SSRF-ish hosts. */
+function isSafeGitUrl(url: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== "https:") return false;
+  const h = u.hostname.toLowerCase();
+  if (h === "localhost" || /^(127\.|10\.|192\.168\.|169\.254\.|0\.)/.test(h)) return false;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return false;
+  return true;
+}
+
+/** npm spec: package name (optionally @scope) + optional @version. No shell metachars/paths. */
+function isSafeNpmSpec(spec: string): boolean {
+  return /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*(@[\w.\-^~*x>=<| ]+)?$/i.test(spec);
+}
+
+/**
+ * Real installer: a confined subprocess with array args (no shell), a wall-clock
+ * timeout, a bounded output buffer, and a validated source. git → shallow clone
+ * into the dest; npm → install the package under the dest prefix.
+ */
+function defaultInstaller(spec: { manager: "npm" | "git"; source: string; destDir: string }): {
+  ok: boolean;
+  output: string;
+} {
+  const run = (cmd: string, args: string[], cwd?: string) => {
+    const r = spawnSync(cmd, args, {
+      cwd,
+      timeout: INSTALL_TIMEOUT_MS,
+      maxBuffer: INSTALL_MAX_BUFFER,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: false,
+    });
+    const out = `${r.stdout ?? ""}${r.stderr ?? ""}`;
+    if (r.error) return { ok: false, output: `${r.error.message}\n${out}` };
+    return { ok: r.status === 0, output: out };
+  };
+
+  if (spec.manager === "git") {
+    if (!isSafeGitUrl(spec.source)) return { ok: false, output: `unsafe git url: ${spec.source}` };
+    return run("git", ["clone", "--depth", "1", "--", spec.source, spec.destDir]);
+  }
+  if (!isSafeNpmSpec(spec.source)) return { ok: false, output: `unsafe npm spec: ${spec.source}` };
+  return run("npm", ["install", "--no-fund", "--no-audit", "--prefix", spec.destDir, spec.source]);
+}
+
+function makeCluster(
+  id: string,
+  obs: Observation[],
+  successRate: number,
+  sentiment: "negative" | "neutral" | "positive",
+): Cluster {
+  return {
+    id,
+    subject: "mcp_plugin",
+    observations: obs,
+    frequency: obs.length,
+    success_rate: successRate,
+    sentiment,
+    subjects_touched: obs.map(
+      (o) =>
+        `${(o.metadata as Record<string, unknown>).server}::${(o.metadata as Record<string, unknown>).tool}`,
+    ),
+  };
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value, sortReplacer, 2);
+}
+
+function sortReplacer(_key: string, value: unknown): unknown {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const sorted: Record<string, unknown> = {};
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[k] = (value as Record<string, unknown>)[k];
+    }
+    return sorted;
+  }
+  return value;
+}
+
+function defaultAuditReader(path: string, since: Date): Array<Record<string, unknown>> {
+  if (!existsSync(path)) return [];
+  const events: Array<Record<string, unknown>> = [];
+  let content: string;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch {
+    return [];
+  }
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed);
+      if (typeof obj !== "object" || obj === null) continue;
+      const ts = (obj as Record<string, unknown>).ts;
+      if (ts) {
+        const tsDate = new Date(ts as string | number);
+        if (tsDate < since) continue;
+      }
+      events.push(obj as Record<string, unknown>);
+    } catch {}
+  }
+  return events;
+}

--- a/src/tuner/subjects/mcp-plugin-subject.ts
+++ b/src/tuner/subjects/mcp-plugin-subject.ts
@@ -17,11 +17,15 @@ import type { RevertibleSubject } from "../wisecron/types.js";
 import type { DateRange, Metric, TelemetryProvider } from "../../skills-tuner/core/telemetry.js";
 import { ARTIFACT_SOURCE } from "../../skills-tuner/core/telemetry.js";
 import { nonzeroRate } from "../../skills-tuner/core/aggregate.js";
+import { detectCapabilityGaps, type CapabilityGap } from "../wisecron/capability-gap.js";
+import { lookupCapability } from "../wisecron/technique-plugin-registry.js";
 
 const BROKEN_MIN_CALLS = 100;
 const BROKEN_SUCCESS_RATE = 0.5;
 const DEAD_WINDOW_DAYS = 90;
 const TRUST_BLOCKED_THRESHOLD = 0.7;
+/** Minimum unmet-intent count before a capability gap is worth a proposal. */
+const CAPABILITY_GAP_MIN = 3;
 
 /** Install subprocess wall-clock cap. */
 const INSTALL_TIMEOUT_MS = 120_000;
@@ -89,6 +93,14 @@ export interface McpPluginSubjectConfig {
   managedPluginsDir?: string;
   /** Injected installer for tests (default = real spawnSync git/npm). */
   installer?: PluginInstaller;
+  /** Session-transcript dirs mined for capability gaps. Default: ~/.claude/projects. */
+  transcriptDirs?: string[];
+  /** Min unmet-intent count before a capability gap becomes an observation. */
+  capabilityGapMin?: number;
+  /** Operator approved-list path for capability offers. Default registry path. */
+  registryPath?: string;
+  /** Injected capability-gap detector for tests. */
+  gapDetector?: (opts: { transcriptDirs?: string[]; since?: Date }) => CapabilityGap[];
 }
 
 export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
@@ -106,10 +118,21 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
   private readonly managedPluginsDir: string;
   private readonly manifestPath: string;
   private readonly installer: PluginInstaller;
+  private readonly transcriptDirs?: string[];
+  private readonly capabilityGapMin: number;
+  private readonly registryPath?: string;
+  private readonly gapDetector: (opts: {
+    transcriptDirs?: string[];
+    since?: Date;
+  }) => CapabilityGap[];
 
   constructor(opts: McpPluginSubjectConfig = {}) {
     super();
     this.llm = opts.llm;
+    this.transcriptDirs = opts.transcriptDirs;
+    this.capabilityGapMin = opts.capabilityGapMin ?? CAPABILITY_GAP_MIN;
+    this.registryPath = opts.registryPath;
+    this.gapDetector = opts.gapDetector ?? detectCapabilityGaps;
     this.auditLog = expandHome(
       opts.auditLog ?? join(homedir(), ".claudeclaw", "journal", "operations.jsonl"),
     );
@@ -126,7 +149,8 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
 
   async collectObservations(since: Date): Promise<Observation[]> {
     const events = this.auditReader(this.auditLog, since);
-    if (events.length === 0) return [];
+    // NOTE: do NOT early-return on empty events — a capability GAP is precisely
+    // the absence of a tool, so it must be detected even with no MCP activity.
 
     const stats = new Map<string, ToolStats>();
     for (const ev of events) {
@@ -197,6 +221,41 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
         },
       });
     }
+
+    // ── Capability-gap face: needs detected from the operator's OWN behaviour ──
+    // (session transcripts = trusted internal data; no external source can inject
+    // a need). A gap ≥ the min becomes an observation → a governed install offer.
+    let gaps: CapabilityGap[] = [];
+    try {
+      gaps = this.gapDetector({ transcriptDirs: this.transcriptDirs, since });
+    } catch {
+      gaps = [];
+    }
+    for (const g of gaps) {
+      if (g.unmetIntentCount < this.capabilityGapMin) continue;
+      observations.push({
+        session_id: `mcp-capgap-${g.capability}-${now.getTime()}`,
+        observed_at: now,
+        signal_type: "repeated_trigger",
+        verbatim: sanitizeObservationContent(
+          JSON.stringify({
+            capability: g.capability,
+            unmet: g.unmetIntentCount,
+            sessions_with_gap: g.sessionsWithGap,
+            examples: g.examples,
+          }),
+          500,
+        ),
+        metadata: {
+          subject: "mcp_plugin",
+          kind: "capability_gap",
+          capability: g.capability,
+          unmet: g.unmetIntentCount,
+          sessions_with_gap: g.sessionsWithGap,
+          examples: g.examples,
+        },
+      });
+    }
     return observations;
   }
 
@@ -205,9 +264,14 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
     const broken: Observation[] = [];
     const dead: Observation[] = [];
     const blockedAllow: Observation[] = [];
+    const capGap: Observation[] = [];
 
     for (const obs of observations) {
       const meta = obs.metadata as Record<string, unknown>;
+      if (meta.kind === "capability_gap") {
+        capGap.push(obs);
+        continue;
+      }
       const calls = (meta.calls as number) ?? 0;
       const successRate = (meta.success_rate as number) ?? 1;
       const blocked = (meta.blocked as number) ?? 0;
@@ -224,6 +288,17 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
     if (dead.length > 0) clusters.push(makeCluster("mcp-dead", dead, 0.0, "neutral"));
     if (blockedAllow.length > 0)
       clusters.push(makeCluster("mcp-blocked-allow", blockedAllow, 0.6, "neutral"));
+    // One cluster per distinct missing capability.
+    const byCap = new Map<string, Observation[]>();
+    for (const o of capGap) {
+      const cap = String((o.metadata as Record<string, unknown>).capability ?? "unknown");
+      const arr = byCap.get(cap) ?? [];
+      arr.push(o);
+      byCap.set(cap, arr);
+    }
+    for (const [cap, obs] of byCap) {
+      clusters.push(makeCluster(`mcp-capability-gap:${cap}`, obs, 0.8, "neutral"));
+    }
     return clusters;
   }
 
@@ -231,6 +306,9 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
     const firstObs = cluster.observations[0];
     if (!firstObs) throw new Error("mcp-plugin-subject.proposeChange: cluster empty");
     const meta = firstObs.metadata as Record<string, unknown>;
+    // ── Capability-gap → offer an APPROVED plugin install (need from the
+    //    operator's behaviour, offer from the operator-approved registry). ──
+    if (meta.kind === "capability_gap") return this.proposeCapabilityInstall(cluster, meta);
     const server = meta.server as string;
     const tool = meta.tool as string;
 
@@ -284,6 +362,62 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
         },
       ],
       pattern_signature: `mcp_plugin:${cluster.id}:${server}:${tool}`,
+      created_at: new Date(),
+    };
+  }
+
+  /**
+   * Turn a detected capability gap into a governed install proposal. The NEED
+   * came from the operator's own transcripts; the OFFER comes from the approved
+   * registry (`lookupCapability`). Approved (verified) entries first; if none,
+   * seeds are surfaced flagged UNVERIFIED; if the registry has nothing, a
+   * detect-only note (nothing is ever written without an approved entry). Each
+   * install alternative carries a `PluginInstallSpec` → apply() routes it through
+   * the confined, reversible install path.
+   */
+  private proposeCapabilityInstall(
+    cluster: Cluster,
+    meta: Record<string, unknown>,
+  ): UnsignedProposal {
+    const capability = String(meta.capability ?? "unknown");
+    const unmet = Number(meta.unmet ?? 0);
+    let offers = lookupCapability(capability, { registryPath: this.registryPath });
+    if (offers.length === 0) {
+      offers = lookupCapability(capability, {
+        registryPath: this.registryPath,
+        includeUnverified: true,
+      });
+    }
+    const alternatives = offers.map((e) => ({
+      id: `install:${e.pluginId}`,
+      label: `Install ${e.pluginId} for ${capability}${e.verified ? "" : " (UNVERIFIED — verify at gate)"}`,
+      diff_or_content: stableJson({
+        op: INSTALL_OP,
+        pluginId: e.pluginId,
+        manager: e.manager,
+        source: e.source,
+        server: e.server,
+      }),
+      tradeoff: `${e.description}${e.note ? ` — ${e.note}` : ""}`,
+    }));
+    if (alternatives.length === 0) {
+      alternatives.push({
+        id: "detect-only",
+        label: `Capability gap: ${capability} — no approved plugin in the registry`,
+        diff_or_content: stableJson({
+          note: `${unmet} unmet ${capability} intents. Curate an approved entry in the registry to offer an install.`,
+        }),
+        tradeoff: "Detect-only: nothing is installed until an approved entry exists.",
+      });
+    }
+    return {
+      id: Date.now(),
+      cluster_id: cluster.id,
+      subject: "mcp_plugin",
+      kind: "patch",
+      target_path: this.settingsPath,
+      alternatives,
+      pattern_signature: `mcp_plugin:capability_gap:${capability}`,
       created_at: new Date(),
     };
   }

--- a/src/tuner/subjects/mcp-plugin-subject.ts
+++ b/src/tuner/subjects/mcp-plugin-subject.ts
@@ -1,4 +1,12 @@
-import { existsSync, copyFileSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  copyFileSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  lstatSync,
+} from "node:fs";
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
@@ -18,7 +26,11 @@ import type { DateRange, Metric, TelemetryProvider } from "../../skills-tuner/co
 import { ARTIFACT_SOURCE } from "../../skills-tuner/core/telemetry.js";
 import { nonzeroRate } from "../../skills-tuner/core/aggregate.js";
 import { detectCapabilityGaps, type CapabilityGap } from "../wisecron/capability-gap.js";
-import { lookupCapability } from "../wisecron/technique-plugin-registry.js";
+import {
+  lookupCapability,
+  matchRegistryEntry,
+  allRegistryEntries,
+} from "../wisecron/technique-plugin-registry.js";
 
 const BROKEN_MIN_CALLS = 100;
 const BROKEN_SUCCESS_RATE = 0.5;
@@ -124,6 +136,7 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
   private readonly gapDetector: (opts: {
     transcriptDirs?: string[];
     since?: Date;
+    providedCapabilities?: string[];
   }) => CapabilityGap[];
 
   constructor(opts: McpPluginSubjectConfig = {}) {
@@ -225,9 +238,23 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
     // ── Capability-gap face: needs detected from the operator's OWN behaviour ──
     // (session transcripts = trusted internal data; no external source can inject
     // a need). A gap ≥ the min becomes an observation → a governed install offer.
+    // Install-aware: suppress a gap whose capability is ALREADY provisioned by an
+    // installed mcpServers entry (not just "a tool was used this session").
+    const providedCapabilities: string[] = [];
+    try {
+      if (existsSync(this.settingsPath)) {
+        const st = JSON.parse(readFileSync(this.settingsPath, "utf8")) as Record<string, unknown>;
+        const servers = Object.keys((st.mcpServers as Record<string, unknown>) ?? {});
+        for (const e of allRegistryEntries({ registryPath: this.registryPath })) {
+          if (e.capability && servers.includes(e.pluginId)) providedCapabilities.push(e.capability);
+        }
+      }
+    } catch {
+      /* ignore malformed settings */
+    }
     let gaps: CapabilityGap[] = [];
     try {
-      gaps = this.gapDetector({ transcriptDirs: this.transcriptDirs, since });
+      gaps = this.gapDetector({ transcriptDirs: this.transcriptDirs, since, providedCapabilities });
     } catch {
       gaps = [];
     }
@@ -438,6 +465,7 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
     // ── allowedTools / disable-server path (existing behaviour) ─────────────────
     // Parse + restringify to guarantee stable key order even if alt source skipped it.
     const normalized = stableJson(parsed);
+    assertNotSymlink(proposal.target_path);
     if (existsSync(proposal.target_path)) {
       copyFileSync(proposal.target_path, `${proposal.target_path}.bak`);
     }
@@ -456,6 +484,14 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
    * entry. On success we record a manifest row so revert can uninstall.
    */
   private applyInstall(spec: PluginInstallSpec, settingsTarget: string): Patch {
+    // Apply-time approved-list gate: the propose-time `verified` check is not
+    // enough — an externally-ingested proposal could carry an off-registry
+    // source behind a benign label. Require an EXACT match to a curated entry.
+    if (!matchRegistryEntry(spec, { registryPath: this.registryPath })) {
+      throw new Error(
+        `mcp-plugin-subject.applyInstall: spec for '${spec.pluginId}' matches no approved registry entry — refusing install`,
+      );
+    }
     const destDir = this.pluginDir(spec.pluginId);
     this.assertInsidePlugins(destDir);
 
@@ -489,6 +525,7 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
     }
 
     // Register the server in settings (.bak first), then record the manifest.
+    assertNotSymlink(settingsTarget);
     if (existsSync(settingsTarget)) copyFileSync(settingsTarget, `${settingsTarget}.bak`);
     writeFileSync(settingsTarget, normalizedSettings, "utf8");
     this.recordInstall({
@@ -571,6 +608,7 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
     this.assertManagedSettings(inversePatch.target_path);
     // Roundtrip parse to keep formatting stable + reject malformed inputs early.
     const restored = JSON.parse(inversePatch.applied_content) as Record<string, unknown>;
+    assertNotSymlink(inversePatch.target_path);
     writeFileSync(inversePatch.target_path, inversePatch.applied_content, "utf8");
     // Reconcile installs: uninstall any tuner-installed plugin that the restored
     // settings no longer reference (so reverting an install also removes it).
@@ -809,6 +847,23 @@ function sanitizePluginId(id: string): string {
   return safe;
 }
 
+/**
+ * Refuse to write THROUGH a symlink. Lexical path confinement (resolve()) does
+ * not resolve symlinks, but copyFile/writeFile follow them — a planted symlink
+ * at a managed target could redirect the write to engine code. lstat (no follow)
+ * catches it before any write.
+ */
+function assertNotSymlink(target: string): void {
+  try {
+    if (lstatSync(target).isSymbolicLink()) {
+      throw new Error(`refusing to write through a symlink: ${target}`);
+    }
+  } catch (e) {
+    // ENOENT (target doesn't exist yet) is fine; re-throw our own guard error.
+    if (e instanceof Error && e.message.startsWith("refusing to write")) throw e;
+  }
+}
+
 /** https git URL only — blocks file://, ssh, shell metachars, SSRF-ish hosts. */
 function isSafeGitUrl(url: string): boolean {
   let u: URL;
@@ -819,6 +874,10 @@ function isSafeGitUrl(url: string): boolean {
   }
   if (u.protocol !== "https:") return false;
   const h = u.hostname.toLowerCase();
+  // Reject ALL IPv6 literals (bracketed `.hostname` contains ':') — the IPv4-only
+  // denylist below missed `[::1]`, `[::ffff:127.0.0.1]`, `fe80::/10`, `fc00::/7`,
+  // `[::]` (SSRF to loopback/link-local/internal). No git host is an IPv6 literal.
+  if (h.includes(":") || h.includes("[")) return false;
   if (h === "localhost" || /^(127\.|10\.|192\.168\.|169\.254\.|0\.)/.test(h)) return false;
   if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return false;
   return true;
@@ -826,7 +885,9 @@ function isSafeGitUrl(url: string): boolean {
 
 /** npm spec: package name (optionally @scope) + optional @version. No shell metachars/paths. */
 function isSafeNpmSpec(spec: string): boolean {
-  return /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*(@[\w.\-^~*x>=<| ]+)?$/i.test(spec);
+  // Leading char classes exclude '-' so a spec can never begin with a flag
+  // (belt-and-suspenders with the `--` end-of-options separator at the call site).
+  return /^(@[a-z0-9~][a-z0-9-._~]*\/)?[a-z0-9~][a-z0-9-._~]*(@[\w.\-^~*x>=<| ]+)?$/i.test(spec);
 }
 
 /**
@@ -838,9 +899,10 @@ function defaultInstaller(spec: { manager: "npm" | "git"; source: string; destDi
   ok: boolean;
   output: string;
 } {
-  const run = (cmd: string, args: string[], cwd?: string) => {
+  const run = (cmd: string, args: string[], cwd?: string, env?: NodeJS.ProcessEnv) => {
     const r = spawnSync(cmd, args, {
       cwd,
+      env,
       timeout: INSTALL_TIMEOUT_MS,
       maxBuffer: INSTALL_MAX_BUFFER,
       encoding: "utf8",
@@ -857,7 +919,26 @@ function defaultInstaller(spec: { manager: "npm" | "git"; source: string; destDi
     return run("git", ["clone", "--depth", "1", "--", spec.source, spec.destDir]);
   }
   if (!isSafeNpmSpec(spec.source)) return { ok: false, output: `unsafe npm spec: ${spec.source}` };
-  return run("npm", ["install", "--no-fund", "--no-audit", "--prefix", spec.destDir, spec.source]);
+  // --ignore-scripts: npm runs package pre/post-install lifecycle scripts by
+  // default, which execute arbitrary package-authored code OUTSIDE the managed
+  // dir (filesystem confinement doesn't confine execution) — install-time RCE
+  // that would break the "tuner never writes engine code" invariant. `--` ends
+  // option parsing so a spec can't smuggle a flag. env scrubs npm_config_* too.
+  return run(
+    "npm",
+    [
+      "install",
+      "--ignore-scripts",
+      "--no-fund",
+      "--no-audit",
+      "--prefix",
+      spec.destDir,
+      "--",
+      spec.source,
+    ],
+    undefined,
+    { ...process.env, npm_config_ignore_scripts: "true" },
+  );
 }
 
 function makeCluster(

--- a/src/tuner/subjects/mcp-plugin-subject.ts
+++ b/src/tuner/subjects/mcp-plugin-subject.ts
@@ -6,10 +6,11 @@ import {
   mkdirSync,
   rmSync,
   lstatSync,
+  realpathSync,
 } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, resolve, dirname, basename } from "node:path";
 import { BaseSubject } from "../../skills-tuner/subjects/base.js";
 import { sanitizeObservationContent } from "../../skills-tuner/core/security.js";
 import type { LLMClient } from "../../skills-tuner/core/llm.js";
@@ -487,9 +488,20 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
     // Apply-time approved-list gate: the propose-time `verified` check is not
     // enough — an externally-ingested proposal could carry an off-registry
     // source behind a benign label. Require an EXACT match to a curated entry.
-    if (!matchRegistryEntry(spec, { registryPath: this.registryPath })) {
+    const registryEntry = matchRegistryEntry(spec, { registryPath: this.registryPath });
+    if (!registryEntry) {
       throw new Error(
         `mcp-plugin-subject.applyInstall: spec for '${spec.pluginId}' matches no approved registry entry — refusing install`,
+      );
+    }
+    // Belt-and-braces with the human gate: even a spec that matches a registry
+    // entry must match a VERIFIED one. Built-in seeds ship `verified: false` by
+    // design (they are recommendations the operator must vet at the gate), so an
+    // unverified seed can never be installed even if a proposal reaches apply()
+    // carrying its exact spec.
+    if (!registryEntry.verified) {
+      throw new Error(
+        `mcp-plugin-subject.applyInstall: spec for '${spec.pluginId}' matches only an UNVERIFIED registry entry — refusing install`,
       );
     }
     const destDir = this.pluginDir(spec.pluginId);
@@ -514,6 +526,13 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
     });
 
     // Clean any stale dir from a previous failed attempt, then install.
+    // Symlink guard BEFORE any fs mutation: a planted symlink at the managed
+    // plugins dir or at the specific install dir would make rmSync/mkdir/clone
+    // follow it OUT of the managed surface. assertInsidePlugins(destDir) above
+    // already realpath-resolves the whole chain; these lstat checks are the
+    // direct belt-and-braces the settings-file path uses.
+    assertNotSymlink(this.managedPluginsDir);
+    assertNotSymlink(destDir);
     if (existsSync(destDir)) rmSync(destDir, { recursive: true, force: true });
     mkdirSync(destDir, { recursive: true });
     const res = this.installer({ manager: spec.manager, source: spec.source, destDir });
@@ -628,12 +647,34 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
     }
   }
 
-  /** Installs may only ever land inside the managed plugins dir. */
+  /**
+   * Installs may only ever land inside the managed plugins dir — enforced on TWO
+   * axes so neither a `..` nor a symlink can escape:
+   *   1. Lexical: `resolve()` (no fs touch) rejects `..` traversal.
+   *   2. Symlink: resolve symlinks on the existing part of the chain and require
+   *      the REAL target to stay under a root canonicalised the same way. The
+   *      target (e.g. `<managed>/<plugin>`) does not exist yet, so we realpath the
+   *      nearest EXISTING ancestor and re-append the not-yet-created suffix —
+   *      catching a planted symlink AT the managed dir or any component of the
+   *      install path, while tolerating benign symlinks ABOVE it (e.g. /tmp).
+   */
   private assertInsidePlugins(target: string): void {
-    const root = resolve(this.managedPluginsDir);
-    const resolved = resolve(target);
-    if (resolved !== root && !resolved.startsWith(`${root}/`)) {
+    const lexicalRoot = resolve(this.managedPluginsDir);
+    const lexicalTarget = resolve(target);
+    // 1. Lexical confinement — a `..` can never point the install outside.
+    if (lexicalTarget !== lexicalRoot && !lexicalTarget.startsWith(`${lexicalRoot}/`)) {
       throw new Error(`install path outside managedPluginsDir: ${target}`);
+    }
+    // 2. Symlink confinement — canonicalise ONLY the ancestry above the managed
+    //    dir, then keep the managed dir's own name lexical, so a symlink planted
+    //    AT the managed dir (or below) diverges the real target and is refused.
+    const canonicalRoot = join(
+      realpathNearestExisting(dirname(lexicalRoot)),
+      basename(lexicalRoot),
+    );
+    const realTarget = realpathNearestExisting(lexicalTarget);
+    if (realTarget !== canonicalRoot && !realTarget.startsWith(`${canonicalRoot}/`)) {
+      throw new Error(`install path escapes managedPluginsDir via symlink: ${target}`);
     }
   }
 
@@ -648,6 +689,9 @@ export class McpPluginSubject extends BaseSubject implements RevertibleSubject {
   }
 
   private writeManifest(entries: ManifestEntry[]): void {
+    // Never mkdir/write the manifest through a symlinked managed dir.
+    assertNotSymlink(this.managedPluginsDir);
+    this.assertInsidePlugins(this.managedPluginsDir);
     mkdirSync(this.managedPluginsDir, { recursive: true });
     writeFileSync(this.manifestPath, stableJson(entries), "utf8");
   }
@@ -864,8 +908,30 @@ function assertNotSymlink(target: string): void {
   }
 }
 
+/**
+ * realpath the longest EXISTING prefix of `p`, then re-append the not-yet-created
+ * suffix lexically. An install leaf (`<managed>/<plugin>`) doesn't exist yet, so
+ * we can't realpath it directly — this canonicalises symlinks on the real part of
+ * the chain while keeping the pending components literal. Benign symlinks above
+ * the managed dir (e.g. `/tmp` → `/private/tmp`) resolve consistently for both
+ * the root and the target, so they don't trip confinement; a symlink planted AT
+ * or below the managed dir diverges the target and is caught.
+ */
+function realpathNearestExisting(p: string): string {
+  let existing = resolve(p);
+  const suffix: string[] = [];
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) return existing; // reached filesystem root
+    suffix.unshift(basename(existing));
+    existing = parent;
+  }
+  const realBase = realpathSync(existing);
+  return suffix.length ? join(realBase, ...suffix) : realBase;
+}
+
 /** https git URL only — blocks file://, ssh, shell metachars, SSRF-ish hosts. */
-function isSafeGitUrl(url: string): boolean {
+export function isSafeGitUrl(url: string): boolean {
   let u: URL;
   try {
     u = new URL(url);
@@ -884,7 +950,7 @@ function isSafeGitUrl(url: string): boolean {
 }
 
 /** npm spec: package name (optionally @scope) + optional @version. No shell metachars/paths. */
-function isSafeNpmSpec(spec: string): boolean {
+export function isSafeNpmSpec(spec: string): boolean {
   // Leading char classes exclude '-' so a spec can never begin with a flag
   // (belt-and-suspenders with the `--` end-of-options separator at the call site).
   return /^(@[a-z0-9~][a-z0-9-._~]*\/)?[a-z0-9~][a-z0-9-._~]*(@[\w.\-^~*x>=<| ]+)?$/i.test(spec);
@@ -976,7 +1042,7 @@ function sortReplacer(_key: string, value: unknown): unknown {
   return value;
 }
 
-function defaultAuditReader(path: string, since: Date): Array<Record<string, unknown>> {
+export function defaultAuditReader(path: string, since: Date): Array<Record<string, unknown>> {
   if (!existsSync(path)) return [];
   const events: Array<Record<string, unknown>> = [];
   let content: string;
@@ -991,11 +1057,13 @@ function defaultAuditReader(path: string, since: Date): Array<Record<string, unk
     try {
       const obj = JSON.parse(trimmed);
       if (typeof obj !== "object" || obj === null) continue;
+      // A line with no (or an unparseable) timestamp can never age out of the
+      // `since` window — it would accumulate on every read and inflate the
+      // dead-tool counts. Treat a missing/invalid ts as pre-window and skip it.
       const ts = (obj as Record<string, unknown>).ts;
-      if (ts) {
-        const tsDate = new Date(ts as string | number);
-        if (tsDate < since) continue;
-      }
+      if (!ts) continue;
+      const tsDate = new Date(ts as string | number);
+      if (Number.isNaN(tsDate.getTime()) || tsDate < since) continue;
       events.push(obj as Record<string, unknown>);
     } catch {}
   }

--- a/src/tuner/wisecron/capability-gap.ts
+++ b/src/tuner/wisecron/capability-gap.ts
@@ -1,0 +1,203 @@
+/**
+ * capability-gap — detect a capability the operator repeatedly NEEDS but does
+ * not have, from their own behaviour (session transcripts = trusted internal
+ * data; no external source can inject a "need"). Example: many research-intent
+ * prompts with no web-search tool available → the operator needs Brave/Perplexity.
+ *
+ * The detected NEED is anchored in the operator's transcripts; the OFFER comes
+ * from the approved technique-plugin-registry (`lookupCapability`). A gap becomes
+ * a human-gated, reversible plugin install (mcp-plugin-subject) — never auto-run.
+ *
+ * Deliberately deterministic + heuristic (regex intent/tool matching). It is a
+ * signal ("you asked N research questions with no search tool"), not a proof;
+ * the number carries the argument, the human decides. Never throws.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Prompts longer than this are treated as system/tool/harness text, not a natural operator ask. */
+const MAX_PROMPT_CHARS = 400;
+
+export interface CapabilitySpec {
+  /** Capability tag; matches `PluginEntry.capability` in the registry. */
+  capability: string;
+  /** User-prompt patterns signalling the need. */
+  intent: RegExp[];
+  /** Tool-name patterns that would already satisfy the need (→ no gap). */
+  tools: RegExp[];
+}
+
+export interface CapabilityGap {
+  capability: string;
+  /** Intent prompts that occurred in sessions with NO satisfying tool. */
+  unmetIntentCount: number;
+  sessionsScanned: number;
+  sessionsWithGap: number;
+  /** A few example prompts (truncated) for the proposal / app display. */
+  examples: string[];
+}
+
+/** Built-in specs. web_search is the canonical first gap (Brave / Perplexity). */
+export const DEFAULT_CAPABILITY_SPECS: CapabilitySpec[] = [
+  {
+    capability: "web_search",
+    intent: [
+      /\b(latest|newest|current|most recent)\b.{0,24}\b(version|release|news|price|rate|score)\b/i,
+      /\bsearch (the web|online|for it|for the)\b/i,
+      /\blook (it|this|that) up\b/i,
+      /\bwhat'?s the (latest|current|newest)\b/i,
+      /\bgoogle (it|this|that)\b/i,
+      /\bweb ?search\b/i,
+      /\bfind (out )?(online|on the web|the latest)\b/i,
+      /\bc'?est quoi (la |le )?(derni[eè]re|nouvelle|dernier)\b/i,
+      /\b(cherche|recherche)\b.{0,30}\b(web|internet|en ligne|google)\b/i,
+    ],
+    tools: [
+      /brave|perplexity|tavily|serper|\bexa\b|web_?search|websearch|web_?fetch|google_?search/i,
+    ],
+  },
+];
+
+type Ev = {
+  type?: string;
+  role?: string;
+  message?: { role?: string; content?: unknown };
+  content?: unknown;
+};
+type Block = { type?: string; text?: string; name?: string };
+
+function expandHome(p: string): string {
+  return p.replace(/^~(?=\/|$)/, homedir());
+}
+
+function content(ev: Ev): unknown {
+  return ev.message?.content ?? ev.content;
+}
+
+function isUser(ev: Ev): boolean {
+  return ev.type === "user" || ev.message?.role === "user" || ev.role === "user";
+}
+
+function userText(ev: Ev): string | null {
+  const c = content(ev);
+  if (typeof c === "string") return c;
+  if (Array.isArray(c)) {
+    const t = (c as Block[])
+      .filter((b) => b?.type === "text" && typeof b.text === "string")
+      .map((b) => b.text as string)
+      .join(" ");
+    return t.length > 0 ? t : null;
+  }
+  return null;
+}
+
+function toolNames(ev: Ev): string[] {
+  const c = content(ev);
+  if (!Array.isArray(c)) return [];
+  return (c as Block[])
+    .filter((b) => b?.type === "tool_use" && typeof b.name === "string")
+    .map((b) => b.name as string);
+}
+
+function walk(dir: string, out: string[]): void {
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    const p = join(dir, name);
+    let isDir = false;
+    let isFile = false;
+    try {
+      const st = statSync(p);
+      isDir = st.isDirectory();
+      isFile = st.isFile();
+    } catch {
+      continue;
+    }
+    if (isDir) walk(p, out);
+    else if (isFile && name.endsWith(".jsonl")) out.push(p);
+  }
+}
+
+/**
+ * Scan session transcripts and report, per capability, how many research-intent
+ * prompts occurred in sessions that never used a satisfying tool.
+ */
+export function detectCapabilityGaps(
+  opts: {
+    transcriptDirs?: string[];
+    since?: Date;
+    specs?: CapabilitySpec[];
+    maxExamples?: number;
+  } = {},
+): CapabilityGap[] {
+  const dirs = (opts.transcriptDirs ?? [join(homedir(), ".claude", "projects")]).map(expandHome);
+  const specs = opts.specs ?? DEFAULT_CAPABILITY_SPECS;
+  const sinceMs = opts.since ? opts.since.getTime() : 0;
+  const maxEx = opts.maxExamples ?? 5;
+
+  const acc = new Map<
+    string,
+    { unmet: number; sessions: number; gap: number; examples: string[] }
+  >();
+  for (const s of specs) acc.set(s.capability, { unmet: 0, sessions: 0, gap: 0, examples: [] });
+
+  const files: string[] = [];
+  for (const d of dirs) if (existsSync(d)) walk(d, files);
+
+  for (const f of files) {
+    let lines: string[];
+    try {
+      if (sinceMs && statSync(f).mtimeMs < sinceMs) continue;
+      lines = readFileSync(f, "utf8").split("\n");
+    } catch {
+      continue;
+    }
+    const prompts: string[] = [];
+    const tools: string[] = [];
+    for (const ln of lines) {
+      if (!ln.trim()) continue;
+      let ev: Ev;
+      try {
+        ev = JSON.parse(ln) as Ev;
+      } catch {
+        continue;
+      }
+      if (isUser(ev)) {
+        const t = userText(ev);
+        // Natural asks are short; skip giant system/tool/harness-injected prompts
+        // (they aren't the operator expressing a need and skew the signal).
+        if (t && t.length <= MAX_PROMPT_CHARS) prompts.push(t);
+      }
+      tools.push(...toolNames(ev));
+    }
+    if (prompts.length === 0) continue;
+    for (const s of specs) {
+      const a = acc.get(s.capability);
+      if (!a) continue;
+      a.sessions++;
+      if (tools.some((n) => s.tools.some((re) => re.test(n)))) continue;
+      const hits = prompts.filter((p) => s.intent.some((re) => re.test(p)));
+      if (hits.length > 0) {
+        a.unmet += hits.length;
+        a.gap++;
+        for (const h of hits) if (a.examples.length < maxEx) a.examples.push(h.slice(0, 120));
+      }
+    }
+  }
+
+  return specs.map((s) => {
+    const a = acc.get(s.capability) ?? { unmet: 0, sessions: 0, gap: 0, examples: [] };
+    return {
+      capability: s.capability,
+      unmetIntentCount: a.unmet,
+      sessionsScanned: a.sessions,
+      sessionsWithGap: a.gap,
+      examples: a.examples,
+    };
+  });
+}

--- a/src/tuner/wisecron/capability-gap.ts
+++ b/src/tuner/wisecron/capability-gap.ts
@@ -12,9 +12,13 @@
  * signal ("you asked N research questions with no search tool"), not a proof;
  * the number carries the argument, the human decides. Never throws.
  */
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, lstatSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+
+/** Bound transcript-tree recursion + per-file read so a hostile/huge tree can't DoS the scan. */
+const MAX_WALK_DEPTH = 12;
+const MAX_TRANSCRIPT_BYTES = 32 * 1024 * 1024;
 
 /** Prompts longer than this are treated as system/tool/harness text, not a natural operator ask. */
 const MAX_PROMPT_CHARS = 400;
@@ -59,6 +63,15 @@ export const DEFAULT_CAPABILITY_SPECS: CapabilitySpec[] = [
   },
 ];
 
+/**
+ * Negation / meta-discussion guard: a prompt that mentions searching only to
+ * decline it ("I'll look it up myself", "no need to search", "the web search
+ * tool is broken") is NOT an unmet need. A prompt matching this is excluded even
+ * if it matches an intent pattern — cuts the biggest false-positive class.
+ */
+const INTENT_NEGATION =
+  /\b(don'?t|do not|won'?t|will not|myself|already|no need|not (?:need|going|gonna)|is broken|isn'?t working|pas besoin|moi-?même|d[eé]j[aà])\b/i;
+
 type Ev = {
   type?: string;
   role?: string;
@@ -81,15 +94,24 @@ function isUser(ev: Ev): boolean {
 
 function userText(ev: Ev): string | null {
   const c = content(ev);
-  if (typeof c === "string") return c;
-  if (Array.isArray(c)) {
-    const t = (c as Block[])
-      .filter((b) => b?.type === "text" && typeof b.text === "string")
-      .map((b) => b.text as string)
-      .join(" ");
-    return t.length > 0 ? t : null;
-  }
-  return null;
+  const raw =
+    typeof c === "string"
+      ? c
+      : Array.isArray(c)
+        ? (c as Block[])
+            .filter((b) => b?.type === "text" && typeof b.text === "string")
+            .map((b) => b.text as string)
+            .join(" ")
+        : "";
+  // Strip injected scaffolding (hook system-reminders, command wrappers) so only
+  // the operator's own words count — and a short ask sharing a turn with a big
+  // reminder isn't pushed over MAX_PROMPT_CHARS and dropped.
+  const clean = raw
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/gi, " ")
+    .replace(/<command-[a-z-]*>[\s\S]*?<\/command-[a-z-]*>/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return clean.length > 0 ? clean : null;
 }
 
 function toolNames(ev: Ev): string[] {
@@ -100,7 +122,8 @@ function toolNames(ev: Ev): string[] {
     .map((b) => b.name as string);
 }
 
-function walk(dir: string, out: string[]): void {
+function walk(dir: string, out: string[], depth = 0): void {
+  if (depth > MAX_WALK_DEPTH) return;
   let names: string[];
   try {
     names = readdirSync(dir);
@@ -112,13 +135,14 @@ function walk(dir: string, out: string[]): void {
     let isDir = false;
     let isFile = false;
     try {
-      const st = statSync(p);
+      // lstat (no symlink follow) → a symlinked dir can't redirect/loop the walk.
+      const st = lstatSync(p);
       isDir = st.isDirectory();
       isFile = st.isFile();
     } catch {
       continue;
     }
-    if (isDir) walk(p, out);
+    if (isDir) walk(p, out, depth + 1);
     else if (isFile && name.endsWith(".jsonl")) out.push(p);
   }
 }
@@ -133,12 +157,15 @@ export function detectCapabilityGaps(
     since?: Date;
     specs?: CapabilitySpec[];
     maxExamples?: number;
+    /** Capabilities already provisioned (e.g. an installed MCP server) → never a gap. */
+    providedCapabilities?: string[];
   } = {},
 ): CapabilityGap[] {
   const dirs = (opts.transcriptDirs ?? [join(homedir(), ".claude", "projects")]).map(expandHome);
   const specs = opts.specs ?? DEFAULT_CAPABILITY_SPECS;
   const sinceMs = opts.since ? opts.since.getTime() : 0;
   const maxEx = opts.maxExamples ?? 5;
+  const provided = new Set(opts.providedCapabilities ?? []);
 
   const acc = new Map<
     string,
@@ -152,7 +179,9 @@ export function detectCapabilityGaps(
   for (const f of files) {
     let lines: string[];
     try {
-      if (sinceMs && statSync(f).mtimeMs < sinceMs) continue;
+      const st = statSync(f);
+      if (sinceMs && st.mtimeMs < sinceMs) continue;
+      if (st.size > MAX_TRANSCRIPT_BYTES) continue; // skip pathologically huge files
       lines = readFileSync(f, "utf8").split("\n");
     } catch {
       continue;
@@ -177,11 +206,14 @@ export function detectCapabilityGaps(
     }
     if (prompts.length === 0) continue;
     for (const s of specs) {
+      if (provided.has(s.capability)) continue; // capability already provisioned → no gap
       const a = acc.get(s.capability);
       if (!a) continue;
       a.sessions++;
       if (tools.some((n) => s.tools.some((re) => re.test(n)))) continue;
-      const hits = prompts.filter((p) => s.intent.some((re) => re.test(p)));
+      const hits = prompts.filter(
+        (p) => !INTENT_NEGATION.test(p) && s.intent.some((re) => re.test(p)),
+      );
       if (hits.length > 0) {
         a.unmet += hits.length;
         a.gap++;

--- a/src/tuner/wisecron/index.ts
+++ b/src/tuner/wisecron/index.ts
@@ -29,11 +29,13 @@ import type { WisecronSettings } from "./types.js";
 
 import { ModelRoutingSubject } from "../subjects/model-routing-subject.js";
 import { MemorySubject } from "../subjects/memory-subject.js";
+import { McpPluginSubject } from "../subjects/mcp-plugin-subject.js";
 // #275 staging: this brick ships the OutcomeLoop + the model-routing subject
 // (the single-subject proof) AND the memory subject (reactive index hygiene +
-// proactive evidence face). The remaining wisecron subjects (cron, claude_md,
-// hook, mcp_plugin, prompt_template, agent) land in their own follow-up bricks
-// once the loop has earned its keep.
+// proactive evidence face) AND the mcp_plugin subject (governed plugin-only
+// install boundary). The remaining wisecron subjects (cron, claude_md, hook,
+// prompt_template, agent) land in their own follow-up bricks once the loop has
+// earned its keep.
 import { makeModeDispatchReader } from "./observation-readers.js";
 
 export interface WisecronContext {
@@ -115,6 +117,10 @@ export function registerWisecronSubjects(
 
   // memory subject: reactive index hygiene + proactive evidence face.
   if (enabled("memory")) registerWithProbeCheck(new MemorySubject({ ...cfg("memory") }));
+  // mcp_plugin subject: governed plugin allowlist + gated, confined, reversible
+  // NEW-plugin install (the only sanctioned path for an architectural capability).
+  if (enabled("mcp_plugin"))
+    registerWithProbeCheck(new McpPluginSubject({ llm: opts.llm, ...cfg("mcp_plugin") }));
 
   // Resolve the active tuning scope (global + per-subject overrides) and record
   // it in the audit chain at registration — the certifier reads "the tuner

--- a/src/tuner/wisecron/technique-plugin-registry.ts
+++ b/src/tuner/wisecron/technique-plugin-registry.ts
@@ -1,0 +1,120 @@
+/**
+ * technique-plugin-registry — the curated map from a RESEARCH technique to an
+ * installable PLUGIN. This is the keystone of the hard boundary: the self-tuner
+ * never writes engine code, so an architectural capability surfaced by the
+ * evidence layer (e.g. "vectorized-retrieval") is delivered ONLY as a gated
+ * plugin install, never as a "go implement this in code" recommendation.
+ *
+ * Resolution: a technique resolves to a `PluginEntry` if (a) a built-in seed
+ * maps it, or (b) the operator curated it in `~/.config/tuner/technique-plugins.json`.
+ * Operator entries win on id collision. A technique with NO entry resolves to
+ * `null` → the proactive cycle emits a detect-only NOTE (nothing to write),
+ * never a code change.
+ *
+ * Security: every entry carries `verified`. Seeds ship `verified: false` — the
+ * registry only *proposes* an install; a human verifies the package/source at
+ * the gate before apply. Install itself is confined + reversible (see
+ * mcp-plugin-subject).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** How the plugin is fetched + installed. Both confined to the managed dir. */
+export type PluginManager = "npm" | "git";
+
+/** A curated technique → installable plugin mapping. */
+export interface PluginEntry {
+  /** The research technique this plugin implements (matches ResearchSpec.technique). */
+  technique: string;
+  /** Stable id; also the `mcpServers` key written into settings. */
+  pluginId: string;
+  /** npm = `npm install <source>` into the managed dir; git = `git clone <source>`. */
+  manager: PluginManager;
+  /** npm package spec (e.g. "pkg@1.2.3") or a clone URL (https git only). */
+  source: string;
+  /** The MCP server entry written into settings.mcpServers[pluginId]. */
+  server: { command: string; args: string[] };
+  /** Human-readable capability description (shown in the proposal). */
+  description: string;
+  /** false on seeds: the operator MUST verify the package/source at the gate. */
+  verified: boolean;
+  /** Provenance / verification note shown alongside the proposal. */
+  note?: string;
+}
+
+/**
+ * Built-in seeds. Deliberately conservative + `verified: false`: they exist to
+ * demonstrate the path and to give the operator a starting point, not to be
+ * auto-trusted. Curate real, pinned entries in the operator file.
+ */
+export const BUILTIN_REGISTRY: readonly PluginEntry[] = [
+  {
+    technique: "vectorized-retrieval",
+    pluginId: "mcp-server-qdrant",
+    manager: "git",
+    source: "https://github.com/qdrant/mcp-server-qdrant",
+    server: { command: "uvx", args: ["--from", ".", "mcp-server-qdrant"] },
+    description: "Vector retrieval over a Qdrant store — vectorised memory recall.",
+    verified: false,
+    note: "Seed (UNVERIFIED): confirm the repo + pin a commit before approving.",
+  },
+];
+
+/** Default operator-curated registry file (JSON array of PluginEntry). */
+export function defaultRegistryPath(): string {
+  return join(homedir(), ".config", "tuner", "technique-plugins.json");
+}
+
+function expandHome(p: string): string {
+  return p.replace(/^~(?=\/|$)/, homedir());
+}
+
+/** Load + validate operator entries. Malformed file → [] (never throws). */
+export function loadOperatorEntries(path = defaultRegistryPath()): PluginEntry[] {
+  const resolved = expandHome(path);
+  if (!existsSync(resolved)) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(resolved, "utf8"));
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter(isValidEntry);
+}
+
+function isValidEntry(e: unknown): e is PluginEntry {
+  if (typeof e !== "object" || e === null) return false;
+  const o = e as Record<string, unknown>;
+  const server = o.server as Record<string, unknown> | undefined;
+  return (
+    typeof o.technique === "string" &&
+    typeof o.pluginId === "string" &&
+    (o.manager === "npm" || o.manager === "git") &&
+    typeof o.source === "string" &&
+    typeof o.description === "string" &&
+    typeof o.verified === "boolean" &&
+    typeof server === "object" &&
+    server !== null &&
+    typeof server.command === "string" &&
+    Array.isArray(server.args) &&
+    server.args.every((a) => typeof a === "string")
+  );
+}
+
+/**
+ * Resolve a technique to its installable plugin, or null. Operator entries
+ * override built-in seeds with the same pluginId. The first matching entry for
+ * the technique wins (operator file scanned first).
+ */
+export function lookupPlugin(
+  technique: string,
+  opts: { registryPath?: string; includeBuiltins?: boolean } = {},
+): PluginEntry | null {
+  const operator = loadOperatorEntries(opts.registryPath);
+  const builtins = opts.includeBuiltins === false ? [] : BUILTIN_REGISTRY;
+  const overridden = new Set(operator.map((e) => e.pluginId));
+  const merged = [...operator, ...builtins.filter((e) => !overridden.has(e.pluginId))];
+  return merged.find((e) => e.technique === technique) ?? null;
+}

--- a/src/tuner/wisecron/technique-plugin-registry.ts
+++ b/src/tuner/wisecron/technique-plugin-registry.ts
@@ -171,3 +171,42 @@ export function lookupCapability(
     (e) => e.capability === capability && (opts.includeUnverified === true || e.verified),
   );
 }
+
+/** All resolvable entries (operator ∪ built-ins, operator wins on id). */
+export function allRegistryEntries(
+  opts: { registryPath?: string; includeBuiltins?: boolean } = {},
+): PluginEntry[] {
+  const operator = loadOperatorEntries(opts.registryPath);
+  const builtins = opts.includeBuiltins === false ? [] : BUILTIN_REGISTRY;
+  const overridden = new Set(operator.map((e) => e.pluginId));
+  return [...operator, ...builtins.filter((e) => !overridden.has(e.pluginId))];
+}
+
+/**
+ * Does an install spec match an approved registry entry EXACTLY (pluginId +
+ * manager + source + server.command + server.args)? The apply-time gate: a
+ * proposal (incl. externally-ingested ones) may only install a spec that a
+ * curated registry entry authorises — the propose-time approved-list check is
+ * not enough on its own. Returns the matching entry, or null.
+ */
+export function matchRegistryEntry(
+  spec: {
+    pluginId: string;
+    manager: string;
+    source: string;
+    server: { command: string; args: string[] };
+  },
+  opts: { registryPath?: string; includeBuiltins?: boolean } = {},
+): PluginEntry | null {
+  return (
+    allRegistryEntries(opts).find(
+      (e) =>
+        e.pluginId === spec.pluginId &&
+        e.manager === spec.manager &&
+        e.source === spec.source &&
+        e.server.command === spec.server.command &&
+        e.server.args.length === spec.server.args.length &&
+        e.server.args.every((a, i) => a === spec.server.args[i]),
+    ) ?? null
+  );
+}

--- a/src/tuner/wisecron/technique-plugin-registry.ts
+++ b/src/tuner/wisecron/technique-plugin-registry.ts
@@ -27,6 +27,12 @@ export type PluginManager = "npm" | "git";
 export interface PluginEntry {
   /** The research technique this plugin implements (matches ResearchSpec.technique). */
   technique: string;
+  /**
+   * Optional capability tag (e.g. "web_search"). Lets a plugin be resolved by a
+   * detected behavioural NEED (capability-gap detection), not only by a research
+   * technique — a detected gap resolves to the entries carrying this capability.
+   */
+  capability?: string;
   /** Stable id; also the `mcpServers` key written into settings. */
   pluginId: string;
   /** npm = `npm install <source>` into the managed dir; git = `git clone <source>`. */
@@ -59,6 +65,29 @@ export const BUILTIN_REGISTRY: readonly PluginEntry[] = [
     verified: false,
     note: "Seed (UNVERIFIED): confirm the repo + pin a commit before approving.",
   },
+  {
+    technique: "web-search",
+    capability: "web_search",
+    pluginId: "brave-search",
+    manager: "npm",
+    source: "@modelcontextprotocol/server-brave-search",
+    server: { command: "npx", args: ["-y", "@modelcontextprotocol/server-brave-search"] },
+    description:
+      "Web search via the Brave Search API — answer research questions with fresh results.",
+    verified: false,
+    note: "Seed (UNVERIFIED): pin the package version + set BRAVE_API_KEY before approving.",
+  },
+  {
+    technique: "web-search",
+    capability: "web_search",
+    pluginId: "perplexity-ask",
+    manager: "npm",
+    source: "@modelcontextprotocol/server-perplexity-ask",
+    server: { command: "npx", args: ["-y", "@modelcontextprotocol/server-perplexity-ask"] },
+    description: "Web research via the Perplexity API — synthesised answers with citations.",
+    verified: false,
+    note: "Seed (UNVERIFIED): pin the package version + set PERPLEXITY_API_KEY before approving.",
+  },
 ];
 
 /** Default operator-curated registry file (JSON array of PluginEntry). */
@@ -90,6 +119,7 @@ function isValidEntry(e: unknown): e is PluginEntry {
   const server = o.server as Record<string, unknown> | undefined;
   return (
     typeof o.technique === "string" &&
+    (o.capability === undefined || typeof o.capability === "string") &&
     typeof o.pluginId === "string" &&
     (o.manager === "npm" || o.manager === "git") &&
     typeof o.source === "string" &&
@@ -117,4 +147,27 @@ export function lookupPlugin(
   const overridden = new Set(operator.map((e) => e.pluginId));
   const merged = [...operator, ...builtins.filter((e) => !overridden.has(e.pluginId))];
   return merged.find((e) => e.technique === technique) ?? null;
+}
+
+/**
+ * Resolve a detected capability NEED (e.g. "web_search") to its APPROVED
+ * installable options. Unlike `lookupPlugin` (one technique → one plugin), a
+ * need can have several options (Brave OR Perplexity), so this returns all
+ * matches. By default only `verified` (operator-approved) entries are returned —
+ * the approved-list gate — since a capability-gap proposal is an install
+ * recommendation, not a demo. Pass `includeUnverified: true` to also surface the
+ * conservative seeds (shown as UNVERIFIED, still human-gated at apply).
+ * Operator entries override built-in seeds on pluginId collision.
+ */
+export function lookupCapability(
+  capability: string,
+  opts: { registryPath?: string; includeBuiltins?: boolean; includeUnverified?: boolean } = {},
+): PluginEntry[] {
+  const operator = loadOperatorEntries(opts.registryPath);
+  const builtins = opts.includeBuiltins === false ? [] : BUILTIN_REGISTRY;
+  const overridden = new Set(operator.map((e) => e.pluginId));
+  const merged = [...operator, ...builtins.filter((e) => !overridden.has(e.pluginId))];
+  return merged.filter(
+    (e) => e.capability === capability && (opts.includeUnverified === true || e.verified),
+  );
 }


### PR DESCRIPTION
## Governed plugin-only boundary [#275 — Phase 4]

> **Stacked on #287** (base shows #287s diff until it merges; review the `governed-plugin-boundary` commit + the mcp_plugin/registry files).

The hard governance limit from the RFC: **the self-tuner never writes engine code.** A new architectural capability (e.g. vectorised retrieval) is delivered **only as a gated, confined, reversible plugin install** — the system *requests + installs* a capability, it never authors or restructures its own code.

### What this adds
- **`technique-plugin-registry`** — technique -> installable plugin. Built-in seeds ship `verified: false` (a human verifies the source at the gate); operators curate `~/.config/tuner/technique-plugins.json`. No plugin -> the proactive cycle emits a detect-only note; nothing is written.
- **`mcp_plugin` real NEW-plugin install** — `git`/`npm` into a confined managed dir (`~/.config/tuner/plugins/<id>`) via a **sandboxed subprocess** (no shell, timeout, bounded buffer, validated https-git / npm-spec source). Install manifest + `revert` that **uninstalls** = full rollback. `supports_creation = true`.
- **apply/revert confinement** — `assertManagedSettings` guarantees the subject only ever writes its managed settings file; no apply can reach engine code.
- Wired into the wisecron registry (enabled-gated).

### Safety / governance
Human gate · signed proposals + audit chain · install confined to a managed dir · sandboxed installer · reversible by uninstall. Compliance-grade property: **the self-improving layer cannot rewrite itself.**

All tests green; biome clean. Draft — review the boundary model before the proactive subjects (separate PRs) land.
