### PR TITLE
feat(tuner): memory subject — reactive hygiene + proactive evidence face [#275 subject 1/3, stacked on #287]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.178",
+      "version": "2.2.179",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.178",
+  "version": "2.2.179",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/tuner/__tests__/wisecron/subjects/memory-shrink.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/memory-shrink.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemorySubject } from "../../../subjects/memory-subject.js";
+
+let dir: string;
+let idx: string;
+const stub = { query: async () => [], capabilities: async () => [] } as never;
+const range = { start: new Date(0), end: new Date() } as never;
+const longHook = (n: number) => "x".repeat(n);
+
+/** Seed a MEMORY.md + matching topic files (so no dead refs). */
+function seed(entries: Array<{ name: string; hook: string }>): void {
+  for (const e of entries) writeFileSync(join(dir, `${e.name}.md`), "topic body");
+  const lines = entries.map((e) => `- [${e.name}](${e.name}.md) — ${e.hook}`);
+  writeFileSync(idx, `${lines.join("\n")}\n`);
+}
+async function proposeShrink(m: MemorySubject) {
+  const obs = await m.collectObservations(new Date(0));
+  const clusters = await m.detectProblems(obs);
+  return m.proposeChange(clusters[0]!);
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "memshrink-"));
+  idx = join(dir, "MEMORY.md");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("MemorySubject — context-cost + long-line metrics", () => {
+  it("measures long_line_count, context_cost, entry_count", async () => {
+    seed([
+      { name: "a", hook: longHook(300) },
+      { name: "b", hook: "short" },
+    ]);
+    const f = await new MemorySubject({ memoryIndex: idx }).measureFitness(range, stub);
+    expect(f.memory_index_long_line_count).toBe(1);
+    expect(f.memory_index_entry_count).toBe(2);
+    expect(f.memory_index_context_cost).toBeGreaterThan(0);
+  });
+});
+
+describe("MemorySubject — deterministic shrink", () => {
+  it("drives long_lines to 0, preserves entries, lowers context_cost", async () => {
+    seed([
+      { name: "a", hook: longHook(300) },
+      { name: "b", hook: longHook(300) },
+      { name: "c", hook: "ok" },
+    ]);
+    const m = new MemorySubject({ memoryIndex: idx }); // no llm → deterministic
+    const before = await m.measureFitness(range, stub);
+    const p = await proposeShrink(m);
+    expect(p.alternatives.some((a) => a.id === "shrink")).toBe(true);
+    await m.apply(p as never, "shrink");
+    const after = await m.measureFitness(range, stub);
+    expect(after.memory_index_long_line_count).toBe(0);
+    expect(after.memory_index_entry_count).toBe(3); // no entry dropped
+    expect(after.memory_index_context_cost).toBeLessThan(
+      before.memory_index_context_cost as number,
+    );
+  });
+});
+
+describe("MemorySubject — drift-safe apply (reconcile)", () => {
+  it("keeps an entry added between propose and apply (no dropped-pointer error)", async () => {
+    seed([{ name: "a", hook: longHook(300) }]);
+    const m = new MemorySubject({ memoryIndex: idx });
+    const p = await proposeShrink(m); // freezes a snapshot
+    // user edits memory AFTER the proposal
+    writeFileSync(join(dir, "newone.md"), "x");
+    writeFileSync(idx, `${readFileSync(idx, "utf8")}- [New](newone.md) — added after propose\n`);
+    await m.apply(p as never, "shrink"); // must NOT throw
+    expect(readFileSync(idx, "utf8")).toContain("newone.md");
+  });
+});
+
+describe("MemorySubject — quality cache", () => {
+  it("reads a cached median as memory_entry_quality", async () => {
+    seed([{ name: "a", hook: "ok" }]);
+    const qc = join(dir, "q.json");
+    writeFileSync(
+      qc,
+      JSON.stringify({ ts: new Date().toISOString(), median: 4, sampleSize: 1, scores: [4] }),
+    );
+    const f = await new MemorySubject({ memoryIndex: idx, qualityCachePath: qc }).measureFitness(
+      range,
+      stub,
+    );
+    expect(f.memory_entry_quality).toBe(4);
+  });
+  it("omits memory_entry_quality when no cache exists", async () => {
+    seed([{ name: "a", hook: "ok" }]);
+    const qc = join(dir, "absent.json");
+    const f = await new MemorySubject({ memoryIndex: idx, qualityCachePath: qc }).measureFitness(
+      range,
+      stub,
+    );
+    expect(f.memory_entry_quality).toBeUndefined();
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/memory-subject-evidence.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/memory-subject-evidence.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemorySubject } from "../../../subjects/memory-subject.js";
+import type { StructuredEvidence, LocalSignal } from "../../../wisecron/evidence-driven.js";
+
+describe("MemorySubject — EvidenceDrivenSubject (proactive face)", () => {
+  let dir: string;
+  let indexPath: string;
+  let historyPath: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "memsubj-"));
+    indexPath = join(dir, "MEMORY.md");
+    historyPath = join(dir, "hist.jsonl");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  const subj = () => new MemorySubject({ memoryIndex: indexPath, signalHistoryPath: historyPath });
+
+  const evidence = (over: Partial<StructuredEvidence> = {}): StructuredEvidence => ({
+    technique: "vectorized-retrieval",
+    independentSources: 5,
+    highTrustSources: 2,
+    provenInProduction: false,
+    citations: ["u1", "u2", "u3"],
+    ...over,
+  });
+  const signal = (over: Partial<LocalSignal> = {}): LocalSignal => ({
+    metric: "memory_load_ms",
+    value: 80,
+    unit: "ms",
+    degraded: true,
+    trend: "degrading",
+    sampledAt: "2026-06-30T00:00:00Z",
+    ...over,
+  });
+
+  it("researchSpec declares the memory topic + high-trust tiers + technique", () => {
+    const spec = subj().researchSpec();
+    expect(spec.subject).toBe("memory");
+    expect(spec.technique).toBe("vectorized-retrieval");
+    expect(spec.sourceTiers).toContain("enterprise");
+  });
+
+  it("localSignal: healthy index (all pointers resolve) → not degraded", async () => {
+    writeFileSync(join(dir, "a.md"), "x");
+    writeFileSync(join(dir, "b.md"), "y");
+    writeFileSync(indexPath, "- [A](a.md) — x\n- [B](b.md) — y\n");
+    const sig = await subj().localSignal();
+    expect(sig.metric).toBe("memory_load_ms");
+    expect(sig.unit).toBe("ms");
+    expect(sig.degraded).toBe(false);
+  });
+
+  it("localSignal: dead pointers above ratio → degraded", async () => {
+    writeFileSync(indexPath, "- [A](missing1.md) — x\n- [B](missing2.md) — y\n");
+    const sig = await subj().localSignal();
+    expect(sig.degraded).toBe(true);
+  });
+
+  it("evaluate: healthy signal → no proposal", () => {
+    const v = subj().evaluate(evidence(), signal({ degraded: false }));
+    expect(v.propose).toBe(false);
+    expect(v.confidence).toBe(0);
+  });
+
+  it("evaluate: degraded but evidence below bar → no proposal", () => {
+    const v = subj().evaluate(evidence({ independentSources: 1, highTrustSources: 0 }), signal());
+    expect(v.propose).toBe(false);
+    expect(v.reason).toContain("below bar");
+  });
+
+  it("evaluate: degraded + convergent high-trust evidence → RECOMMENDATION carrying proof", () => {
+    const v = subj().evaluate(evidence(), signal());
+    expect(v.propose).toBe(true);
+    expect(v.kind).toBe("recommendation"); // architectural = detect-only, never auto-applied
+    expect(v.confidence).toBeGreaterThan(0);
+    expect(v.reason).toContain("independent sources");
+  });
+
+  it("evaluate: production-proven evidence lifts confidence even without high-trust sources", () => {
+    const v = subj().evaluate(
+      evidence({ highTrustSources: 0, provenInProduction: true }),
+      signal(),
+    );
+    expect(v.propose).toBe(true);
+    expect(v.reason).toContain("proven in production");
+  });
+
+  it("confirm: latency improved (after < before) → true", async () => {
+    writeFileSync(indexPath, "- [A](missing.md) — x\n"); // tiny index → low load latency
+    const improved = await subj().confirm(signal({ value: 9999 }));
+    expect(improved).toBe(true);
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
@@ -450,8 +450,10 @@ describe("MemorySubject — Pass B: proposeChange emits unified diff", () => {
       subjects_touched: ["memory"],
     };
     const proposal = await s.proposeChange(cluster);
-    // 3 dedup diffs (≤2KB each) + 1 full-content "shrink" alternative.
-    expect(proposal.alternatives).toHaveLength(4);
+    // 2 dedup diffs (≤2KB each) + 1 full-content "shrink" alternative = 3.
+    // Schema caps alternatives at 3 (adapter surfaces show 3 choices), so the
+    // subject must not exceed it — see UnsignedProposalSchema.alternatives.max(3).
+    expect(proposal.alternatives).toHaveLength(3);
     for (const alt of proposal.alternatives.filter((a) => a.id !== "shrink")) {
       expect(alt.diff_or_content.length).toBeLessThanOrEqual(2048);
     }

--- a/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
@@ -111,16 +111,11 @@ describe("MemorySubject — detectProblems", () => {
     expect(clusters[0]?.subjects_touched).toEqual(["memory"]);
   });
 
-  it("returns empty when total < 2", async () => {
+  it("returns empty when there are no observations", async () => {
     const s = new MemorySubject({ memoryIndex: indexPath });
-    const single: Observation = {
-      session_id: "t",
-      observed_at: new Date(),
-      signal_type: "orphan",
-      verbatim: "{}",
-      metadata: { subject: "memory" },
-    };
-    const clusters = await s.detectProblems([single]);
+    // A single real issue (dead ref, dup, or a verbose index) now warrants a
+    // cluster; only a truly empty observation set yields no proposal.
+    const clusters = await s.detectProblems([]);
     expect(clusters).toEqual([]);
   });
 });
@@ -455,8 +450,9 @@ describe("MemorySubject — Pass B: proposeChange emits unified diff", () => {
       subjects_touched: ["memory"],
     };
     const proposal = await s.proposeChange(cluster);
-    expect(proposal.alternatives).toHaveLength(3);
-    for (const alt of proposal.alternatives) {
+    // 3 dedup diffs (≤2KB each) + 1 full-content "shrink" alternative.
+    expect(proposal.alternatives).toHaveLength(4);
+    for (const alt of proposal.alternatives.filter((a) => a.id !== "shrink")) {
       expect(alt.diff_or_content.length).toBeLessThanOrEqual(2048);
     }
   });
@@ -509,7 +505,9 @@ describe("MemorySubject — Pass B: proposeChange emits unified diff", () => {
       subjects_touched: ["memory"],
     };
     const proposal = await s.proposeChange(cluster);
-    for (const alt of proposal.alternatives) {
+    // Dedup alternatives are unified diffs with a summary header; the "shrink"
+    // alternative is full content, not a diff.
+    for (const alt of proposal.alternatives.filter((a) => a.id !== "shrink")) {
       expect(alt.diff_or_content).toMatch(/@@ \d+ removed, \d+ added, \d+ reordered @@/);
     }
   });

--- a/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
@@ -1,0 +1,602 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemorySubject } from "../../../subjects/memory-subject.js";
+import type { Cluster, Observation, Patch, Proposal } from "../../../../skills-tuner/core/types.js";
+
+let tmpDir: string;
+let indexPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "memsubj-"));
+  indexPath = join(tmpDir, "MEMORY.md");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function seed(content: string): void {
+  writeFileSync(indexPath, content, "utf8");
+}
+
+function touch(name: string): void {
+  writeFileSync(join(tmpDir, name), "# stub\n", "utf8");
+}
+
+describe("MemorySubject — identity", () => {
+  it('name === "memory", risk_tier === "low"', () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    expect(s.name).toBe("memory");
+    expect(s.risk_tier).toBe("low");
+    expect(s.auto_merge_default).toBe(true);
+  });
+});
+
+describe("MemorySubject — collectObservations", () => {
+  it("parses MEMORY.md entries into { slug, description, file_ref }", async () => {
+    seed(
+      [
+        "# Memory Index",
+        "",
+        "- [Alpha](alpha.md) — first hook",
+        "- [Beta](beta.md) — second hook",
+      ].join("\n"),
+    );
+    touch("alpha.md");
+    touch("beta.md");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const obs = await s.collectObservations(new Date(0));
+    // No dead/dup → zero observations (collectObservations only emits issues).
+    expect(obs).toEqual([]);
+  });
+
+  it("detects dead refs (file does not exist)", async () => {
+    seed(
+      ["# Memory Index", "", "- [Alpha](alpha.md) — exists", "- [Ghost](ghost.md) — does not"].join(
+        "\n",
+      ),
+    );
+    touch("alpha.md");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const obs = await s.collectObservations(new Date(0));
+    expect(obs.length).toBe(1);
+    expect(obs[0]?.metadata.dead).toBe(true);
+    expect(obs[0]?.metadata.file).toBe("ghost.md");
+  });
+
+  it("detects duplicates (same slug or near-duplicate description)", async () => {
+    seed(
+      ["# Memory Index", "", "- [Alpha](alpha.md) — first", "- [Alpha-dup](alpha.md) — copy"].join(
+        "\n",
+      ),
+    );
+    touch("alpha.md");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const obs = await s.collectObservations(new Date(0));
+    expect(obs.length).toBe(2);
+    expect(obs.every((o) => o.metadata.duplicate === true)).toBe(true);
+  });
+
+  it("returns empty array when index missing", async () => {
+    const s = new MemorySubject({ memoryIndex: join(tmpDir, "nope.md") });
+    const obs = await s.collectObservations(new Date(0));
+    expect(obs).toEqual([]);
+  });
+});
+
+describe("MemorySubject — detectProblems", () => {
+  it("returns single cluster covering all problems when total >= 2", async () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const obs: Observation[] = [
+      {
+        session_id: "t1",
+        observed_at: new Date(),
+        signal_type: "orphan",
+        verbatim: "{}",
+        metadata: { subject: "memory", file: "a.md", dead: true, duplicate: false },
+      },
+      {
+        session_id: "t2",
+        observed_at: new Date(),
+        signal_type: "repeated_trigger",
+        verbatim: "{}",
+        metadata: { subject: "memory", file: "b.md", dead: false, duplicate: true },
+      },
+    ];
+    const clusters = await s.detectProblems(obs);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]?.id).toBe("memory-index-cleanup");
+    expect(clusters[0]?.subjects_touched).toEqual(["memory"]);
+  });
+
+  it("returns empty when total < 2", async () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const single: Observation = {
+      session_id: "t",
+      observed_at: new Date(),
+      signal_type: "orphan",
+      verbatim: "{}",
+      metadata: { subject: "memory" },
+    };
+    const clusters = await s.detectProblems([single]);
+    expect(clusters).toEqual([]);
+  });
+});
+
+describe("MemorySubject — apply / validate", () => {
+  it("apply writes .bak before replacement", async () => {
+    // dedup-dead strategy removes entries whose .md file does not exist on
+    // disk. Seed an index with two entries; only `a.md` exists.
+    seed("# Memory Index\n\n- [A](a.md) — alpha\n- [Ghost](ghost.md) — gone\n");
+    touch("a.md");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "memory-index-cleanup",
+      subject: "memory",
+      kind: "patch",
+      target_path: indexPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "sig",
+      // diff_or_content is now informational (unified diff text) — apply
+      // re-runs the strategy on disk state rather than writing this verbatim.
+      alternatives: [
+        {
+          id: "dedup-dead",
+          label: "lbl",
+          tradeoff: "",
+          diff_or_content:
+            "--- MEMORY.md\n+++ MEMORY.md (dedup-dead)\n@@ 1 removed @@\n-- [Ghost](ghost.md) — gone",
+        },
+      ],
+    };
+    await s.apply(proposal, "dedup-dead");
+    expect(existsSync(`${indexPath}.bak`)).toBe(true);
+    expect(readFileSync(`${indexPath}.bak`, "utf8")).toContain("Ghost");
+    const written = readFileSync(indexPath, "utf8");
+    expect(written).toContain("[A](a.md)");
+    expect(written).not.toContain("Ghost");
+  });
+
+  it("apply rejects mismatching target_path", async () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "memory",
+      kind: "patch",
+      target_path: "/elsewhere/MEMORY.md",
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "sig",
+      alternatives: [{ id: "a", label: "l", tradeoff: "", diff_or_content: "# Memory Index\n" }],
+    };
+    await expect(s.apply(proposal, "a")).rejects.toThrow(/target_path/);
+  });
+
+  it('validate requires "# Memory Index" header', async () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const result = await s.validate({
+      target_path: indexPath,
+      kind: "patch",
+      applied_content: "# Wrong Header\n\n- [A](a.md)\n",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/header/);
+  });
+
+  it("validate rejects entries referencing files outside memory/ dir", async () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const result = await s.validate({
+      target_path: indexPath,
+      kind: "patch",
+      applied_content: "# Memory Index\n\n- [Evil](../../escape.md) — out\n",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/outside/);
+  });
+
+  it("validate rejects index > 200 lines", async () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const big = ["# Memory Index", ""];
+    for (let i = 0; i < 220; i++) big.push(`- [Item${i}](item${i}.md) — hook`);
+    const result = await s.validate({
+      target_path: indexPath,
+      kind: "patch",
+      applied_content: big.join("\n"),
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/200 lines/);
+  });
+
+  it("validate accepts a clean index", async () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const result = await s.validate({
+      target_path: indexPath,
+      kind: "patch",
+      applied_content: "# Memory Index\n\n- [A](a.md) — one\n- [B](b.md) — two\n",
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("MemorySubject — revert", () => {
+  it("replays inverse content back into memoryIndex (hash compare)", async () => {
+    const original = "# Memory Index\n\n- [Orig](orig.md) — original\n";
+    seed(original);
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    writeFileSync(indexPath, "# Memory Index\n\n- [Mutated](mut.md)\n", "utf8");
+
+    const inverse: Patch = {
+      target_path: indexPath,
+      kind: "patch",
+      applied_content: original,
+    };
+    await s.revert(inverse);
+    expect(readFileSync(indexPath, "utf8")).toBe(original);
+  });
+});
+
+// ── Pass B: edges, idempotency, perf, guardrails ───────────────────────────
+
+describe("MemorySubject — Pass B: edges", () => {
+  it("collectObservations: empty MEMORY.md returns empty list", async () => {
+    seed("");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    expect(await s.collectObservations(new Date(0))).toEqual([]);
+  });
+
+  it("collectObservations: missing MEMORY.md returns empty list (no throw)", async () => {
+    // do not seed — file does not exist
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    expect(await s.collectObservations(new Date(0))).toEqual([]);
+  });
+
+  it("validate rejects entry referencing parent dir (../escape.md)", async () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const result = await s.validate({
+      target_path: indexPath,
+      kind: "patch",
+      applied_content: "# Memory Index\n- [Bad](../escape.md) — bad\n",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/outside memory dir/);
+  });
+
+  it("validate rejects entry with absolute path", async () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const result = await s.validate({
+      target_path: indexPath,
+      kind: "patch",
+      applied_content: "# Memory Index\n- [Abs](/etc/passwd) — abs\n",
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it("apply: missing alternative id → clear error", async () => {
+    seed("# Memory Index\n- [A](a.md)\n");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "memory",
+      kind: "patch",
+      target_path: indexPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "s",
+      alternatives: [
+        { id: "real-id", label: "", tradeoff: "", diff_or_content: "# Memory Index\n" },
+      ],
+    };
+    await expect(s.apply(proposal, "wrong-id")).rejects.toThrow(/alternative/);
+  });
+});
+
+describe("MemorySubject — Pass B: idempotency", () => {
+  it("apply same content twice → identical file state", async () => {
+    // dedup-dead strategy is deterministic given the same disk state, so
+    // applying twice in a row yields the same content (no further dead
+    // entries to remove on the second pass).
+    seed("# Memory Index\n- [Old](old.md) — old\n");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "memory",
+      kind: "patch",
+      target_path: indexPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "s",
+      alternatives: [{ id: "dedup-dead", label: "", tradeoff: "", diff_or_content: "" }],
+    };
+    await s.apply(proposal, "dedup-dead");
+    const after1 = readFileSync(indexPath, "utf8");
+    await s.apply(proposal, "dedup-dead");
+    expect(readFileSync(indexPath, "utf8")).toBe(after1);
+  });
+
+  it("revert same inverse twice → no double-mutation", async () => {
+    seed("# Memory Index\n- [Mutated](m.md)\n");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const inverse: Patch = {
+      target_path: indexPath,
+      kind: "patch",
+      applied_content: "# Memory Index\n- [Original](o.md) — orig\n",
+    };
+    await s.revert(inverse);
+    const after1 = readFileSync(indexPath, "utf8");
+    await s.revert(inverse);
+    expect(readFileSync(indexPath, "utf8")).toBe(after1);
+  });
+});
+
+describe("MemorySubject — Pass B: perf", () => {
+  it("validate scales linearly on large valid index (assert <250ms on 200 entries)", async () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const lines = ["# Memory Index"];
+    for (let i = 0; i < 195; i++) lines.push(`- [Entry${i}](e${i}.md) — hook ${i}`);
+    const content = lines.join("\n");
+    const start = Date.now();
+    const result = await s.validate({
+      target_path: indexPath,
+      kind: "patch",
+      applied_content: content,
+    });
+    const elapsed = Date.now() - start;
+    expect(result.valid).toBe(true);
+    expect(elapsed).toBeLessThan(250);
+  });
+
+  it("collectObservations on 50K-line index reads in <500ms (no quadratic scan)", async () => {
+    // Build a 50K-line "memory" file that legitimately parses as MEMORY.md.
+    // The current implementation: parseEntries iterates lines once + slugCounts
+    // built once + final loop is O(n). Just confirm we don't time out.
+    const lines = ["# Memory Index"];
+    for (let i = 0; i < 50_000; i++) lines.push(`- [E${i}](e${i}.md) — h`);
+    seed(lines.join("\n"));
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const start = Date.now();
+    const obs = await s.collectObservations(new Date(0));
+    const elapsed = Date.now() - start;
+    // None of the e0..eN.md files exist → every entry is dead. Just check
+    // wall-clock is sane.
+    expect(obs.length).toBeGreaterThan(0);
+    expect(elapsed).toBeLessThan(1500);
+  });
+});
+
+describe("MemorySubject — Pass B: validate/apply symmetry", () => {
+  it("apply roundtrip: produced Patch validates clean", async () => {
+    seed("# Memory Index\n\n- [A](a.md) — alpha\n- [B](b.md) — beta\n");
+    touch("a.md");
+    touch("b.md");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "memory",
+      kind: "patch",
+      target_path: indexPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "s",
+      alternatives: [{ id: "dedup-dead", label: "", tradeoff: "", diff_or_content: "" }],
+    };
+    const patch = await s.apply(proposal, "dedup-dead");
+    const v = await s.validate(patch);
+    expect(v.valid).toBe(true);
+  });
+
+  it("apply throws on target_path mismatch → validate would not flag (different file path concern)", async () => {
+    seed("# Memory Index\n");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "memory",
+      kind: "patch",
+      target_path: "/tmp/wrong-path.md",
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "s",
+      alternatives: [{ id: "a", label: "", tradeoff: "", diff_or_content: "# Memory Index\n" }],
+    };
+    await expect(s.apply(proposal, "a")).rejects.toThrow(/target_path mismatch/);
+  });
+});
+
+describe("MemorySubject — Pass B: risk_tier guardrails", () => {
+  it("risk_tier is low — auto-merge default allowed", () => {
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    expect(s.risk_tier).toBe("low");
+    expect(s.auto_merge_default).toBe(true);
+  });
+});
+
+describe("MemorySubject — Pass B: proposeChange emits unified diff", () => {
+  function seedRealistic(): void {
+    // Mirror the ~50KB MEMORY.md shape that triggered Phase 4's wall-of-text
+    // problem. 50 entries with 4 of them pointing at non-existent files.
+    const lines = ["# Memory Index", ""];
+    for (let i = 0; i < 50; i++) {
+      lines.push(`- [Entry ${i}](file_${String(i).padStart(2, "0")}.md) — hook ${i}`);
+    }
+    seed(`${lines.join("\n")}\n`);
+    // Only 46 of the 50 reference files exist on disk → 4 dead refs.
+    for (let i = 0; i < 50; i++) {
+      if (i === 7 || i === 19 || i === 33 || i === 41) continue;
+      touch(`file_${String(i).padStart(2, "0")}.md`);
+    }
+  }
+
+  it("each alternative diff_or_content is ≤ 2KB", async () => {
+    seedRealistic();
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const cluster: Cluster = {
+      id: "memory-index-cleanup",
+      subject: "memory",
+      observations: [
+        {
+          session_id: "t",
+          observed_at: new Date(),
+          signal_type: "orphan",
+          verbatim: "{}",
+          metadata: { subject: "memory" },
+        },
+      ],
+      frequency: 4,
+      success_rate: 0.5,
+      sentiment: "neutral",
+      subjects_touched: ["memory"],
+    };
+    const proposal = await s.proposeChange(cluster);
+    expect(proposal.alternatives).toHaveLength(3);
+    for (const alt of proposal.alternatives) {
+      expect(alt.diff_or_content.length).toBeLessThanOrEqual(2048);
+    }
+  });
+
+  it("all three alternatives produce visibly distinct diff text", async () => {
+    seedRealistic();
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const cluster: Cluster = {
+      id: "memory-index-cleanup",
+      subject: "memory",
+      observations: [
+        {
+          session_id: "t",
+          observed_at: new Date(),
+          signal_type: "orphan",
+          verbatim: "{}",
+          metadata: { subject: "memory" },
+        },
+      ],
+      frequency: 4,
+      success_rate: 0.5,
+      sentiment: "neutral",
+      subjects_touched: ["memory"],
+    };
+    const proposal = await s.proposeChange(cluster);
+    const [a, b, c] = proposal.alternatives.map((alt) => alt.diff_or_content);
+    expect(a).not.toBe(b);
+    expect(b).not.toBe(c);
+    expect(a).not.toBe(c);
+  });
+
+  it("each alternative diff includes a summary header line", async () => {
+    seedRealistic();
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const cluster: Cluster = {
+      id: "memory-index-cleanup",
+      subject: "memory",
+      observations: [
+        {
+          session_id: "t",
+          observed_at: new Date(),
+          signal_type: "orphan",
+          verbatim: "{}",
+          metadata: { subject: "memory" },
+        },
+      ],
+      frequency: 4,
+      success_rate: 0.5,
+      sentiment: "neutral",
+      subjects_touched: ["memory"],
+    };
+    const proposal = await s.proposeChange(cluster);
+    for (const alt of proposal.alternatives) {
+      expect(alt.diff_or_content).toMatch(/@@ \d+ removed, \d+ added, \d+ reordered @@/);
+    }
+  });
+});
+
+describe("MemorySubject — Pass B: apply re-computes strategy on current state", () => {
+  it("apply rejects unknown strategy id", async () => {
+    seed("# Memory Index\n- [A](a.md)\n");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "memory",
+      kind: "patch",
+      target_path: indexPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "s",
+      alternatives: [{ id: "free-form", label: "", tradeoff: "", diff_or_content: "" }],
+    };
+    await expect(s.apply(proposal, "free-form")).rejects.toThrow(/unknown strategy/);
+  });
+
+  it("apply dedup-reorder sorts entries alphabetically", async () => {
+    seed("# Memory Index\n\n- [Zeta](z.md) — z\n- [Alpha](a.md) — a\n- [Mu](m.md) — m\n");
+    touch("a.md");
+    touch("m.md");
+    touch("z.md");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "memory",
+      kind: "patch",
+      target_path: indexPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "s",
+      alternatives: [{ id: "dedup-reorder", label: "", tradeoff: "", diff_or_content: "" }],
+    };
+    await s.apply(proposal, "dedup-reorder");
+    const written = readFileSync(indexPath, "utf8");
+    const aIdx = written.indexOf("Alpha");
+    const mIdx = written.indexOf("Mu");
+    const zIdx = written.indexOf("Zeta");
+    expect(aIdx).toBeGreaterThan(0);
+    expect(aIdx).toBeLessThan(mIdx);
+    expect(mIdx).toBeLessThan(zIdx);
+  });
+
+  it("apply dedup-group buckets entries by name prefix", async () => {
+    seed(
+      `${[
+        "# Memory Index",
+        "",
+        "- [Project A](project_alpha.md)",
+        "- [Feedback B](feedback_beta.md)",
+        "- [Project C](project_charlie.md)",
+        "- [Feedback D](feedback_delta.md)",
+      ].join("\n")}\n`,
+    );
+    touch("project_alpha.md");
+    touch("feedback_beta.md");
+    touch("project_charlie.md");
+    touch("feedback_delta.md");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const proposal: Proposal = {
+      id: 1,
+      cluster_id: "c",
+      subject: "memory",
+      kind: "patch",
+      target_path: indexPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "s",
+      alternatives: [{ id: "dedup-group", label: "", tradeoff: "", diff_or_content: "" }],
+    };
+    await s.apply(proposal, "dedup-group");
+    const written = readFileSync(indexPath, "utf8");
+    // feedback_* bucket precedes project_* (alphabetical group key order),
+    // and entries within each bucket are contiguous.
+    const fbBeta = written.indexOf("feedback_beta");
+    const fbDelta = written.indexOf("feedback_delta");
+    const projAlpha = written.indexOf("project_alpha");
+    const projCharlie = written.indexOf("project_charlie");
+    expect(fbBeta).toBeLessThan(projAlpha);
+    expect(fbDelta).toBeLessThan(projAlpha);
+    expect(projAlpha).toBeLessThan(projCharlie === -1 ? Infinity : projCharlie);
+  });
+});

--- a/src/tuner/subjects/memory-signal.ts
+++ b/src/tuner/subjects/memory-signal.ts
@@ -1,0 +1,116 @@
+/**
+ * memory-signal — the memory subject's LOCAL signal (no web, no LLM). Measures the
+ * cost + health of the memory index and keeps a history so degradation shows as a
+ * trend. This is what `memory-subject.localSignal()` will read; it is also the cheap
+ * post-apply CONFIRMATION (re-measure → did it improve?).
+ *
+ * Signals: load+parse+resolve latency (ms), index size (bytes/entries), dead-entry
+ * ratio (pointers to missing files). All from local files — safe inside the tuner.
+ *
+ *   bun memory-signal.ts <MEMORY.md> [--record]
+ */
+import { existsSync, readFileSync, appendFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface MemorySample {
+  ts: string;
+  bytes: number;
+  entries: number;
+  deadRatio: number;
+  loadMs: number;
+}
+
+/** Measure one sample: time the work a recall does (load → parse → resolve pointers). */
+export function measureMemorySignal(indexPath: string, nowIso: string): MemorySample {
+  const t0 = performance.now();
+  const md = existsSync(indexPath) ? readFileSync(indexPath, "utf8") : "";
+  const dir = dirname(indexPath);
+  const pointers = [...md.matchAll(/\]\(([^)]+\.md)\)/g)].map((m) => m[1]!);
+  let dead = 0;
+  for (const f of pointers) if (!existsSync(join(dir, f))) dead++;
+  const loadMs = performance.now() - t0;
+  return {
+    ts: nowIso,
+    bytes: md.length,
+    entries: pointers.length,
+    deadRatio: pointers.length ? dead / pointers.length : 0,
+    loadMs: Math.round(loadMs * 1000) / 1000,
+  };
+}
+
+/** Append a sample to the history log (one JSON object per line). */
+export function recordSample(historyPath: string, sample: MemorySample): void {
+  appendFileSync(historyPath, JSON.stringify(sample) + "\n", "utf8");
+}
+
+/** Load recent samples (most recent last). Tolerates a missing/corrupt history. */
+export function loadHistory(historyPath: string, limit = 30): MemorySample[] {
+  if (!existsSync(historyPath)) return [];
+  const lines = readFileSync(historyPath, "utf8").trim().split("\n").filter(Boolean);
+  const out: MemorySample[] = [];
+  for (const l of lines.slice(-limit)) {
+    try {
+      out.push(JSON.parse(l));
+    } catch {
+      /* skip corrupt line */
+    }
+  }
+  return out;
+}
+
+/**
+ * Trend of a metric over the history: compare the recent half vs the older half.
+ * "degrading" if the metric rose by more than `tol` (fractional), etc.
+ */
+export function trendOf(
+  history: MemorySample[],
+  pick: (s: MemorySample) => number,
+  tol = 0.1,
+  minAbsDelta = 0,
+): "improving" | "stable" | "degrading" {
+  if (history.length < 4) return "stable";
+  const mid = Math.floor(history.length / 2);
+  const avg = (xs: MemorySample[]) => xs.reduce((a, s) => a + pick(s), 0) / xs.length;
+  const older = avg(history.slice(0, mid));
+  const recent = avg(history.slice(mid));
+  // Noise floor: ignore changes below a minimum ABSOLUTE delta (sub-ms jitter, etc.).
+  if (Math.abs(recent - older) <= minAbsDelta) return "stable";
+  if (older === 0) return recent > 0 ? "degrading" : "stable";
+  const delta = (recent - older) / older;
+  if (delta > tol) return "degrading";
+  if (delta < -tol) return "improving";
+  return "stable";
+}
+
+/** The degradation verdict the subject exposes (latency is the primary signal). */
+export function memorySignalSummary(
+  indexPath: string,
+  historyPath: string,
+  nowIso: string,
+  thresholds: { maxLoadMs?: number; maxDeadRatio?: number } = {},
+): { sample: MemorySample; trend: "improving" | "stable" | "degrading"; degraded: boolean } {
+  const sample = measureMemorySignal(indexPath, nowIso);
+  const history = [...loadHistory(historyPath), sample];
+  const trend = trendOf(history, (s) => s.loadMs);
+  const degraded =
+    trend === "degrading" ||
+    sample.loadMs > (thresholds.maxLoadMs ?? Infinity) ||
+    sample.deadRatio > (thresholds.maxDeadRatio ?? 0.05);
+  return { sample, trend, degraded };
+}
+
+if (import.meta.main) {
+  const indexPath =
+    process.argv[2] ?? `${process.env.HOME}/.claude/projects/-home-simon-agent/memory/MEMORY.md`;
+  const historyPath = `${process.env.HOME}/.config/tuner/memory-signal-history.jsonl`;
+  const nowIso = new Date().toISOString();
+  const { sample, trend, degraded } = memorySignalSummary(indexPath, historyPath, nowIso, {
+    maxLoadMs: 50,
+    maxDeadRatio: 0.05,
+  });
+  if (process.argv.includes("--record")) recordSample(historyPath, sample);
+  console.log(`[memory-signal] ${JSON.stringify(sample)}`);
+  console.log(
+    `[memory-signal] trend(loadMs)=${trend} degraded=${degraded} (history: ${loadHistory(historyPath).length} samples)`,
+  );
+}

--- a/src/tuner/subjects/memory-subject.ts
+++ b/src/tuner/subjects/memory-subject.ts
@@ -1,0 +1,562 @@
+import { existsSync, copyFileSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, resolve } from "node:path";
+import { BaseSubject } from "../../skills-tuner/subjects/base.js";
+import { sanitizeObservationContent } from "../../skills-tuner/core/security.js";
+import type { LLMClient } from "../../skills-tuner/core/llm.js";
+import type {
+  Cluster,
+  Observation,
+  Patch,
+  Proposal,
+  UnsignedProposal,
+  ValidationResult,
+} from "../../skills-tuner/core/types.js";
+import type { RevertibleSubject } from "../wisecron/types.js";
+import { renderDiff } from "../wisecron/render-diff.js";
+import type { DateRange, Metric, TelemetryProvider } from "../../skills-tuner/core/telemetry.js";
+import { ARTIFACT_SOURCE } from "../../skills-tuner/core/telemetry.js";
+import { median } from "../../skills-tuner/core/aggregate.js";
+import {
+  type EvidenceDrivenSubject,
+  type ResearchSpec,
+  type LocalSignal,
+  type StructuredEvidence,
+  type EvidenceVerdict,
+  meetsEvidenceBar,
+} from "../wisecron/evidence-driven.js";
+import { measureMemorySignal, loadHistory, trendOf } from "./memory-signal.js";
+
+/** Memory load cost (ms) above which the index is "slow". */
+const MEMORY_MAX_LOAD_MS = 50;
+/** Dead-pointer ratio above which memory hygiene is degraded. */
+const MEMORY_MAX_DEAD_RATIO = 0.05;
+/** Only treat index GROWTH as degradation once the index is genuinely sizable. */
+const MEMORY_SIZE_FLOOR = 18_000;
+
+/** Derive Claude Code's per-user memory index location.
+ * Mirrors Claude Code's pattern: `~/.claude/projects/-home-<basename>/memory/MEMORY.md`.
+ */
+function defaultMemoryIndex(): string {
+  const home = homedir();
+  const slug = `-home-${basename(home)}`;
+  return `${home}/.claude/projects/${slug}/memory/MEMORY.md`;
+}
+
+const MAX_INDEX_LINES = 200;
+const HEADER = "# Memory Index";
+// `- [Title](file.md) — hook` shape — em-dash or ASCII hyphen separator.
+const ENTRY_RE = /^- \[([^\]]+)\]\(([^)]+\.md)\)(?:\s+[—-]\s+(.+))?$/;
+
+interface MemoryEntry {
+  raw: string;
+  title: string;
+  file: string;
+  hook: string | null;
+}
+
+/**
+ * MemorySubject — wisecron-managed MEMORY.md index tuner (LOW).
+ *
+ * What it tunes: MEMORY.md (auto-memory index) at
+ * `~/.claude/projects/-home-<user>/memory/MEMORY.md`. Detects:
+ *  - duplicate entries (same slug or near-duplicate description)
+ *  - dead entries (referenced .md file no longer exists)
+ *  - stale ordering (most-referenced entries should be on top)
+ *  - bloated index (>200 lines per CLAUDE.md spec)
+ *
+ * Telemetry: count of memory file reads per UserPromptSubmit hook log.
+ * Risk class: LOW — index reorder/dedup, no content removed from per-file
+ * memory bodies (only the index pointers shift).
+ */
+export interface MemorySubjectConfig {
+  llm?: LLMClient;
+  /** Path to MEMORY.md index. */
+  memoryIndex?: string;
+  /** UserPromptSubmit hook log for read-frequency telemetry. */
+  hookLog?: string;
+  /** Path to the memory-signal sampler history (the local degradation signal). */
+  signalHistoryPath?: string;
+}
+
+export class MemorySubject extends BaseSubject implements RevertibleSubject, EvidenceDrivenSubject {
+  readonly name = "memory";
+  readonly risk_tier = "low" as const;
+  readonly auto_merge_default = true;
+  readonly supports_creation = false;
+
+  private readonly llm?: LLMClient;
+  private readonly memoryIndex: string;
+  private readonly hookLog?: string;
+  private readonly signalHistoryPath: string;
+
+  constructor(opts: MemorySubjectConfig = {}) {
+    super();
+    this.llm = opts.llm;
+    // Expand a leading `~` (config files pass `~/.claude/...`; without this
+    // existsSync(this.memoryIndex) is false and collectObservations returns
+    // [] -> the subject silently produces 0 observations).
+    this.memoryIndex = (opts.memoryIndex ?? defaultMemoryIndex()).replace(/^~(?=\/|$)/, homedir());
+    this.hookLog = opts.hookLog;
+    this.signalHistoryPath = (
+      opts.signalHistoryPath ?? `${homedir()}/.config/tuner/memory-signal-history.jsonl`
+    ).replace(/^~(?=\/|$)/, homedir());
+  }
+
+  // ── Proactive face: EvidenceDrivenSubject (faisceau de preuves + signal local) ──
+
+  researchSpec(): ResearchSpec {
+    return {
+      subject: "memory",
+      query: "agent long-term memory scaling vectorized retrieval RAG forgetting curve",
+      sourceTiers: ["enterprise", "authoritative", "papers"],
+      technique: "vectorized-retrieval",
+    };
+  }
+
+  /** The local degradation signal: load latency (primary), with size/dead-ratio. */
+  async localSignal(): Promise<LocalSignal> {
+    const current = measureMemorySignal(this.memoryIndex, new Date().toISOString());
+    const history = [...loadHistory(this.signalHistoryPath), current];
+    // Drive the trend off a STABLE metric (index size) with a 1KB noise floor — NOT
+    // sub-millisecond load latency, which is pure FS jitter on a small file.
+    const trend = trendOf(history, (sample) => sample.bytes, 0.1, 1000);
+    const degraded =
+      current.deadRatio > MEMORY_MAX_DEAD_RATIO ||
+      (trend === "degrading" && current.bytes > MEMORY_SIZE_FLOOR) ||
+      current.loadMs > MEMORY_MAX_LOAD_MS;
+    return {
+      metric: "memory_load_ms",
+      value: current.loadMs,
+      unit: "ms",
+      degraded,
+      trend,
+      sampledAt: current.ts,
+    };
+  }
+
+  /**
+   * Decide from CLEAN structured evidence (from the feeder) + the local signal.
+   * An architectural technique (e.g. vectorized retrieval) is a detect-only
+   * RECOMMENDATION carrying its proof — never an auto-applied infra change.
+   */
+  evaluate(evidence: StructuredEvidence, signal: LocalSignal): EvidenceVerdict {
+    if (!signal.degraded) {
+      return {
+        propose: false,
+        reason: `memory signal healthy (${signal.metric}=${signal.value}${signal.unit}, ${signal.trend})`,
+        kind: "recommendation",
+        confidence: 0,
+      };
+    }
+    if (!meetsEvidenceBar(evidence)) {
+      return {
+        propose: false,
+        reason: `evidence below bar for '${evidence.technique}' (${evidence.independentSources} independent, ${evidence.highTrustSources} high-trust)`,
+        kind: "recommendation",
+        confidence: 0.2,
+      };
+    }
+    // Confidence = convergence (clamped). meetsEvidenceBar already guarantees a
+    // high-trust/prod source, so a separate trustBoost factor would be a no-op (L2).
+    const confidence = Math.round(Math.min(1, evidence.independentSources / 5) * 100) / 100;
+    return {
+      propose: true,
+      reason: `memory degrading (${signal.trend}, ${signal.value}${signal.unit}) + ${evidence.independentSources} independent sources for '${evidence.technique}'${evidence.provenInProduction ? " (proven in production)" : ""}`,
+      kind: "recommendation",
+      confidence,
+    };
+  }
+
+  /** Post-apply confirmation: re-read the signal — did latency improve? */
+  async confirm(before: LocalSignal): Promise<boolean> {
+    const after = await this.localSignal();
+    return after.value < before.value;
+  }
+
+  async collectObservations(_since: Date): Promise<Observation[]> {
+    if (!existsSync(this.memoryIndex)) return [];
+    const content = readFileSync(this.memoryIndex, "utf8");
+    const entries = parseEntries(content);
+    if (entries.length === 0) return [];
+
+    const memoryDir = dirname(this.memoryIndex);
+    const observations: Observation[] = [];
+    const now = new Date();
+
+    const slugCounts = new Map<string, number>();
+    for (const e of entries) {
+      const slug = e.file.replace(/\.md$/, "");
+      slugCounts.set(slug, (slugCounts.get(slug) ?? 0) + 1);
+    }
+
+    for (const e of entries) {
+      const slug = e.file.replace(/\.md$/, "");
+      const refPath = resolve(memoryDir, e.file);
+      const dead = !existsSync(refPath);
+      const duplicate = (slugCounts.get(slug) ?? 0) > 1;
+      if (!dead && !duplicate) continue;
+
+      const issues: string[] = [];
+      if (dead) issues.push("dead_ref");
+      if (duplicate) issues.push("duplicate_slug");
+
+      observations.push({
+        session_id: `memory-${slug}-${now.getTime()}`,
+        observed_at: now,
+        signal_type: dead ? "orphan" : "repeated_trigger",
+        verbatim: sanitizeObservationContent(
+          JSON.stringify({
+            slug,
+            file: e.file,
+            title: e.title,
+            issues,
+          }),
+          500,
+        ),
+        metadata: {
+          subject: "memory",
+          slug,
+          file: e.file,
+          dead,
+          duplicate,
+        },
+      });
+    }
+
+    return observations;
+  }
+
+  async detectProblems(observations: Observation[]): Promise<Cluster[]> {
+    if (observations.length < 2) return [];
+    return [
+      {
+        id: "memory-index-cleanup",
+        subject: "memory",
+        observations,
+        frequency: observations.length,
+        success_rate: 0.5,
+        sentiment: "neutral",
+        subjects_touched: ["memory"],
+      },
+    ];
+  }
+
+  async proposeChange(cluster: Cluster): Promise<UnsignedProposal> {
+    if (!existsSync(this.memoryIndex)) {
+      throw new Error("memory-subject.proposeChange: index missing");
+    }
+    const current = readFileSync(this.memoryIndex, "utf8");
+    const dedupDead = applyStrategy(current, this.memoryIndex, "dedup-dead");
+    const dedupReorder = applyStrategy(current, this.memoryIndex, "dedup-reorder");
+    const dedupGroup = applyStrategy(current, this.memoryIndex, "dedup-group");
+
+    // Emit unified diffs (≤2KB each) so the three alternatives stay visually
+    // distinct in adapter surfaces. apply() re-runs the strategy against the
+    // live file rather than blindly writing what's in diff_or_content.
+    return {
+      id: Date.now(),
+      cluster_id: cluster.id,
+      subject: "memory",
+      kind: "patch",
+      target_path: this.memoryIndex,
+      alternatives: [
+        {
+          id: "dedup-dead",
+          label: "Dedup + remove dead refs",
+          diff_or_content: renderDiff(current, dedupDead, {
+            fromLabel: "MEMORY.md",
+            toLabel: "MEMORY.md (dedup-dead)",
+          }),
+          tradeoff: "Smallest diff, removes only confirmed-dead pointers.",
+        },
+        {
+          id: "dedup-reorder",
+          label: "Dedup + reorder alphabetically",
+          diff_or_content: renderDiff(current, dedupReorder, {
+            fromLabel: "MEMORY.md",
+            toLabel: "MEMORY.md (dedup-reorder)",
+          }),
+          tradeoff: "Easier visual scan; reorder churn in git blame.",
+        },
+        {
+          id: "dedup-group",
+          label: "Dedup + group by name prefix",
+          diff_or_content: renderDiff(current, dedupGroup, {
+            fromLabel: "MEMORY.md",
+            toLabel: "MEMORY.md (dedup-group)",
+          }),
+          tradeoff: "Groups feedback_/project_/user_ entries together; loses chronological order.",
+        },
+      ],
+      pattern_signature: `memory:dedup:${parseEntries(current).length}`,
+      created_at: new Date(),
+    };
+  }
+
+  async apply(proposal: Proposal, alternativeId: string): Promise<Patch> {
+    if (proposal.target_path !== this.memoryIndex) {
+      throw new Error(
+        `memory-subject.apply: target_path mismatch (${proposal.target_path} vs ${this.memoryIndex})`,
+      );
+    }
+    const alt = proposal.alternatives.find((a) => a.id === alternativeId);
+    if (!alt) throw new Error(`memory-subject.apply: alternative ${alternativeId} not found`);
+
+    const current = existsSync(this.memoryIndex) ? readFileSync(this.memoryIndex, "utf8") : "";
+    // A KNOWN strategy id -> re-run the strategy on the live index (the alternative's
+    // diff_or_content is then an informational unified diff, NOT content to write).
+    // An UNKNOWN id -> an external/research proposal carrying the full new index in
+    // diff_or_content. validate() gates the result either way.
+    let newContent: string;
+    if (isKnownStrategy(alternativeId)) {
+      newContent = applyStrategy(current, this.memoryIndex, alternativeId);
+    } else {
+      const explicit = (alt as { diff_or_content?: string }).diff_or_content;
+      if (typeof explicit !== "string" || explicit.trim().length === 0) {
+        throw new Error(
+          `memory-subject.apply: unknown strategy '${alternativeId}' and no diff_or_content`,
+        );
+      }
+      newContent = explicit;
+      // Pre-write validation for EXTERNAL content (M5/L5): structure + no live-pointer loss.
+      if (!newContent.startsWith(HEADER)) {
+        throw new Error("memory-subject.apply: external content missing index header");
+      }
+      const memDir = dirname(this.memoryIndex);
+      const liveBefore = [...current.matchAll(/\]\(([^)]+\.md)\)/g)]
+        .map((m) => m[1] as string)
+        .filter((file) => existsSync(resolve(memDir, file)));
+      const afterPtrs = new Set(
+        [...newContent.matchAll(/\]\(([^)]+\.md)\)/g)].map((m) => m[1] as string),
+      );
+      const dropped = liveBefore.filter((file) => !afterPtrs.has(file));
+      if (dropped.length > 0) {
+        throw new Error(
+          `memory-subject.apply: external content drops ${dropped.length} live pointer(s): ${dropped.slice(0, 3).join(", ")}`,
+        );
+      }
+    }
+
+    if (existsSync(this.memoryIndex)) {
+      copyFileSync(this.memoryIndex, `${this.memoryIndex}.bak`);
+    }
+    // Atomic: write a temp then rename so a mid-write failure can't truncate the index.
+    const tmpPath = `${this.memoryIndex}.tmp`;
+    writeFileSync(tmpPath, newContent, "utf8");
+    renameSync(tmpPath, this.memoryIndex);
+
+    return {
+      target_path: this.memoryIndex,
+      kind: "patch",
+      applied_content: newContent,
+    };
+  }
+
+  async validate(patch: Patch): Promise<ValidationResult> {
+    const content = patch.applied_content;
+    if (!content.startsWith(HEADER)) {
+      return { valid: false, reason: `missing "${HEADER}" header` };
+    }
+    const lines = content.split("\n");
+    if (lines.length > MAX_INDEX_LINES) {
+      return { valid: false, reason: `index exceeds ${MAX_INDEX_LINES} lines (${lines.length})` };
+    }
+    const memoryDir = dirname(this.memoryIndex);
+    for (const line of lines) {
+      if (!line.startsWith("- ")) continue;
+      const m = line.match(ENTRY_RE);
+      if (!m) return { valid: false, reason: `malformed entry: ${line}` };
+      const file = m[2]!;
+      if (file.includes("..") || file.startsWith("/")) {
+        return { valid: false, reason: `entry references file outside memory dir: ${file}` };
+      }
+      const resolved = resolve(memoryDir, file);
+      if (!resolved.startsWith(`${memoryDir}/`) && resolved !== memoryDir) {
+        return { valid: false, reason: `entry references file outside memory dir: ${file}` };
+      }
+    }
+    return { valid: true };
+  }
+
+  async revert(inversePatch: Patch): Promise<void> {
+    if (inversePatch.target_path !== this.memoryIndex) {
+      throw new Error(`memory-subject.revert: target_path mismatch`);
+    }
+    writeFileSync(this.memoryIndex, inversePatch.applied_content, "utf8");
+  }
+
+  /**
+   * OutcomeLoop fitness for the memory subject (LOW risk).
+   *
+   * Target — `memory_median_reads_per_entry` (Tier 1, `memory_access`): the
+   * typical index entry's read frequency (median per-entry access count over the
+   * window). Higher is better — a well-curated index gets used. Median, so one
+   * hot entry can't dominate. The gameable shortcut is to delete entries to lift
+   * the per-entry median, so it is guarded by `memory_index_entry_count`
+   * (Tier 1b artifact, higher_is_better). `memory_index_defect_count`
+   * (Tier 1b artifact): always-on scan for dead-ref + duplicate-slug entries.
+   */
+  fitnessSignals(): Metric[] {
+    return [
+      {
+        name: "memory_median_reads_per_entry",
+        source: "memory_access",
+        kind: "verifiable",
+        direction: "higher_is_better",
+        windowDays: 7,
+        guardrails: ["memory_index_entry_count"],
+      },
+      {
+        name: "memory_index_defect_count",
+        source: ARTIFACT_SOURCE,
+        kind: "verifiable",
+        direction: "lower_is_better",
+        windowDays: 1,
+      },
+      {
+        name: "memory_index_entry_count",
+        source: ARTIFACT_SOURCE,
+        kind: "verifiable",
+        direction: "higher_is_better",
+        windowDays: 7,
+      },
+    ];
+  }
+
+  /**
+   * Telemetry read ONLY via `provider.query("memory_access", …)`; aggregated as
+   * a median of per-entry read counts (outlier-robust). Artifact metrics parse
+   * the managed index and are omitted only when the index file is absent.
+   */
+  async measureFitness(
+    range: DateRange,
+    provider: TelemetryProvider,
+  ): Promise<Record<string, number>> {
+    const out: Record<string, number> = {};
+
+    // ── Tier 1: memory_access stream (one sample per read, labels.file) ─────
+    const samples = await provider.query("memory_access", range);
+    if (samples.length > 0) {
+      const perFile = new Map<string, number>();
+      for (const s of samples) {
+        const file = s.labels?.file ?? "unknown";
+        perFile.set(file, (perFile.get(file) ?? 0) + 1);
+      }
+      out.memory_median_reads_per_entry = median([...perFile.values()]);
+    }
+
+    // ── Tier 1b: artifact scan of the index ─────────────────────────────────
+    const scan = this.scanIndex();
+    if (scan !== null) {
+      out.memory_index_entry_count = scan.entries;
+      out.memory_index_defect_count = scan.defects;
+    }
+
+    return out;
+  }
+
+  /**
+   * Scan MEMORY.md: defects = entries whose referenced file is missing (dead) +
+   * duplicate-slug entries. Returns null when the index file is absent.
+   */
+  private scanIndex(): { entries: number; defects: number } | null {
+    if (!existsSync(this.memoryIndex)) return null;
+    let content: string;
+    try {
+      content = readFileSync(this.memoryIndex, "utf8");
+    } catch {
+      return null;
+    }
+    const entries = parseEntries(content);
+    const memoryDir = dirname(this.memoryIndex);
+    const slugCounts = new Map<string, number>();
+    for (const e of entries) {
+      const slug = e.file.replace(/\.md$/, "");
+      slugCounts.set(slug, (slugCounts.get(slug) ?? 0) + 1);
+    }
+    let defects = 0;
+    for (const e of entries) {
+      const slug = e.file.replace(/\.md$/, "");
+      if (!existsSync(resolve(memoryDir, e.file))) defects += 1;
+      else if ((slugCounts.get(slug) ?? 0) > 1) defects += 1;
+    }
+    return { entries: entries.length, defects };
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function parseEntries(content: string): MemoryEntry[] {
+  const out: MemoryEntry[] = [];
+  for (const line of content.split("\n")) {
+    const m = line.match(ENTRY_RE);
+    if (!m) continue;
+    out.push({
+      raw: line,
+      title: m[1]!,
+      file: m[2]!,
+      hook: m[3] ?? null,
+    });
+  }
+  return out;
+}
+
+function dedupe(entries: MemoryEntry[]): MemoryEntry[] {
+  const seen = new Set<string>();
+  const out: MemoryEntry[] = [];
+  for (const e of entries) {
+    if (seen.has(e.file)) continue;
+    seen.add(e.file);
+    out.push(e);
+  }
+  return out;
+}
+
+function renderIndex(entries: MemoryEntry[]): string {
+  const lines: string[] = [HEADER, ""];
+  for (const e of entries) {
+    if (e.hook) lines.push(`- [${e.title}](${e.file}) — ${e.hook}`);
+    else lines.push(`- [${e.title}](${e.file})`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+type Strategy = "dedup-dead" | "dedup-reorder" | "dedup-group";
+
+function isKnownStrategy(s: string): s is Strategy {
+  return s === "dedup-dead" || s === "dedup-reorder" || s === "dedup-group";
+}
+
+function applyStrategy(current: string, indexPath: string, strategy: Strategy): string {
+  const entries = parseEntries(current);
+  const memoryDir = dirname(indexPath);
+  const live = entries.filter((e) => existsSync(resolve(memoryDir, e.file)));
+  const deduped = dedupe(live);
+
+  switch (strategy) {
+    case "dedup-dead":
+      return renderIndex(deduped);
+    case "dedup-reorder":
+      return renderIndex([...deduped].sort((a, b) => a.title.localeCompare(b.title)));
+    case "dedup-group": {
+      // Group by leading slug-prefix (e.g. `feedback_`, `project_`, `user_`);
+      // entries without an underscore prefix go to a final 'misc' bucket.
+      const groups = new Map<string, MemoryEntry[]>();
+      for (const e of deduped) {
+        const m = e.file.match(/^([a-zA-Z][a-zA-Z0-9]*)_/);
+        const key = m ? m[1]! : "misc";
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key)?.push(e);
+      }
+      const orderedKeys = [...groups.keys()].sort();
+      const out: MemoryEntry[] = [];
+      for (const k of orderedKeys) {
+        const bucket = groups.get(k)!;
+        bucket.sort((a, b) => a.title.localeCompare(b.title));
+        out.push(...bucket);
+      }
+      return renderIndex(out);
+    }
+  }
+}

--- a/src/tuner/subjects/memory-subject.ts
+++ b/src/tuner/subjects/memory-subject.ts
@@ -44,7 +44,58 @@ function defaultMemoryIndex(): string {
 }
 
 const MAX_INDEX_LINES = 200;
+/** One-line budget per index entry (CLAUDE.md memory spec ~200 chars). */
+const MAX_INDEX_LINE_CHARS = 200;
 const HEADER = "# Memory Index";
+
+/** A memory index starts with the "# Memory Index" header OR (headerless live format) a "- [" entry. */
+function hasValidIndexStart(content: string): boolean {
+  const first = content.split("\n").find((l) => l.trim().length > 0) ?? "";
+  return first.startsWith(HEADER) || first.startsWith("- [");
+}
+
+/** One `.md` pointer of an entry line, or null if not exactly one. */
+function entryPointer(line: string): string | null {
+  const m = [...line.matchAll(/\]\(([^)]+\.md)\)/g)].map((x) => x[1]);
+  return m.length === 1 ? (m[0] as string) : null;
+}
+
+/**
+ * Reconcile a proposed (possibly stale) index against the LIVE index. Iterate
+ * the LIVE lines so no current entry is ever dropped: reuse the proposed
+ * shortened line where the entry still exists (by pointer), else deterministically
+ * shorten the new/changed live line. Non-entry lines come from live. Result's
+ * pointer set == live's pointer set (no loss), with propose-time shortening kept.
+ */
+function reconcileToLive(snapshot: string, live: string): string {
+  const shortByPtr = new Map<string, string>();
+  for (const l of snapshot.split("\n")) {
+    if (!l.startsWith("- [")) continue;
+    const p = entryPointer(l);
+    if (p) shortByPtr.set(p, l);
+  }
+  return live
+    .split("\n")
+    .map((l) => {
+      if (!l.startsWith("- [")) return l;
+      const p = entryPointer(l);
+      if (p && shortByPtr.has(p)) return shortByPtr.get(p) as string;
+      return shortenIndexLine(l);
+    })
+    .join("\n");
+}
+
+/** Deterministic shrink of one over-long index line: keep the link, trim the hook to budget. */
+function shortenIndexLine(line: string): string {
+  if (!line.startsWith("- [") || line.length <= MAX_INDEX_LINE_CHARS) return line;
+  const m = line.match(/^(- \[[^\]]*\]\([^)]+\.md\)\s*—\s*)([\s\S]*)$/);
+  if (!m) return `${line.slice(0, MAX_INDEX_LINE_CHARS - 1)}…`;
+  const head = m[1] as string;
+  const budget = MAX_INDEX_LINE_CHARS - head.length - 1;
+  if (budget <= 0) return `${line.slice(0, MAX_INDEX_LINE_CHARS - 1)}…`;
+  const hook = (m[2] as string).slice(0, budget).replace(/\s+\S*$/, "");
+  return `${head}${hook}…`;
+}
 // `- [Title](file.md) — hook` shape — em-dash or ASCII hyphen separator.
 const ENTRY_RE = /^- \[([^\]]+)\]\(([^)]+\.md)\)(?:\s+[—-]\s+(.+))?$/;
 
@@ -77,6 +128,8 @@ export interface MemorySubjectConfig {
   hookLog?: string;
   /** Path to the memory-signal sampler history (the local degradation signal). */
   signalHistoryPath?: string;
+  /** Path to the entry-quality judge cache (LLM-judged, sampled, cached). */
+  qualityCachePath?: string;
 }
 
 export class MemorySubject extends BaseSubject implements RevertibleSubject, EvidenceDrivenSubject {
@@ -89,6 +142,7 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
   private readonly memoryIndex: string;
   private readonly hookLog?: string;
   private readonly signalHistoryPath: string;
+  private readonly qualityCachePath: string;
 
   constructor(opts: MemorySubjectConfig = {}) {
     super();
@@ -100,6 +154,9 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
     this.hookLog = opts.hookLog;
     this.signalHistoryPath = (
       opts.signalHistoryPath ?? `${homedir()}/.config/tuner/memory-signal-history.jsonl`
+    ).replace(/^~(?=\/|$)/, homedir());
+    this.qualityCachePath = (
+      opts.qualityCachePath ?? `${homedir()}/.config/tuner/memory-quality-cache.json`
     ).replace(/^~(?=\/|$)/, homedir());
   }
 
@@ -224,11 +281,27 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
       });
     }
 
+    // Verbose-index signal: entries over the one-line budget bloat the per-session
+    // context cost. Emit one observation so a shrink is proposed even with 0 dead/dup.
+    const longLines = content.split("\n").filter((l) => l.length > MAX_INDEX_LINE_CHARS).length;
+    if (longLines > 0) {
+      observations.push({
+        session_id: `memory-verbose-${now.getTime()}`,
+        observed_at: now,
+        signal_type: "correction",
+        verbatim: sanitizeObservationContent(
+          JSON.stringify({ longLines, bytes: content.length }),
+          200,
+        ),
+        metadata: { subject: "memory", verbose: true, longLines, bytes: content.length },
+      });
+    }
+
     return observations;
   }
 
   async detectProblems(observations: Observation[]): Promise<Cluster[]> {
-    if (observations.length < 2) return [];
+    if (observations.length === 0) return [];
     return [
       {
         id: "memory-index-cleanup",
@@ -250,6 +323,9 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
     const dedupDead = applyStrategy(current, this.memoryIndex, "dedup-dead");
     const dedupReorder = applyStrategy(current, this.memoryIndex, "dedup-reorder");
     const dedupGroup = applyStrategy(current, this.memoryIndex, "dedup-group");
+    // Shrink: rewrite over-long entries to one line each (LLM, deterministic
+    // fallback). Unknown-strategy id → apply() writes this content verbatim.
+    const shrunk = await this.rewriteShort(current);
 
     // Emit unified diffs (≤2KB each) so the three alternatives stay visually
     // distinct in adapter surfaces. apply() re-runs the strategy against the
@@ -261,6 +337,13 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
       kind: "patch",
       target_path: this.memoryIndex,
       alternatives: [
+        {
+          id: "shrink",
+          label: "Shrink: rewrite over-long entries to one line (detail stays in topics)",
+          diff_or_content: shrunk,
+          tradeoff:
+            "Cuts per-session context cost + long-line count toward 0; keeps every entry + link.",
+        },
         {
           id: "dedup-dead",
           label: "Dedup + remove dead refs",
@@ -318,11 +401,20 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
           `memory-subject.apply: unknown strategy '${alternativeId}' and no diff_or_content`,
         );
       }
-      newContent = explicit;
-      // Pre-write validation for EXTERNAL content (M5/L5): structure + no live-pointer loss.
-      if (!newContent.startsWith(HEADER)) {
-        throw new Error("memory-subject.apply: external content missing index header");
+      // Accept both the "# Memory Index" header AND the headerless entry-first
+      // format the live auto-memory files actually use.
+      if (!hasValidIndexStart(explicit)) {
+        throw new Error(
+          "memory-subject.apply: external content is not a memory index (no header/entry start)",
+        );
       }
+      // Reconcile the (possibly stale) proposed index against the LIVE index at
+      // APPLY time: the proposal froze a snapshot at propose-time, but the user
+      // may have edited the memory before tapping Approve. Keep every current
+      // entry — using the proposed shortened line where the entry still exists,
+      // and deterministically shortening any new/changed entry — so Approve
+      // always succeeds on the current state and NEVER drops a live pointer.
+      newContent = reconcileToLive(explicit, current);
       const memDir = dirname(this.memoryIndex);
       const liveBefore = [...current.matchAll(/\]\(([^)]+\.md)\)/g)]
         .map((m) => m[1] as string)
@@ -331,9 +423,10 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
         [...newContent.matchAll(/\]\(([^)]+\.md)\)/g)].map((m) => m[1] as string),
       );
       const dropped = liveBefore.filter((file) => !afterPtrs.has(file));
+      // After reconciliation this should never fire; kept as a hard safety net.
       if (dropped.length > 0) {
         throw new Error(
-          `memory-subject.apply: external content drops ${dropped.length} live pointer(s): ${dropped.slice(0, 3).join(", ")}`,
+          `memory-subject.apply: reconciled content still drops ${dropped.length} live pointer(s): ${dropped.slice(0, 3).join(", ")}`,
         );
       }
     }
@@ -355,8 +448,11 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
 
   async validate(patch: Patch): Promise<ValidationResult> {
     const content = patch.applied_content;
-    if (!content.startsWith(HEADER)) {
-      return { valid: false, reason: `missing "${HEADER}" header` };
+    if (!hasValidIndexStart(content)) {
+      return {
+        valid: false,
+        reason: `not a memory index (no "${HEADER}" header or "- [" entry start)`,
+      };
     }
     const lines = content.split("\n");
     if (lines.length > MAX_INDEX_LINES) {
@@ -421,6 +517,40 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
         direction: "higher_is_better",
         windowDays: 7,
       },
+      {
+        // Context tax: MEMORY.md loads into context EVERY session, so its token
+        // footprint is a recurring cost. Lower is better. Gameable by deleting
+        // entries → guarded by memory_index_entry_count (higher_is_better).
+        name: "memory_index_context_cost",
+        source: ARTIFACT_SOURCE,
+        kind: "verifiable",
+        direction: "lower_is_better",
+        windowDays: 1,
+        guardrails: ["memory_index_entry_count"],
+      },
+      {
+        // Entry-verbosity defect: index lines over the one-line budget
+        // (~200 chars). Lower is better; the shrink strategy drives it to 0
+        // without dropping entries (entry_count guardrail).
+        name: "memory_index_long_line_count",
+        source: ARTIFACT_SOURCE,
+        kind: "verifiable",
+        direction: "lower_is_better",
+        windowDays: 1,
+        guardrails: ["memory_index_entry_count"],
+      },
+      {
+        // Semantic quality: an LLM judge rates a SAMPLE of entries 1–5 for
+        // clarity+specificity+actionability; the median is cached (sampled by a
+        // refresh, not measured inline — measureFitness stays fast). Higher is
+        // better. The anti-Goodhart pair to context_cost: shrinking must not
+        // gut the entries' usefulness.
+        name: "memory_entry_quality",
+        source: ARTIFACT_SOURCE,
+        kind: "verifiable",
+        direction: "higher_is_better",
+        windowDays: 7,
+      },
     ];
   }
 
@@ -451,16 +581,155 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
     if (scan !== null) {
       out.memory_index_entry_count = scan.entries;
       out.memory_index_defect_count = scan.defects;
+      out.memory_index_context_cost = scan.contextCostTokens;
+      out.memory_index_long_line_count = scan.longLines;
     }
 
+    // ── Tier 2: cached LLM entry-quality (judged out-of-band; read fast here) ─
+    const q = this.readQualityCache();
+    if (q !== null) out.memory_entry_quality = q;
+
     return out;
+  }
+
+  /** Read the cached median entry-quality (1–5), or null if absent/malformed. */
+  private readQualityCache(): number | null {
+    if (!existsSync(this.qualityCachePath)) return null;
+    try {
+      const c = JSON.parse(readFileSync(this.qualityCachePath, "utf8"));
+      return typeof c.median === "number" ? c.median : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * LLM-judge a random SAMPLE of index entries (1–5 for clarity + specificity +
+   * actionability), cache the median. Expensive (one LLM call) → run out-of-band
+   * (a refresh timer / on demand), NOT inside measureFitness. Returns the median,
+   * or null when there's no LLM or nothing to judge.
+   */
+  async measureEntryQuality(sampleSize = 12): Promise<number | null> {
+    if (!this.llm || !existsSync(this.memoryIndex)) return null;
+    const entryLines = readFileSync(this.memoryIndex, "utf8")
+      .split("\n")
+      .filter((l) => l.startsWith("- ["));
+    if (entryLines.length === 0) return null;
+    // Deterministic-ish sample: evenly spaced across the index.
+    const step = Math.max(1, Math.floor(entryLines.length / sampleSize));
+    const sample = entryLines.filter((_, i) => i % step === 0).slice(0, sampleSize);
+    const system =
+      "You are a strict memory-index reviewer. For EACH line, rate the entry 1-5 on " +
+      "clarity + specificity + actionability (5 = crisp, specific, immediately useful; " +
+      "1 = vague/redundant/noise). Reply ONLY with a JSON array of integers, one per " +
+      "line, in order. No prose.";
+    try {
+      const raw = await this.llm.call(
+        "judge",
+        system,
+        [{ role: "user", content: sample.join("\n") }],
+        400,
+      );
+      const nums = JSON.parse((raw.match(/\[[\s\S]*\]/) ?? ["[]"])[0]) as unknown[];
+      const scores = nums.filter((n): n is number => typeof n === "number" && n >= 1 && n <= 5);
+      if (scores.length === 0) return null;
+      const med = median(scores);
+      writeFileSync(
+        this.qualityCachePath,
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          median: med,
+          sampleSize: scores.length,
+          scores,
+        }),
+        "utf8",
+      );
+      return med;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Rough per-session context cost of the index in tokens (~4 chars/token). */
+  private estimateContextTokens(content: string): number {
+    return Math.ceil(content.length / 4);
+  }
+
+  /**
+   * Produce a shrunk index: each over-long entry becomes one line ≤200 chars,
+   * keeping its exact `[Title](file.md)` link (detail lives in the topic file).
+   * LLM rewrite when available (better prose); deterministic truncation as the
+   * fallback AND as the guard — if the LLM drops/adds an entry or a pointer, we
+   * fall back so the result always preserves every entry + link.
+   */
+  private async rewriteShort(content: string): Promise<string> {
+    const lines = content.split("\n");
+    if (!this.llm) return lines.map(shortenIndexLine).join("\n");
+    // Only over-long entry lines need rewriting; batch them so each LLM call is
+    // small + fast (a one-shot rewrite of a big index times out). Per-line guard:
+    // the output line must keep the SAME single pointer as its input, else that
+    // whole batch falls back to deterministic truncation. Non-entry + short lines
+    // are untouched and order is preserved.
+    const targets = lines
+      .map((l, i) => ({ l, i }))
+      .filter((x) => x.l.startsWith("- [") && x.l.length > MAX_INDEX_LINE_CHARS)
+      .map((x) => x.i);
+    if (targets.length === 0) return content;
+    const onePtr = (s: string) => {
+      const m = [...s.matchAll(/\]\(([^)]+\.md)\)/g)].map((x) => x[1]);
+      return m.length === 1 ? m[0] : null;
+    };
+    const system =
+      'You tighten memory-index lines of the form "- [Title](file.md) — hook". For EACH input ' +
+      "line, shorten the hook so the whole line is <=200 characters, KEEP the exact " +
+      '"[Title](file.md)" link, and return exactly ONE line per input line, in the SAME order. ' +
+      "Do NOT drop, add, merge, or reorder. Reply ONLY with the revised lines, nothing else.";
+    const BATCH = 15;
+    for (let b = 0; b < targets.length; b += BATCH) {
+      const idxs = targets.slice(b, b + BATCH);
+      const src = idxs.map((i) => lines[i] as string);
+      let ok = false;
+      try {
+        const raw = await this.llm.call(
+          "proposer",
+          system,
+          [{ role: "user", content: src.join("\n") }],
+          4000,
+        );
+        const out = raw
+          .trim()
+          .split("\n")
+          .filter((l) => l.startsWith("- ["));
+        ok =
+          out.length === src.length &&
+          out.every((o, k) => onePtr(o) !== null && onePtr(o) === onePtr(src[k] as string));
+        if (ok) {
+          idxs.forEach((i, k) => {
+            lines[i] = out[k] as string;
+          });
+        }
+      } catch {
+        ok = false;
+      }
+      if (!ok) {
+        idxs.forEach((i) => {
+          lines[i] = shortenIndexLine(lines[i] as string);
+        });
+      }
+    }
+    return lines.join("\n");
   }
 
   /**
    * Scan MEMORY.md: defects = entries whose referenced file is missing (dead) +
    * duplicate-slug entries. Returns null when the index file is absent.
    */
-  private scanIndex(): { entries: number; defects: number } | null {
+  private scanIndex(): {
+    entries: number;
+    defects: number;
+    contextCostTokens: number;
+    longLines: number;
+  } | null {
     if (!existsSync(this.memoryIndex)) return null;
     let content: string;
     try {
@@ -481,7 +750,14 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
       if (!existsSync(resolve(memoryDir, e.file))) defects += 1;
       else if ((slugCounts.get(slug) ?? 0) > 1) defects += 1;
     }
-    return { entries: entries.length, defects };
+    // Entry lines over the ~200-char one-line budget (CLAUDE.md memory spec).
+    const longLines = content.split("\n").filter((l) => l.length > MAX_INDEX_LINE_CHARS).length;
+    return {
+      entries: entries.length,
+      defects,
+      contextCostTokens: this.estimateContextTokens(content),
+      longLines,
+    };
   }
 }
 

--- a/src/tuner/subjects/memory-subject.ts
+++ b/src/tuner/subjects/memory-subject.ts
@@ -5,6 +5,7 @@ import {
   writeFileSync,
   renameSync,
   statSync,
+  lstatSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, resolve } from "node:path";
@@ -81,12 +82,27 @@ function reconcileToLive(snapshot: string, live: string): string {
     const p = entryPointer(l);
     if (p) shortByPtr.set(p, l);
   }
-  return live
-    .split("\n")
+  const liveLines = live.split("\n");
+  // Count live pointer occurrences so a duplicated slug never collapses two
+  // distinct live lines into one snapshot line (L1).
+  const ptrCount = new Map<string, number>();
+  for (const l of liveLines) {
+    if (!l.startsWith("- [")) continue;
+    const p = entryPointer(l);
+    if (p) ptrCount.set(p, (ptrCount.get(p) ?? 0) + 1);
+  }
+  return liveLines
     .map((l) => {
       if (!l.startsWith("- [")) return l;
+      // Within budget → KEEP the live line verbatim. This preserves any edit the
+      // operator made between propose-time and approve-time (M4): only over-budget
+      // lines are touched, and shortening is exactly what needs doing there.
+      if (l.length <= MAX_INDEX_LINE_CHARS) return l;
       const p = entryPointer(l);
-      if (p && shortByPtr.has(p)) return shortByPtr.get(p) as string;
+      // Over-budget + a UNIQUE pointer → use the proposed shortened line;
+      // duplicated pointers shorten each occurrence individually (no collapse).
+      if (p && (ptrCount.get(p) ?? 0) === 1 && shortByPtr.has(p))
+        return shortByPtr.get(p) as string;
       return shortenIndexLine(l);
     })
     .join("\n");
@@ -441,6 +457,12 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
       }
     }
 
+    // M3: refuse to operate on a symlinked index (defence-in-depth — the rename
+    // below replaces the link rather than following it, but a planted symlink
+    // still signals tampering).
+    if (existsSync(this.memoryIndex) && lstatSync(this.memoryIndex).isSymbolicLink()) {
+      throw new Error(`memory-subject.apply: index is a symlink, refusing: ${this.memoryIndex}`);
+    }
     if (existsSync(this.memoryIndex)) {
       copyFileSync(this.memoryIndex, `${this.memoryIndex}.bak`);
     }
@@ -621,10 +643,18 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
   private async refreshQualityIfStale(maxAgeDays = 7): Promise<void> {
     if (!this.llm) return;
     try {
-      const fresh =
-        existsSync(this.qualityCachePath) &&
-        Date.now() - statSync(this.qualityCachePath).mtimeMs < maxAgeDays * 86_400_000;
-      if (!fresh) await this.measureEntryQuality();
+      if (existsSync(this.qualityCachePath)) {
+        const ageMs = Date.now() - statSync(this.qualityCachePath).mtimeMs;
+        let cooldownMs = maxAgeDays * 86_400_000;
+        try {
+          const c = JSON.parse(readFileSync(this.qualityCachePath, "utf8"));
+          if (c && c.failed === true) cooldownMs = 6 * 3_600_000; // short retry after a failure (L8)
+        } catch {
+          /* unreadable → treat as stale, refresh */
+        }
+        if (ageMs < cooldownMs) return;
+      }
+      await this.measureEntryQuality();
     } catch {
       /* best-effort; never block observation collection */
     }
@@ -659,7 +689,10 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
       );
       const nums = JSON.parse((raw.match(/\[[\s\S]*\]/) ?? ["[]"])[0]) as unknown[];
       const scores = nums.filter((n): n is number => typeof n === "number" && n >= 1 && n <= 5);
-      if (scores.length === 0) return null;
+      if (scores.length === 0) {
+        this.stampQualityFailure();
+        return null;
+      }
       const med = median(scores);
       writeFileSync(
         this.qualityCachePath,
@@ -673,7 +706,22 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
       );
       return med;
     } catch {
+      this.stampQualityFailure();
       return null;
+    }
+  }
+
+  /** L8: record a short-TTL failure stamp so refreshQualityIfStale won't re-fire a
+   * blocking LLM call every cycle after an error/timeout/unparseable reply. */
+  private stampQualityFailure(): void {
+    try {
+      writeFileSync(
+        this.qualityCachePath,
+        JSON.stringify({ ts: new Date().toISOString(), median: null, failed: true }),
+        "utf8",
+      );
+    } catch {
+      /* best-effort */
     }
   }
 
@@ -729,7 +777,15 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
           .filter((l) => l.startsWith("- ["));
         ok =
           out.length === src.length &&
-          out.every((o, k) => onePtr(o) !== null && onePtr(o) === onePtr(src[k] as string));
+          // Preserve pointers AND actually shorten: an LLM line that keeps the
+          // pointer but stays over-budget must not pass (L2) — else the shrink
+          // reports success while long_line_count never reaches 0.
+          out.every(
+            (o, k) =>
+              onePtr(o) !== null &&
+              onePtr(o) === onePtr(src[k] as string) &&
+              o.length <= MAX_INDEX_LINE_CHARS,
+          );
         if (ok) {
           idxs.forEach((i, k) => {
             lines[i] = out[k] as string;
@@ -772,10 +828,15 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
       slugCounts.set(slug, (slugCounts.get(slug) ?? 0) + 1);
     }
     let defects = 0;
+    const countedDupSlugs = new Set<string>();
     for (const e of entries) {
       const slug = e.file.replace(/\.md$/, "");
       if (!existsSync(resolve(memoryDir, e.file))) defects += 1;
-      else if ((slugCounts.get(slug) ?? 0) > 1) defects += 1;
+      // A duplicated slug is ONE defect, not one per occurrence (L9).
+      else if ((slugCounts.get(slug) ?? 0) > 1 && !countedDupSlugs.has(slug)) {
+        defects += 1;
+        countedDupSlugs.add(slug);
+      }
     }
     // Entry lines over the ~200-char one-line budget (CLAUDE.md memory spec).
     const longLines = content.split("\n").filter((l) => l.length > MAX_INDEX_LINE_CHARS).length;

--- a/src/tuner/subjects/memory-subject.ts
+++ b/src/tuner/subjects/memory-subject.ts
@@ -348,7 +348,6 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
     const current = readFileSync(this.memoryIndex, "utf8");
     const dedupDead = applyStrategy(current, this.memoryIndex, "dedup-dead");
     const dedupReorder = applyStrategy(current, this.memoryIndex, "dedup-reorder");
-    const dedupGroup = applyStrategy(current, this.memoryIndex, "dedup-group");
     // Shrink: rewrite over-long entries to one line each (LLM, deterministic
     // fallback). Unknown-strategy id → apply() writes this content verbatim.
     const shrunk = await this.rewriteShort(current);
@@ -387,15 +386,6 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
             toLabel: "MEMORY.md (dedup-reorder)",
           }),
           tradeoff: "Easier visual scan; reorder churn in git blame.",
-        },
-        {
-          id: "dedup-group",
-          label: "Dedup + group by name prefix",
-          diff_or_content: renderDiff(current, dedupGroup, {
-            fromLabel: "MEMORY.md",
-            toLabel: "MEMORY.md (dedup-group)",
-          }),
-          tradeoff: "Groups feedback_/project_/user_ entries together; loses chronological order.",
         },
       ],
       pattern_signature: `memory:dedup:${parseEntries(current).length}`,

--- a/src/tuner/subjects/memory-subject.ts
+++ b/src/tuner/subjects/memory-subject.ts
@@ -1,4 +1,11 @@
-import { existsSync, copyFileSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import {
+  existsSync,
+  copyFileSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, resolve } from "node:path";
 import { BaseSubject } from "../../skills-tuner/subjects/base.js";
@@ -233,6 +240,9 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
 
   async collectObservations(_since: Date): Promise<Observation[]> {
     if (!existsSync(this.memoryIndex)) return [];
+    // Out-of-band, best-effort: refresh the LLM entry-quality cache if it's stale
+    // (gated on an LLM being configured → dormant + zero cost by default).
+    await this.refreshQualityIfStale();
     const content = readFileSync(this.memoryIndex, "utf8");
     const entries = parseEntries(content);
     if (entries.length === 0) return [];
@@ -600,6 +610,23 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
       return typeof c.median === "number" ? c.median : null;
     } catch {
       return null;
+    }
+  }
+
+  /**
+   * Wire for the quality judge: refresh the cache if older than `maxAgeDays`.
+   * Gated on an LLM being configured (default: none → no-op, zero cost), so the
+   * judge is reachable from the normal cycle without adding cost by default.
+   */
+  private async refreshQualityIfStale(maxAgeDays = 7): Promise<void> {
+    if (!this.llm) return;
+    try {
+      const fresh =
+        existsSync(this.qualityCachePath) &&
+        Date.now() - statSync(this.qualityCachePath).mtimeMs < maxAgeDays * 86_400_000;
+      if (!fresh) await this.measureEntryQuality();
+    } catch {
+      /* best-effort; never block observation collection */
     }
   }
 

--- a/src/tuner/wisecron/evidence-driven.ts
+++ b/src/tuner/wisecron/evidence-driven.ts
@@ -1,0 +1,117 @@
+/**
+ * evidence-driven — the SOCLE contract for proactive, evidence-backed improvement.
+ *
+ * Each tunable subject MAY implement `EvidenceDrivenSubject` to gain a second,
+ * proactive face (alongside its reactive `detect()`): it declares WHAT to research,
+ * exposes its own LOCAL signal (degradation history from telemetry/files), and
+ * DECIDES from clean structured evidence + that signal whether to propose.
+ *
+ * Boundary (security): the subject NEVER touches the web. A separate sandboxed
+ * feeder fetches untrusted sources (papers/blogs), extracts them with a strict
+ * schema (anti prompt-injection), and produces `StructuredEvidence`. Only that
+ * clean, verified evidence crosses into the governed tuner. Raw paper text never
+ * enters the engine.
+ */
+
+/** What a subject wants researched. Declarative only — no fetching here. */
+export interface ResearchSpec {
+  subject: string;
+  /** The topic the feeder should gather evidence on. */
+  query: string;
+  /** Trust tiers the feeder may use (high → low). */
+  sourceTiers: Array<"enterprise" | "authoritative" | "papers" | "synthesis">;
+  /** The candidate technique under evaluation (e.g. "vectorized-retrieval"). */
+  technique: string;
+}
+
+/** Clean, structured evidence produced by the FEEDER (never raw paper text). */
+export interface StructuredEvidence {
+  technique: string;
+  /** Count of INDEPENDENT confirmations (the core of "faisceau de preuves"). */
+  independentSources: number;
+  /** Subset coming from enterprise/authoritative tiers (highest trust). */
+  highTrustSources: number;
+  /** Demonstrated-elsewhere flag: proven in a production system, not just a paper. */
+  provenInProduction: boolean;
+  /** Claimed gain, verbatim from the source (e.g. "recall +13pp"). */
+  claimedGain?: string;
+  /** The condition under which the technique helps (for applicability matching). */
+  applicableWhen?: string;
+  /** Source URLs — the audit trail. */
+  citations: string[];
+}
+
+/** A subject's local signal, read from telemetry/files. The degradation history. */
+export interface LocalSignal {
+  metric: string;
+  value: number;
+  unit: string;
+  /** Has the metric crossed the subject's own degradation threshold? */
+  degraded: boolean;
+  /** Direction over the recent history window. */
+  trend: "improving" | "stable" | "degrading";
+  sampledAt: string;
+}
+
+/** The subject's decision, given evidence + signal. */
+export interface EvidenceVerdict {
+  propose: boolean;
+  reason: string;
+  /**
+   * How the improvement is delivered — this drives the proactive router:
+   *   • `patch` = a CONTENT/CONFIG change the subject applies itself, in its own
+   *     confined dir (e.g. rewriting a skill description). A normal gated patch —
+   *     NO plugin. The subject must implement `proposeEvidencePatch`.
+   *   • `recommendation` = an ARCHITECTURAL capability (e.g. vectorised retrieval)
+   *     the subject cannot deliver as content. It resolves to a gated PLUGIN
+   *     install (technique-plugin-registry) or, if no plugin maps it, a
+   *     detect-only note. NEVER engine code.
+   */
+  kind: "patch" | "recommendation";
+  /** 0..1, from convergence × applicability × signal severity. */
+  confidence: number;
+}
+
+/** A concrete, evidence-backed content patch the subject will apply (kind="patch"). */
+export interface EvidencePatch {
+  /** File the subject will write — must be inside the subject's own managed dir. */
+  target_path: string;
+  alternatives: Array<{ id: string; label: string; diff_or_content: string; tradeoff: string }>;
+}
+
+/**
+ * Implemented by each subject that supports proactive, evidence-backed improvement.
+ * The proactive cycle drives it; the feeder supplies the StructuredEvidence.
+ */
+export interface EvidenceDrivenSubject {
+  /** Subject id (matches BaseSubject.name). */
+  readonly name: string;
+  /** Declare what to research (the feeder fetches; the subject never touches the web). */
+  researchSpec(): ResearchSpec;
+  /** Read the subject's own local signal (degradation history) from telemetry/files. */
+  localSignal(): Promise<LocalSignal>;
+  /** Decide, from CLEAN structured evidence + the local signal, whether/what to propose. */
+  evaluate(evidence: StructuredEvidence, signal: LocalSignal): EvidenceVerdict;
+  /**
+   * For a `kind:"patch"` verdict: build the concrete CONTENT patch the subject
+   * will apply itself (gated, in its own dir — never a plugin, never engine code).
+   * Returns null when nothing actionable is found. Required only for subjects
+   * whose evaluate() can return `kind:"patch"`.
+   */
+  proposeEvidencePatch?(
+    evidence: StructuredEvidence,
+    signal: LocalSignal,
+  ): Promise<EvidencePatch | null>;
+  /** After an apply, re-read the signal to confirm the change actually helped. */
+  confirm(before: LocalSignal): Promise<boolean>;
+}
+
+/** Default convergence gate: enough independent + some high-trust + applicable. */
+export function meetsEvidenceBar(
+  e: StructuredEvidence,
+  opts: { minIndependent?: number; minHighTrust?: number } = {},
+): boolean {
+  const minInd = opts.minIndependent ?? 3;
+  const minHigh = opts.minHighTrust ?? 1;
+  return e.independentSources >= minInd && (e.highTrustSources >= minHigh || e.provenInProduction);
+}

--- a/src/tuner/wisecron/index.ts
+++ b/src/tuner/wisecron/index.ts
@@ -28,6 +28,7 @@ import { ApplyPipeline } from "./apply-pipeline.js";
 import type { WisecronSettings } from "./types.js";
 
 import { ModelRoutingSubject } from "../subjects/model-routing-subject.js";
+import { MemorySubject } from "../subjects/memory-subject.js";
 // #275 staging: this brick ships the OutcomeLoop + ONLY the model-routing subject
 // (reversible, measurable) as the single-subject proof. The other 7 wisecron
 // subjects (cron, claude_md, hook, mcp_plugin, prompt_template, memory, agent)
@@ -109,6 +110,9 @@ export function registerWisecronSubjects(
         ),
       }),
     );
+
+  // memory subject: reactive index hygiene + proactive evidence face.
+  if (enabled("memory")) registerWithProbeCheck(new MemorySubject({ ...cfg("memory") }));
 
   // Resolve the active tuning scope (global + per-subject overrides) and record
   // it in the audit chain at registration — the certifier reads "the tuner

--- a/src/tuner/wisecron/index.ts
+++ b/src/tuner/wisecron/index.ts
@@ -29,10 +29,11 @@ import type { WisecronSettings } from "./types.js";
 
 import { ModelRoutingSubject } from "../subjects/model-routing-subject.js";
 import { MemorySubject } from "../subjects/memory-subject.js";
-// #275 staging: this brick ships the OutcomeLoop + ONLY the model-routing subject
-// (reversible, measurable) as the single-subject proof. The other 7 wisecron
-// subjects (cron, claude_md, hook, mcp_plugin, prompt_template, memory, agent)
-// land in their own follow-up bricks once the loop has earned its keep.
+// #275 staging: this brick ships the OutcomeLoop + the model-routing subject
+// (the single-subject proof) AND the memory subject (reactive index hygiene +
+// proactive evidence face). The remaining wisecron subjects (cron, claude_md,
+// hook, mcp_plugin, prompt_template, agent) land in their own follow-up bricks
+// once the loop has earned its keep.
 import { makeModeDispatchReader } from "./observation-readers.js";
 
 export interface WisecronContext {
@@ -97,7 +98,8 @@ export function registerWisecronSubjects(
     warnIfMissingHealthProbe(subject);
   };
 
-  // Single-subject proof (#275): only model-routing is wired in this brick.
+  // Single-subject proof (#275): model-routing is the reference subject; the
+  // memory subject is wired just below.
   if (enabled("model_routing"))
     registerWithProbeCheck(
       new ModelRoutingSubject({


### PR DESCRIPTION
## memory subject (reactive + proactive) [#275 — Phase 4, subject 1/3]

> **Stacked on #287.** First of three separate subject PRs.

The `memory` TunableSubject:
- **Reactive**: dead-pointer / oversize / duplicate hygiene patches on the memory index (data-preservation-checked, atomic writes, 3-way revert).
- **Proactive** (`EvidenceDrivenSubject`): a local signal (index load latency / size / dead-pointer ratio, trend off a stable metric with a noise floor) → only when degraded, asks the feeder for **convergent** external evidence → a gated proposal. The technique here (vectorised retrieval) is architectural → routes to a plugin install (see #290), never engine code.

Also lands the shared **`EvidenceDrivenSubject` contract** (`researchSpec` / `localSignal` / `evaluate` / `confirm` + optional `proposeEvidencePatch`) reused by the model_routing and skills subject PRs.

Tests green; biome clean.
