### PR TITLE
feat(tuner): model_routing proactive evidence face [#275 subject 2/3, stacked on #287]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.174",
+      "version": "2.2.175",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.183",
+      "version": "2.2.184",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.181",
+      "version": "2.2.182",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.179",
+      "version": "2.2.180",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.176",
+      "version": "2.2.177",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.182",
+      "version": "2.2.183",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.178",
+      "version": "2.2.179",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.180",
+      "version": "2.2.181",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.184",
+      "version": "2.2.189",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.175",
+      "version": "2.2.176",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.188",
+      "version": "2.2.174",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.177",
+      "version": "2.2.178",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.190",
+      "version": "2.2.191",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.189",
+      "version": "2.2.190",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.184",
+  "version": "2.2.189",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.179",
+  "version": "2.2.180",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.176",
+  "version": "2.2.177",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.178",
+  "version": "2.2.179",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.177",
+  "version": "2.2.178",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.182",
+  "version": "2.2.183",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.189",
+  "version": "2.2.190",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.180",
+  "version": "2.2.181",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.188",
+  "version": "2.2.174",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.190",
+  "version": "2.2.191",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.175",
+  "version": "2.2.176",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.174",
+  "version": "2.2.175",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.183",
+  "version": "2.2.184",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.181",
+  "version": "2.2.182",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/tuner/__tests__/wisecron/subjects/agentic-config.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/agentic-config.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "bun:test";
+import {
+  toAaSlug,
+  isRunnableModel,
+  readAgenticModes,
+  setAgenticModel,
+} from "../../../subjects/agentic-config.js";
+import type { ModelBenchmark } from "../../../subjects/model-routing-benchmarks.js";
+
+const bm = (id: string): ModelBenchmark => ({
+  model_id: id,
+  name: id,
+  intelligence_index: 1,
+  coding_index: 1,
+  agentic_index: 1,
+  price_in_usd_per_mtok: 1,
+  price_out_usd_per_mtok: 1,
+  price_cache_hit_usd_per_mtok: null,
+  source: "t",
+  fetched_at: "t",
+});
+
+const SETTINGS = JSON.stringify(
+  {
+    model: "",
+    agentic: {
+      enabled: true,
+      defaultMode: "implementation",
+      modes: [
+        { name: "planning", model: "claude-3-5-sonnet", keywords: ["design"] },
+        { name: "implementation", model: "sonnet", keywords: ["code"] },
+      ],
+    },
+    other: { keep: true },
+  },
+  null,
+  2,
+);
+
+describe("agentic-config — real settings.json reconciliation (#292)", () => {
+  it("aliases operator model names to AA slugs, passes unknown through", () => {
+    expect(toAaSlug("sonnet")).toBe("claude-sonnet-5");
+    expect(toAaSlug("claude-3-5-sonnet")).toBe("claude-35-sonnet");
+    expect(toAaSlug("SomeFuture-Model")).toBe("somefuture-model");
+  });
+
+  it("constrains candidates to runnable (Claude) models", () => {
+    expect(isRunnableModel(bm("claude-sonnet-5"))).toBe(true);
+    expect(isRunnableModel(bm("minimax-m3"))).toBe(false);
+    expect(isRunnableModel(bm("command-a-plus"))).toBe(false);
+  });
+
+  it("reads agentic.modes (list format) and attaches the AA slug", () => {
+    expect(readAgenticModes(SETTINGS)).toEqual([
+      { mode: "planning", model: "claude-3-5-sonnet", aaSlug: "claude-35-sonnet" },
+      { mode: "implementation", model: "sonnet", aaSlug: "claude-sonnet-5" },
+    ]);
+  });
+
+  it("returns [] gracefully on bad JSON / no agentic / disabled-without-modes", () => {
+    expect(readAgenticModes("{not json")).toEqual([]);
+    expect(readAgenticModes("{}")).toEqual([]);
+    expect(readAgenticModes(JSON.stringify({ agentic: {} }))).toEqual([]);
+  });
+
+  it("setAgenticModel changes ONE mode's model, preserving the rest of settings.json", () => {
+    const out = setAgenticModel(SETTINGS, "planning", "claude-sonnet-5");
+    const parsed = JSON.parse(out);
+    expect(parsed.agentic.modes[0].model).toBe("claude-sonnet-5"); // changed
+    expect(parsed.agentic.modes[1].model).toBe("sonnet"); // untouched
+    expect(parsed.other.keep).toBe(true); // rest intact
+    expect(parsed.agentic.modes[0].keywords).toEqual(["design"]); // keywords kept
+  });
+
+  it("setAgenticModel is a safe no-op on absent mode / bad JSON", () => {
+    expect(setAgenticModel(SETTINGS, "nonexistent", "x")).toBe(SETTINGS);
+    expect(setAgenticModel("{bad", "planning", "x")).toBe("{bad");
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-benchmarks.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-benchmarks.test.ts
@@ -24,9 +24,11 @@ function aaResponse() {
         id: "m1",
         name: "Claude Opus 4.8",
         slug: "claude-4-8-opus",
-        artificial_analysis_intelligence_index: 71.2,
-        artificial_analysis_coding_index: 68.0,
-        artificial_analysis_agentic_index: 55.4,
+        evaluations: {
+          artificial_analysis_intelligence_index: 71.2,
+          artificial_analysis_coding_index: 68.0,
+          artificial_analysis_agentic_index: 55.4,
+        },
         pricing: {
           price_1m_input_tokens: 15,
           price_1m_output_tokens: 75,
@@ -35,12 +37,12 @@ function aaResponse() {
       },
       {
         name: "No-slug model",
-        artificial_analysis_intelligence_index: 40,
+        evaluations: { artificial_analysis_intelligence_index: 40 },
       }, // dropped: no slug/id
       {
         slug: "haiku-cheap",
         name: "Haiku",
-        artificial_analysis_intelligence_index: 50,
+        evaluations: { artificial_analysis_intelligence_index: 50 },
         // no pricing, no coding/agentic → null, not throw
       },
     ],

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-benchmarks.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-benchmarks.test.ts
@@ -194,3 +194,33 @@ describe("model-routing-benchmarks — cache", () => {
     expect(rows.length).toBe(2);
   });
 });
+
+describe("model-routing-benchmarks — cache stores the FULL set (no poisoning)", () => {
+  it("filtered getModelBenchmarks does not shrink the cache for later readers", async () => {
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "aa-poison-"));
+    const cachePath = join(dir, "b.json");
+    const { impl } = mockFetch(aaResponse());
+    // 1st call: filter to ONE model + cache
+    await getModelBenchmarks({
+      apiKey: "k",
+      fetchImpl: impl,
+      cachePath,
+      nowMs: NOW,
+      models: ["claude-4-8-opus"],
+    });
+    // 2nd call: SAME cache, no filter → must still see both models (cache holds full set)
+    const { impl: impl2, calls: calls2 } = mockFetch(aaResponse());
+    const all = await getModelBenchmarks({
+      apiKey: "k",
+      fetchImpl: impl2,
+      cachePath,
+      nowMs: NOW + 1000,
+    });
+    expect(all.length).toBe(2); // NOT 1 — cache was not poisoned
+    expect(calls2.length).toBe(0); // served from the (full) cache
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-benchmarks.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-benchmarks.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ATTRIBUTION,
+  DEFAULT_TTL_MS,
+  parseArtificialAnalysis,
+  fetchModelBenchmarks,
+  readBenchmarkCache,
+  writeBenchmarkCache,
+  getModelBenchmarks,
+} from "../../../subjects/model-routing-benchmarks.js";
+
+const NOW = 1_700_000_000_000;
+
+// A trimmed but shape-accurate Artificial Analysis /models/free row.
+function aaResponse() {
+  return {
+    tier: "free",
+    intelligence_index_version: 4.1,
+    data: [
+      {
+        id: "m1",
+        name: "Claude Opus 4.8",
+        slug: "claude-4-8-opus",
+        artificial_analysis_intelligence_index: 71.2,
+        artificial_analysis_coding_index: 68.0,
+        artificial_analysis_agentic_index: 55.4,
+        pricing: {
+          price_1m_input_tokens: 15,
+          price_1m_output_tokens: 75,
+          price_1m_cache_hit_tokens: 1.5,
+        },
+      },
+      {
+        name: "No-slug model",
+        artificial_analysis_intelligence_index: 40,
+      }, // dropped: no slug/id
+      {
+        slug: "haiku-cheap",
+        name: "Haiku",
+        artificial_analysis_intelligence_index: 50,
+        // no pricing, no coding/agentic → null, not throw
+      },
+    ],
+  };
+}
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  const calls: Array<{ url: string; headers?: Record<string, string> }> = [];
+  const impl = async (url: string, init?: { headers?: Record<string, string> }) => {
+    calls.push({ url, headers: init?.headers });
+    return { ok, status, json: async () => body };
+  };
+  return { impl, calls };
+}
+
+describe("model-routing-benchmarks — parse", () => {
+  it("maps AA rows to ModelBenchmark with correct fields", () => {
+    const rows = parseArtificialAnalysis(aaResponse(), new Date(NOW).toISOString());
+    expect(rows.length).toBe(2); // no-slug row dropped
+    const opus = rows.find((r) => r.model_id === "claude-4-8-opus")!;
+    expect(opus.intelligence_index).toBe(71.2);
+    expect(opus.coding_index).toBe(68.0);
+    expect(opus.price_in_usd_per_mtok).toBe(15);
+    expect(opus.price_out_usd_per_mtok).toBe(75);
+    expect(opus.price_cache_hit_usd_per_mtok).toBe(1.5);
+    expect(opus.source).toBe(ATTRIBUTION);
+    expect(opus.fetched_at).toBe(new Date(NOW).toISOString());
+  });
+
+  it("degrades missing fields to null without throwing", () => {
+    const rows = parseArtificialAnalysis(aaResponse(), "t");
+    const haiku = rows.find((r) => r.model_id === "haiku-cheap")!;
+    expect(haiku.coding_index).toBeNull();
+    expect(haiku.agentic_index).toBeNull();
+    expect(haiku.price_in_usd_per_mtok).toBeNull();
+    expect(haiku.intelligence_index).toBe(50);
+  });
+
+  it("returns [] on a non-array / malformed body", () => {
+    expect(parseArtificialAnalysis({}, "t")).toEqual([]);
+    expect(parseArtificialAnalysis({ data: "nope" }, "t")).toEqual([]);
+    expect(parseArtificialAnalysis(null, "t")).toEqual([]);
+  });
+});
+
+describe("model-routing-benchmarks — fetch", () => {
+  it("sends x-api-key to the free endpoint and parses the result", async () => {
+    const { impl, calls } = mockFetch(aaResponse());
+    const rows = await fetchModelBenchmarks({ apiKey: "k", fetchImpl: impl, nowMs: NOW });
+    expect(rows.length).toBe(2);
+    expect(calls[0]?.headers?.["x-api-key"]).toBe("k");
+    expect(calls[0]?.url).toContain("/language/models/free");
+  });
+
+  it("returns [] with no API key (no call made)", async () => {
+    const { impl, calls } = mockFetch(aaResponse());
+    const rows = await fetchModelBenchmarks({ fetchImpl: impl });
+    expect(rows).toEqual([]);
+    expect(calls.length).toBe(0);
+  });
+
+  it("returns [] on non-200, on a thrown network error, and on malformed JSON", async () => {
+    const non200 = mockFetch(aaResponse(), false, 503);
+    expect(await fetchModelBenchmarks({ apiKey: "k", fetchImpl: non200.impl })).toEqual([]);
+
+    const thrower = async () => {
+      throw new Error("ECONNRESET");
+    };
+    expect(await fetchModelBenchmarks({ apiKey: "k", fetchImpl: thrower as never })).toEqual([]);
+
+    const badJson = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("bad json");
+      },
+    });
+    expect(await fetchModelBenchmarks({ apiKey: "k", fetchImpl: badJson as never })).toEqual([]);
+  });
+
+  it("filters to the requested model slugs (case-insensitive)", async () => {
+    const { impl } = mockFetch(aaResponse());
+    const rows = await fetchModelBenchmarks({
+      apiKey: "k",
+      fetchImpl: impl,
+      models: ["Claude-4-8-Opus"],
+    });
+    expect(rows.map((r) => r.model_id)).toEqual(["claude-4-8-opus"]);
+  });
+});
+
+describe("model-routing-benchmarks — cache", () => {
+  let dir: string;
+  let cachePath: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "aa-bench-"));
+    cachePath = join(dir, "benchmarks.json");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("returns fresh cache and null once past TTL", () => {
+    const rows = parseArtificialAnalysis(aaResponse(), "t");
+    writeBenchmarkCache(cachePath, rows, NOW);
+    expect(readBenchmarkCache(cachePath, DEFAULT_TTL_MS, NOW + 1000)?.length).toBe(2);
+    expect(readBenchmarkCache(cachePath, DEFAULT_TTL_MS, NOW + DEFAULT_TTL_MS + 1)).toBeNull();
+  });
+
+  it("returns null for a missing or corrupt cache file", () => {
+    expect(readBenchmarkCache(join(dir, "nope.json"), DEFAULT_TTL_MS, NOW)).toBeNull();
+    writeFileSync(cachePath, "{not json", "utf8");
+    expect(readBenchmarkCache(cachePath, DEFAULT_TTL_MS, NOW)).toBeNull();
+  });
+
+  it("getModelBenchmarks serves fresh cache without fetching", async () => {
+    writeBenchmarkCache(cachePath, parseArtificialAnalysis(aaResponse(), "t"), NOW);
+    const { impl, calls } = mockFetch(aaResponse());
+    const rows = await getModelBenchmarks({
+      apiKey: "k",
+      fetchImpl: impl,
+      cachePath,
+      nowMs: NOW + 1000,
+    });
+    expect(rows.length).toBe(2);
+    expect(calls.length).toBe(0); // cache hit → no network
+  });
+
+  it("getModelBenchmarks fetches + persists on a cold/stale cache", async () => {
+    const { impl, calls } = mockFetch(aaResponse());
+    const rows = await getModelBenchmarks({ apiKey: "k", fetchImpl: impl, cachePath, nowMs: NOW });
+    expect(rows.length).toBe(2);
+    expect(calls.length).toBe(1);
+    expect(existsSync(cachePath)).toBe(true);
+    const persisted = JSON.parse(readFileSync(cachePath, "utf8"));
+    expect(persisted.attribution).toBe(ATTRIBUTION);
+    expect(persisted.benchmarks.length).toBe(2);
+  });
+
+  it("falls back to STALE cache when a refresh fetch fails", async () => {
+    // seed a stale cache (older than TTL)
+    writeBenchmarkCache(cachePath, parseArtificialAnalysis(aaResponse(), "t"), NOW);
+    const failing = mockFetch(aaResponse(), false, 500);
+    const rows = await getModelBenchmarks({
+      apiKey: "k",
+      fetchImpl: failing.impl,
+      cachePath,
+      nowMs: NOW + DEFAULT_TTL_MS + 5000, // cache is stale
+    });
+    // fresh fetch failed → stale beats empty
+    expect(rows.length).toBe(2);
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-confinement.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-confinement.test.ts
@@ -32,9 +32,7 @@ describe("ModelRoutingSubject — apply/revert confinement", () => {
   it("apply refuses a target_path outside the managed modes config", async () => {
     const sub = new ModelRoutingSubject({ modesConfigPath: configPath });
     const foreign = join(tmpRoot, "engine.ts");
-    await expect(sub.apply(foreignProposal(foreign), "a")).rejects.toThrow(
-      /not the managed modes config/,
-    );
+    await expect(sub.apply(foreignProposal(foreign), "a")).rejects.toThrow(/not a managed config/);
   });
 
   it("revert refuses a foreign target_path", async () => {
@@ -44,7 +42,7 @@ describe("ModelRoutingSubject — apply/revert confinement", () => {
       kind: "patch_inverse",
       applied_content: "x",
     };
-    await expect(sub.revert(inverse)).rejects.toThrow(/not the managed modes config/);
+    await expect(sub.revert(inverse)).rejects.toThrow(/not a managed config/);
   });
 
   it("apply still works for the managed config", async () => {

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { ModelRoutingSubject } from "../../../subjects/model-routing-subject.js";
 import type { StructuredEvidence, LocalSignal } from "../../../wisecron/evidence-driven.js";
+import type { ModelBenchmark } from "../../../subjects/model-routing-benchmarks.js";
 
 function makeCostDb(path: string, rows: Array<[string, number]>): void {
   const db = new Database(path);
@@ -110,5 +111,69 @@ describe("ModelRoutingSubject — EvidenceDrivenSubject (proactive)", () => {
       [daysAgo(0), 1],
     ]);
     expect(await subj().confirm({ ...degraded, value: 999 })).toBe(true);
+  });
+});
+
+function bm(id: string, iq: number, pin: number, pout: number): ModelBenchmark {
+  return {
+    model_id: id,
+    name: id,
+    intelligence_index: iq,
+    coding_index: null,
+    agentic_index: null,
+    price_in_usd_per_mtok: pin,
+    price_out_usd_per_mtok: pout,
+    price_cache_hit_usd_per_mtok: null,
+    source: "t",
+    fetched_at: "t",
+  };
+}
+
+describe("ModelRoutingSubject — proposeEvidencePatch (benchmark reroute, #292)", () => {
+  let dir: string, cfgPath: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mr-patch-"));
+    cfgPath = join(dir, "agentic.yaml");
+    writeFileSync(
+      cfgPath,
+      ["modes:", "  fast:", "    model: claude-opus", "  slow:", "    model: claude-haiku"].join(
+        "\n",
+      ),
+      "utf8",
+    );
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const withBench = (rows: ModelBenchmark[]) =>
+    new ModelRoutingSubject({
+      modesConfigPath: cfgPath,
+      benchmarkProvider: async () => rows,
+      rerouteGate: { qualityTolerance: 6 },
+    });
+
+  it("proposes a quality-gated reroute patch for the degraded routing", async () => {
+    const s = withBench([
+      bm("claude-opus", 70, 15, 75),
+      bm("claude-sonnet", 66, 3, 15),
+      bm("claude-haiku", 55, 0.8, 4),
+    ]);
+    const patch = await s.proposeEvidencePatch(ev(), degraded);
+    expect(patch).not.toBeNull();
+    expect(patch!.target_path).toBe(cfgPath);
+    // fast (opus) → sonnet (best quality-safe cheaper); slow (haiku) has no safe swap.
+    const fast = patch!.alternatives.find((a) => a.id === "reroute-fast-to-claude-sonnet");
+    expect(fast).toBeDefined();
+    expect(fast!.diff_or_content).toContain("model: claude-sonnet");
+    expect(fast!.diff_or_content).toContain("model: claude-haiku"); // slow untouched
+  });
+
+  it("returns null when the cost signal is not degraded", async () => {
+    const s = withBench([bm("claude-opus", 70, 15, 75), bm("claude-sonnet", 66, 3, 15)]);
+    expect(await s.proposeEvidencePatch(ev(), { ...degraded, degraded: false })).toBeNull();
+  });
+
+  it("returns null when no benchmark data is available (no key / offline)", async () => {
+    const s = withBench([]);
+    expect(await s.proposeEvidencePatch(ev(), degraded)).toBeNull();
   });
 });

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
@@ -13,6 +13,15 @@ function makeCostDb(path: string, rows: Array<[string, number]>): void {
     db.run("INSERT INTO session_costs (date, cost_usd) VALUES (?1, ?2)", [date, c]);
   db.close();
 }
+
+// Seed dates RELATIVE to today: readDailyCost filters `date >= date('now','-30
+// days')`, so hard-coded fixtures would drift out of the window over time and
+// make these tests flaky (Copilot review on #292).
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
 const ev = (o: Partial<StructuredEvidence> = {}): StructuredEvidence => ({
   technique: "cost-aware-routing",
   independentSources: 5,
@@ -48,14 +57,14 @@ describe("ModelRoutingSubject — EvidenceDrivenSubject (proactive)", () => {
 
   it("localSignal: RISING cost trend → degraded", async () => {
     makeCostDb(dbPath, [
-      ["2026-06-20", 1],
-      ["2026-06-21", 1],
-      ["2026-06-22", 1],
-      ["2026-06-23", 1],
-      ["2026-06-27", 5],
-      ["2026-06-28", 6],
-      ["2026-06-29", 7],
-      ["2026-06-30", 8],
+      [daysAgo(7), 1],
+      [daysAgo(6), 1],
+      [daysAgo(5), 1],
+      [daysAgo(4), 1],
+      [daysAgo(3), 5],
+      [daysAgo(2), 6],
+      [daysAgo(1), 7],
+      [daysAgo(0), 8],
     ]);
     const sig = await subj().localSignal();
     expect(sig.metric).toBe("session_cost_usd");
@@ -65,12 +74,12 @@ describe("ModelRoutingSubject — EvidenceDrivenSubject (proactive)", () => {
 
   it("localSignal: FLAT cost → not degraded", async () => {
     makeCostDb(dbPath, [
-      ["2026-06-20", 2],
-      ["2026-06-21", 2],
-      ["2026-06-22", 2],
-      ["2026-06-23", 2],
-      ["2026-06-27", 2],
-      ["2026-06-28", 2],
+      [daysAgo(5), 2],
+      [daysAgo(4), 2],
+      [daysAgo(3), 2],
+      [daysAgo(2), 2],
+      [daysAgo(1), 2],
+      [daysAgo(0), 2],
     ]);
     expect((await subj().localSignal()).degraded).toBe(false);
   });
@@ -97,8 +106,8 @@ describe("ModelRoutingSubject — EvidenceDrivenSubject (proactive)", () => {
   });
   it("confirm: cost improved (after < before) → true", async () => {
     makeCostDb(dbPath, [
-      ["2026-06-29", 1],
-      ["2026-06-30", 1],
+      [daysAgo(1), 1],
+      [daysAgo(0), 1],
     ]);
     expect(await subj().confirm({ ...degraded, value: 999 })).toBe(true);
   });

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { ModelRoutingSubject } from "../../../subjects/model-routing-subject.js";
+import type { StructuredEvidence, LocalSignal } from "../../../wisecron/evidence-driven.js";
+
+function makeCostDb(path: string, rows: Array<[string, number]>): void {
+  const db = new Database(path);
+  db.run("CREATE TABLE session_costs (date TEXT, job TEXT, model TEXT, cost_usd REAL)");
+  for (const [date, c] of rows)
+    db.run("INSERT INTO session_costs (date, cost_usd) VALUES (?1, ?2)", [date, c]);
+  db.close();
+}
+const ev = (o: Partial<StructuredEvidence> = {}): StructuredEvidence => ({
+  technique: "cost-aware-routing",
+  independentSources: 5,
+  highTrustSources: 2,
+  provenInProduction: false,
+  citations: ["a", "b"],
+  ...o,
+});
+const degraded: LocalSignal = {
+  metric: "session_cost_usd",
+  value: 8,
+  unit: "usd",
+  degraded: true,
+  trend: "degrading",
+  sampledAt: "2026-06-30T00:00:00Z",
+};
+
+describe("ModelRoutingSubject — EvidenceDrivenSubject (proactive)", () => {
+  let dir: string, dbPath: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mr-"));
+    dbPath = join(dir, "costs.db");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  const subj = () => new ModelRoutingSubject({ costDbPath: dbPath });
+
+  it("researchSpec declares the routing topic + technique + tiers", () => {
+    const spec = subj().researchSpec();
+    expect(spec.subject).toBe("model_routing");
+    expect(spec.technique).toBe("cost-aware-routing");
+    expect(spec.sourceTiers).toContain("enterprise");
+  });
+
+  it("localSignal: RISING cost trend → degraded", async () => {
+    makeCostDb(dbPath, [
+      ["2026-06-20", 1],
+      ["2026-06-21", 1],
+      ["2026-06-22", 1],
+      ["2026-06-23", 1],
+      ["2026-06-27", 5],
+      ["2026-06-28", 6],
+      ["2026-06-29", 7],
+      ["2026-06-30", 8],
+    ]);
+    const sig = await subj().localSignal();
+    expect(sig.metric).toBe("session_cost_usd");
+    expect(sig.degraded).toBe(true);
+    expect(sig.trend).toBe("degrading");
+  });
+
+  it("localSignal: FLAT cost → not degraded", async () => {
+    makeCostDb(dbPath, [
+      ["2026-06-20", 2],
+      ["2026-06-21", 2],
+      ["2026-06-22", 2],
+      ["2026-06-23", 2],
+      ["2026-06-27", 2],
+      ["2026-06-28", 2],
+    ]);
+    expect((await subj().localSignal()).degraded).toBe(false);
+  });
+
+  it("localSignal: missing DB → graceful (not degraded)", async () => {
+    expect(
+      (await new ModelRoutingSubject({ costDbPath: join(dir, "nope.db") }).localSignal()).degraded,
+    ).toBe(false);
+  });
+
+  it("evaluate: degraded + convergent → recommendation", () => {
+    const v = subj().evaluate(ev(), degraded);
+    expect(v.propose).toBe(true);
+    expect(v.kind).toBe("recommendation");
+    expect(v.confidence).toBeGreaterThan(0);
+  });
+  it("evaluate: healthy signal → no proposal", () => {
+    expect(subj().evaluate(ev(), { ...degraded, degraded: false }).propose).toBe(false);
+  });
+  it("evaluate: weak evidence → no proposal", () => {
+    expect(
+      subj().evaluate(ev({ independentSources: 1, highTrustSources: 0 }), degraded).propose,
+    ).toBe(false);
+  });
+  it("confirm: cost improved (after < before) → true", async () => {
+    makeCostDb(dbPath, [
+      ["2026-06-29", 1],
+      ["2026-06-30", 1],
+    ]);
+    expect(await subj().confirm({ ...degraded, value: 999 })).toBe(true);
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
@@ -159,12 +159,12 @@ describe("ModelRoutingSubject — proposeEvidencePatch (benchmark reroute, #292)
     ]);
     const patch = await s.proposeEvidencePatch(ev(), degraded);
     expect(patch).not.toBeNull();
-    expect(patch!.target_path).toBe(cfgPath);
+    expect(patch?.target_path).toBe(cfgPath);
     // fast (opus) → sonnet (best quality-safe cheaper); slow (haiku) has no safe swap.
-    const fast = patch!.alternatives.find((a) => a.id === "reroute-fast-to-claude-sonnet");
+    const fast = patch?.alternatives.find((a) => a.id === "reroute-fast-to-claude-sonnet");
     expect(fast).toBeDefined();
-    expect(fast!.diff_or_content).toContain("model: claude-sonnet");
-    expect(fast!.diff_or_content).toContain("model: claude-haiku"); // slow untouched
+    expect(fast?.diff_or_content).toContain("model: claude-sonnet");
+    expect(fast?.diff_or_content).toContain("model: claude-haiku"); // slow untouched
   });
 
   it("returns null when the cost signal is not degraded", async () => {

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
@@ -197,3 +197,63 @@ describe("ModelRoutingSubject — feeder frontier: no self-fetch (#292)", () => 
     rmSync(dir, { recursive: true, force: true });
   });
 });
+
+import { toLaunchableModel } from "../../../subjects/agentic-config.js";
+
+describe("ModelRoutingSubject — settingsPath write-back is LAUNCHABLE (Terry #292)", () => {
+  it("writes a launchable tier (opus/sonnet/haiku), never an Artificial-Analysis slug", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mr-launch-"));
+    const settings = join(dir, "settings.json");
+    writeFileSync(
+      settings,
+      JSON.stringify(
+        { agentic: { enabled: true, modes: [{ name: "impl", model: "claude-3-5-sonnet" }] } },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    // Realistic AA slugs as model_id — exactly what tripped the original bug.
+    const rows = [
+      bm2("claude-35-sonnet", 9.9, 3, 15), // current (claude-3-5-sonnet → this slug)
+      bm2("claude-opus-4-7-non-reasoning", 82, 2, 10), // AA catalog slug, better+cheaper
+    ];
+    const s = new ModelRoutingSubject({
+      settingsPath: settings,
+      benchmarkProvider: async () => rows,
+      rerouteGate: { qualityMetric: "intelligence" },
+    });
+    const deg = {
+      metric: "c",
+      value: 8,
+      unit: "usd",
+      degraded: true,
+      trend: "degrading" as const,
+      sampledAt: "t",
+    };
+    const patch = await s.proposeEvidencePatch(ev(), deg);
+    expect(patch).not.toBeNull();
+    const written = patch?.alternatives[0]?.diff_or_content;
+    const model = JSON.parse(written).agentic.modes[0].model;
+    // The written value MUST be a launchable tier, NOT the AA slug.
+    expect(model).toBe("opus");
+    expect(model).not.toContain("non-reasoning");
+    expect(toLaunchableModel(model)).not.toBeNull();
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+function bm2(id: string, iq: number, pin: number, pout: number) {
+  return {
+    model_id: id,
+    name: id,
+    intelligence_index: iq,
+    coding_index: null,
+    agentic_index: null,
+    price_in_usd_per_mtok: pin,
+    price_out_usd_per_mtok: pout,
+    price_cache_hit_usd_per_mtok: null,
+    source: "t",
+    fetched_at: "t",
+  };
+}

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-evidence.test.ts
@@ -177,3 +177,23 @@ describe("ModelRoutingSubject — proposeEvidencePatch (benchmark reroute, #292)
     expect(await s.proposeEvidencePatch(ev(), degraded)).toBeNull();
   });
 });
+
+describe("ModelRoutingSubject — feeder frontier: no self-fetch (#292)", () => {
+  it("with NO injected benchmarkProvider, proposeEvidencePatch returns null (never fetches)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mr-nofetch-"));
+    const cfg = join(dir, "agentic.yaml");
+    writeFileSync(cfg, ["modes:", "  fast:", "    model: claude-opus"].join("\n"), "utf8");
+    // default provider must NOT hit the network; it yields no data → null.
+    const s = new ModelRoutingSubject({ modesConfigPath: cfg });
+    const deg = {
+      metric: "session_cost_usd",
+      value: 8,
+      unit: "usd",
+      degraded: true,
+      trend: "degrading" as const,
+      sampledAt: "t",
+    };
+    expect(await s.proposeEvidencePatch(ev(), deg)).toBeNull();
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-hardening.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-hardening.test.ts
@@ -353,3 +353,42 @@ describe("HARD gate corrections found by the Greg test (#292)", () => {
     expect(evaluateReroute(cur, neg).code).toBe("insufficient_data");
   });
 });
+
+import { enrichWithAnthropicCoding } from "../../../subjects/anthropic-benchmarks.js";
+
+describe("HARD metric fallback (A) + Anthropic enrichment (B) — the opus-null fix", () => {
+  it("A: falls back to the intelligence composite when coding is null for a model", () => {
+    // opus has intelligence but NO coding (AA gap); candidate has both.
+    const opus = bm({ intelligence_index: 42.7, coding_index: null });
+    const cand = bm({
+      intelligence_index: 53.4,
+      coding_index: 71.5,
+      price_in_usd_per_mtok: 1,
+      price_out_usd_per_mtok: 5,
+    });
+    // coding requested, but opus lacks it → fallback to intelligence for BOTH → 42.7 vs 53.4 = win
+    const v = evaluateReroute(opus, cand, { qualityMetric: "coding" });
+    expect(v.propose).toBe(true);
+    expect(v.quality_delta).toBeCloseTo(53.4 - 42.7, 5); // compared on intelligence, not coding
+  });
+
+  it("A: metricFallback:false keeps the strict coding gate (opus → insufficient_data)", () => {
+    const opus = bm({ intelligence_index: 42.7, coding_index: null });
+    const cand = bm({ intelligence_index: 53.4, coding_index: 71.5 });
+    expect(
+      evaluateReroute(opus, cand, { qualityMetric: "coding", metricFallback: false }).code,
+    ).toBe("insufficient_data");
+  });
+
+  it("B: enrichment fills a null Claude coding_index from the Anthropic table, never overwrites AA", () => {
+    const rows = [
+      bm({ model_id: "claude-opus-4-7-non-reasoning", coding_index: null }),
+      bm({ model_id: "claude-sonnet-5", coding_index: 71.5 }), // AA already has it
+      bm({ model_id: "some-other-model", coding_index: null }), // not in table → stays null
+    ];
+    const out = enrichWithAnthropicCoding(rows);
+    expect(out[0]!.coding_index).toBe(82.0); // filled from Anthropic
+    expect(out[1]!.coding_index).toBe(71.5); // AA value untouched
+    expect(out[2]!.coding_index).toBeNull(); // unknown → left null (fallback A covers it)
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-hardening.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-hardening.test.ts
@@ -68,7 +68,7 @@ describe("HARD parseArtificialAnalysis — hostile / messy input", () => {
     }));
     const rows = parseArtificialAnalysis({ data }, "t");
     expect(rows.length).toBe(1000);
-    expect(rows[0]!.price_in_usd_per_mtok).toBe(-1); // negative is a real (if odd) number
+    expect(rows[0]?.price_in_usd_per_mtok).toBe(-1); // negative is a real (if odd) number
   });
 });
 
@@ -162,7 +162,7 @@ describe("HARD parseModelAssignments — messy configs", () => {
     const cfg = ["modes:", "  fast:", "    model: sonnet"].join("\r\n");
     const asg = parseModelAssignments(cfg);
     expect(asg.length).toBe(1);
-    expect(asg[0]!.model).toBe("sonnet");
+    expect(asg[0]?.model).toBe("sonnet");
   });
 });
 
@@ -238,7 +238,7 @@ describe("HARD proposeBenchmarkReroute — scale + ties + all-vetoed", () => {
     });
     const props = proposeBenchmarkReroute([{ key: "k", model: "cur" }], [cur, ...cands]);
     expect(props.length).toBe(1);
-    expect(props[0]!.to_model).toBe("c199"); // cheapest quality-safe
+    expect(props[0]?.to_model).toBe("c199"); // cheapest quality-safe
   });
 
   it("returns [] when every candidate regresses quality (strict veto holds at scale)", () => {
@@ -306,7 +306,7 @@ describe("HARD gate corrections found by the Greg test (#292)", () => {
       { qualityMetric: "coding" },
     );
     expect(props.length).toBe(1);
-    expect(props[0]!.to_model).toBe("sonnet-5"); // NOT command-a-plus
+    expect(props[0]?.to_model).toBe("sonnet-5"); // NOT command-a-plus
   });
 
   it("a $0/$0 (missing-pricing) candidate never yields a bogus cost win", () => {
@@ -387,8 +387,8 @@ describe("HARD metric fallback (A) + Anthropic enrichment (B) — the opus-null 
       bm({ model_id: "some-other-model", coding_index: null }), // not in table → stays null
     ];
     const out = enrichWithAnthropicCoding(rows);
-    expect(out[0]!.coding_index).toBe(82.0); // filled from Anthropic
-    expect(out[1]!.coding_index).toBe(71.5); // AA value untouched
-    expect(out[2]!.coding_index).toBeNull(); // unknown → left null (fallback A covers it)
+    expect(out[0]?.coding_index).toBe(82.0); // filled from Anthropic
+    expect(out[1]?.coding_index).toBe(71.5); // AA value untouched
+    expect(out[2]?.coding_index).toBeNull(); // unknown → left null (fallback A covers it)
   });
 });

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-hardening.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-hardening.test.ts
@@ -254,3 +254,102 @@ describe("HARD proposeBenchmarkReroute — scale + ties + all-vetoed", () => {
     expect(proposeBenchmarkReroute([{ key: "k", model: "top" }], [cur, ...cands])).toEqual([]);
   });
 });
+
+describe("HARD gate corrections found by the Greg test (#292)", () => {
+  it("qualityMetric='coding' can REJECT what 'intelligence' would accept (the Greg trap)", () => {
+    // command-a-plus: higher general IQ, LOWER coding, than the current model.
+    const cur = bm({
+      intelligence_index: 9.9,
+      coding_index: 30.2,
+      price_in_usd_per_mtok: 3,
+      price_out_usd_per_mtok: 15,
+    });
+    const cand = bm({
+      intelligence_index: 22.5,
+      coding_index: 27.8,
+      price_in_usd_per_mtok: 1,
+      price_out_usd_per_mtok: 5,
+    });
+    // general index → looks like a win
+    expect(evaluateReroute(cur, cand, { qualityMetric: "intelligence" }).propose).toBe(true);
+    // coding index → correctly VETOED (candidate is worse at code)
+    const coded = evaluateReroute(cur, cand, { qualityMetric: "coding" });
+    expect(coded.propose).toBe(false);
+    expect(coded.code).toBe("quality_regression");
+  });
+
+  it("gates on coding and prefers the real coding leader (sonnet-5 over command-a-plus)", () => {
+    const cur = bm({
+      model_id: "old-sonnet",
+      intelligence_index: 9.9,
+      coding_index: 30.2,
+      price_in_usd_per_mtok: 3,
+      price_out_usd_per_mtok: 15,
+    });
+    const commandA = bm({
+      model_id: "command-a-plus",
+      intelligence_index: 22.5,
+      coding_index: 27.8,
+      price_in_usd_per_mtok: 0,
+      price_out_usd_per_mtok: 0,
+    });
+    const sonnet5 = bm({
+      model_id: "sonnet-5",
+      intelligence_index: 53.4,
+      coding_index: 71.5,
+      price_in_usd_per_mtok: 2,
+      price_out_usd_per_mtok: 10,
+    });
+    const props = proposeBenchmarkReroute(
+      [{ key: "greg", model: "old-sonnet" }],
+      [cur, commandA, sonnet5],
+      { qualityMetric: "coding" },
+    );
+    expect(props.length).toBe(1);
+    expect(props[0]!.to_model).toBe("sonnet-5"); // NOT command-a-plus
+  });
+
+  it("a $0/$0 (missing-pricing) candidate never yields a bogus cost win", () => {
+    const cur = bm({
+      intelligence_index: 50,
+      price_in_usd_per_mtok: 3,
+      price_out_usd_per_mtok: 15,
+    });
+    const freebie = bm({
+      intelligence_index: 55,
+      price_in_usd_per_mtok: 0,
+      price_out_usd_per_mtok: 0,
+    });
+    const v = evaluateReroute(cur, freebie); // quality safe, but pricing is 0/0
+    expect(v.propose).toBe(false);
+    expect(v.code).toBe("insufficient_data");
+  });
+
+  it("quality veto still fires on a $0 candidate that is WORSE (veto before pricing)", () => {
+    const cur = bm({
+      intelligence_index: 60,
+      price_in_usd_per_mtok: 3,
+      price_out_usd_per_mtok: 15,
+    });
+    const worse = bm({
+      intelligence_index: 40,
+      price_in_usd_per_mtok: 0,
+      price_out_usd_per_mtok: 0,
+    });
+    expect(evaluateReroute(cur, worse).code).toBe("quality_regression");
+  });
+
+  it("negative prices are treated as missing (not a giant saving)", () => {
+    const cur = bm({
+      intelligence_index: 50,
+      price_in_usd_per_mtok: 3,
+      price_out_usd_per_mtok: 15,
+    });
+    const neg = bm({
+      intelligence_index: 55,
+      price_in_usd_per_mtok: -1,
+      price_out_usd_per_mtok: -1,
+    });
+    expect(evaluateReroute(cur, neg).code).toBe("insufficient_data");
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-hardening.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-hardening.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from "bun:test";
+import {
+  parseArtificialAnalysis,
+  type ModelBenchmark,
+} from "../../../subjects/model-routing-benchmarks.js";
+import {
+  evaluateReroute,
+  proposeBenchmarkReroute,
+  parseModelAssignments,
+  setModelInYaml,
+} from "../../../subjects/model-routing-quality.js";
+
+const bm = (p: Partial<ModelBenchmark>): ModelBenchmark => ({
+  model_id: "x",
+  name: "X",
+  intelligence_index: 60,
+  coding_index: null,
+  agentic_index: null,
+  price_in_usd_per_mtok: 3,
+  price_out_usd_per_mtok: 15,
+  price_cache_hit_usd_per_mtok: null,
+  source: "t",
+  fetched_at: "t",
+  ...p,
+});
+
+// ─────────────────────────── parser: adversarial ───────────────────────────
+describe("HARD parseArtificialAnalysis — hostile / messy input", () => {
+  it("survives prototype-pollution keys in the payload", () => {
+    const raw = JSON.parse(
+      '{"data":[{"slug":"m","__proto__":{"polluted":true},"evaluations":{"artificial_analysis_intelligence_index":5}}]}',
+    );
+    const rows = parseArtificialAnalysis(raw, "t");
+    expect(rows.length).toBe(1);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined(); // no global pollution
+  });
+
+  it("coerces wrong-typed scores/prices to null (string, bool, NaN, Infinity, object)", () => {
+    const raw = {
+      data: [
+        {
+          slug: "weird",
+          evaluations: { artificial_analysis_intelligence_index: "12.3" }, // string → null
+          pricing: {
+            price_1m_input_tokens: true, // bool → null
+            price_1m_output_tokens: Number.POSITIVE_INFINITY, // → null
+          },
+        },
+      ],
+    };
+    const r = parseArtificialAnalysis(raw, "t")[0]!;
+    expect(r.intelligence_index).toBeNull();
+    expect(r.price_in_usd_per_mtok).toBeNull();
+    expect(r.price_out_usd_per_mtok).toBeNull();
+  });
+
+  it("skips null / non-object / slug-less rows without throwing", () => {
+    const raw = { data: [null, 42, "str", {}, { id: 7 }, { slug: "ok" }] };
+    const rows = parseArtificialAnalysis(raw, "t");
+    expect(rows.map((r) => r.model_id)).toEqual(["ok"]);
+  });
+
+  it("handles a large payload (1000 rows) and negative prices pass through as numbers", () => {
+    const data = Array.from({ length: 1000 }, (_, i) => ({
+      slug: `m${i}`,
+      evaluations: { artificial_analysis_intelligence_index: i % 100 },
+      pricing: { price_1m_input_tokens: -1, price_1m_output_tokens: 0 },
+    }));
+    const rows = parseArtificialAnalysis({ data }, "t");
+    expect(rows.length).toBe(1000);
+    expect(rows[0]!.price_in_usd_per_mtok).toBe(-1); // negative is a real (if odd) number
+  });
+});
+
+// ─────────────────────── YAML editors: the #306 class ───────────────────────
+const MULTI = [
+  "modes:",
+  "  fast:",
+  "    model: claude-sonnet",
+  "    keywords:",
+  "      - quick",
+  "  slow:",
+  "    model: claude-opus",
+  "  balanced:",
+  "    model: claude-haiku",
+].join("\n");
+
+describe("HARD setModelInYaml — must never corrupt a sibling mode", () => {
+  it("changes ONLY the target mode's model line — every other byte identical", () => {
+    const out = setModelInYaml(MULTI, "slow", "gpt-5");
+    const inLines = MULTI.split("\n");
+    const outLines = out.split("\n");
+    expect(outLines.length).toBe(inLines.length);
+    const changed = inLines.map((l, i) => (l !== outLines[i] ? i : -1)).filter((i) => i >= 0);
+    expect(changed.length).toBe(1); // exactly one line changed
+    expect(outLines[changed[0]!]).toContain("gpt-5");
+    expect(out).toContain("model: claude-sonnet"); // fast untouched
+    expect(out).toContain("model: claude-haiku"); // balanced untouched
+  });
+
+  it("a comment indented at exactly modeIndent does NOT prematurely close the block (#307)", () => {
+    const cfg = [
+      "modes:",
+      "  fast:",
+      "  # a stray comment at mode indent",
+      "    model: sonnet",
+    ].join("\n");
+    const out = setModelInYaml(cfg, "fast", "haiku");
+    expect(out).toContain("model: haiku"); // still found + swapped despite the comment
+  });
+
+  it("does not mis-target a mode whose name is a prefix of another (fast vs fastest)", () => {
+    const cfg = ["modes:", "  fast:", "    model: a", "  fastest:", "    model: b"].join("\n");
+    const out = setModelInYaml(cfg, "fast", "Z");
+    expect(out).toContain("model: Z"); // fast changed
+    expect(out).toContain("model: b"); // fastest untouched
+    expect(out).not.toContain("  fastest:\n    model: Z");
+  });
+
+  it("treats a regex-metachar mode name literally", () => {
+    const cfg = ["modes:", "  fa.st:", "    model: a", "  faXst:", "    model: b"].join("\n");
+    const out = setModelInYaml(cfg, "fa.st", "Z");
+    expect(out).toContain("model: Z");
+    expect(out).toContain("model: b"); // faXst must NOT match fa.st
+  });
+
+  it("preserves quoted model values by replacing the whole value", () => {
+    const cfg = ["modes:", "  fast:", '    model: "claude-sonnet"'].join("\n");
+    const out = setModelInYaml(cfg, "fast", "haiku");
+    expect(out).toContain("model: haiku");
+    expect(out).not.toContain("claude-sonnet");
+  });
+
+  it("no-ops safely on a mode with no model line / absent mode / empty input", () => {
+    expect(setModelInYaml("modes:\n  fast:\n    keywords: [a]\n", "fast", "z")).toContain(
+      "keywords: [a]",
+    );
+    expect(setModelInYaml(MULTI, "nonexistent", "z")).toBe(MULTI);
+    expect(setModelInYaml("", "fast", "z")).toBe("");
+  });
+
+  it("round-trips: parse(set(cfg)) reflects exactly the one change", () => {
+    const out = setModelInYaml(MULTI, "balanced", "grok-4");
+    const asg = parseModelAssignments(out);
+    expect(asg).toEqual([
+      { key: "fast", model: "claude-sonnet" },
+      { key: "slow", model: "claude-opus" },
+      { key: "balanced", model: "grok-4" },
+    ]);
+  });
+});
+
+describe("HARD parseModelAssignments — messy configs", () => {
+  it("ignores a top-level model: not inside any mode", () => {
+    const cfg = ["model: orphan", "modes:", "  fast:", "    model: real"].join("\n");
+    // the orphan is at col0 with no mode header before it at deeper indent
+    const asg = parseModelAssignments(cfg);
+    expect(asg).toEqual([{ key: "fast", model: "real" }]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const cfg = ["modes:", "  fast:", "    model: sonnet"].join("\r\n");
+    const asg = parseModelAssignments(cfg);
+    expect(asg.length).toBe(1);
+    expect(asg[0]!.model).toBe("sonnet");
+  });
+});
+
+// ─────────────────────── quality gate: boundaries ───────────────────────
+describe("HARD evaluateReroute — exact boundaries + degenerate numbers", () => {
+  it("quality delta EXACTLY at -tolerance is allowed (not vetoed)", () => {
+    const cur = bm({ intelligence_index: 60 });
+    const cand = bm({
+      intelligence_index: 57,
+      price_in_usd_per_mtok: 1,
+      price_out_usd_per_mtok: 1,
+    });
+    const v = evaluateReroute(cur, cand, { qualityTolerance: 3 }); // delta = -3 == -tol
+    expect(v.code).not.toBe("quality_regression");
+    expect(v.propose).toBe(true);
+  });
+
+  it("just past tolerance (-tol - ε) IS vetoed", () => {
+    const cur = bm({ intelligence_index: 60 });
+    const cand = bm({
+      intelligence_index: 56.9,
+      price_in_usd_per_mtok: 1,
+      price_out_usd_per_mtok: 1,
+    });
+    const v = evaluateReroute(cur, cand, { qualityTolerance: 3 });
+    expect(v.code).toBe("quality_regression");
+  });
+
+  it("savings EXACTLY at the floor does not propose (strict >)", () => {
+    const cur = bm({ intelligence_index: 60, price_in_usd_per_mtok: 2, price_out_usd_per_mtok: 2 });
+    const cand = bm({
+      intelligence_index: 60,
+      price_in_usd_per_mtok: 1,
+      price_out_usd_per_mtok: 1,
+    });
+    // blended saving = 1.0 exactly
+    const v = evaluateReroute(cur, cand, { minSavingsUsdPerMtok: 1 });
+    expect(v.propose).toBe(false);
+    expect(v.code).toBe("not_cheaper");
+  });
+
+  it("identical model (same IQ, same price) → not_cheaper, never proposes", () => {
+    const m = bm({ intelligence_index: 50 });
+    expect(evaluateReroute(m, m).propose).toBe(false);
+  });
+
+  it("zero-priced candidate still gated on quality (free but worse = vetoed)", () => {
+    const cur = bm({ intelligence_index: 60 });
+    const cand = bm({
+      intelligence_index: 40,
+      price_in_usd_per_mtok: 0,
+      price_out_usd_per_mtok: 0,
+    });
+    expect(evaluateReroute(cur, cand).code).toBe("quality_regression");
+  });
+});
+
+describe("HARD proposeBenchmarkReroute — scale + ties + all-vetoed", () => {
+  it("with 200 candidates picks the max-savings quality-safe one, deterministically", () => {
+    const cands = Array.from({ length: 200 }, (_, i) =>
+      bm({
+        model_id: `c${i}`,
+        intelligence_index: 60 + (i % 5), // all >= current, quality-safe
+        price_in_usd_per_mtok: 10 - i * 0.01, // cheaper as i grows
+        price_out_usd_per_mtok: 10 - i * 0.01,
+      }),
+    );
+    const cur = bm({
+      model_id: "cur",
+      intelligence_index: 60,
+      price_in_usd_per_mtok: 10,
+      price_out_usd_per_mtok: 10,
+    });
+    const props = proposeBenchmarkReroute([{ key: "k", model: "cur" }], [cur, ...cands]);
+    expect(props.length).toBe(1);
+    expect(props[0]!.to_model).toBe("c199"); // cheapest quality-safe
+  });
+
+  it("returns [] when every candidate regresses quality (strict veto holds at scale)", () => {
+    const cur = bm({ model_id: "top", intelligence_index: 99 });
+    const cands = Array.from({ length: 50 }, (_, i) =>
+      bm({
+        model_id: `c${i}`,
+        intelligence_index: i,
+        price_in_usd_per_mtok: 0.1,
+        price_out_usd_per_mtok: 0.1,
+      }),
+    );
+    expect(proposeBenchmarkReroute([{ key: "k", model: "top" }], [cur, ...cands])).toEqual([]);
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-quality.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-quality.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "bun:test";
+import type { ModelBenchmark } from "../../../subjects/model-routing-benchmarks.js";
+import { evaluateReroute } from "../../../subjects/model-routing-quality.js";
+
+function bench(p: Partial<ModelBenchmark>): ModelBenchmark {
+  return {
+    model_id: "x",
+    name: "X",
+    intelligence_index: 60,
+    coding_index: null,
+    agentic_index: null,
+    price_in_usd_per_mtok: 3,
+    price_out_usd_per_mtok: 15,
+    price_cache_hit_usd_per_mtok: null,
+    source: "t",
+    fetched_at: "t",
+    ...p,
+  };
+}
+
+describe("model-routing-quality — evaluateReroute (quality is the veto)", () => {
+  it("proposes a strict quality win that is also cheaper", () => {
+    const cur = bench({
+      intelligence_index: 60,
+      price_in_usd_per_mtok: 3,
+      price_out_usd_per_mtok: 15,
+    });
+    const cand = bench({
+      intelligence_index: 65,
+      price_in_usd_per_mtok: 1,
+      price_out_usd_per_mtok: 5,
+    });
+    const v = evaluateReroute(cur, cand);
+    expect(v.propose).toBe(true);
+    expect(v.code).toBe("quality_win");
+    expect(v.quality_delta).toBe(5);
+    expect(v.projected_savings_usd_per_mtok).toBeGreaterThan(0);
+  });
+
+  it("VETOES a cheaper candidate that regresses quality", () => {
+    const cur = bench({ intelligence_index: 60 });
+    const cand = bench({
+      intelligence_index: 50,
+      price_in_usd_per_mtok: 0.5,
+      price_out_usd_per_mtok: 2,
+    });
+    const v = evaluateReroute(cur, cand);
+    expect(v.propose).toBe(false);
+    expect(v.code).toBe("quality_regression");
+    // savings are real but irrelevant — quality wins
+    expect(v.projected_savings_usd_per_mtok).toBeGreaterThan(0);
+  });
+
+  it("does NOT propose when quality holds but there is no cost win", () => {
+    const cur = bench({
+      intelligence_index: 60,
+      price_in_usd_per_mtok: 3,
+      price_out_usd_per_mtok: 15,
+    });
+    const cand = bench({
+      intelligence_index: 62,
+      price_in_usd_per_mtok: 4,
+      price_out_usd_per_mtok: 20,
+    });
+    const v = evaluateReroute(cur, cand);
+    expect(v.propose).toBe(false);
+    expect(v.code).toBe("not_cheaper");
+  });
+
+  it("allows a within-tolerance quality dip when it buys a cost win", () => {
+    const cur = bench({
+      intelligence_index: 60,
+      price_in_usd_per_mtok: 3,
+      price_out_usd_per_mtok: 15,
+    });
+    const cand = bench({
+      intelligence_index: 58,
+      price_in_usd_per_mtok: 1,
+      price_out_usd_per_mtok: 5,
+    });
+    const v = evaluateReroute(cur, cand, { qualityTolerance: 3 });
+    expect(v.propose).toBe(true);
+    expect(v.code).toBe("cost_win_quality_held");
+    expect(v.quality_delta).toBe(-2);
+  });
+
+  it("with zero tolerance (default), even a tiny quality dip is vetoed", () => {
+    const cur = bench({ intelligence_index: 60 });
+    const cand = bench({
+      intelligence_index: 59.5,
+      price_in_usd_per_mtok: 0.1,
+      price_out_usd_per_mtok: 0.5,
+    });
+    const v = evaluateReroute(cur, cand);
+    expect(v.propose).toBe(false);
+    expect(v.code).toBe("quality_regression");
+  });
+
+  it("respects the minimum-savings floor", () => {
+    const cur = bench({
+      intelligence_index: 60,
+      price_in_usd_per_mtok: 3,
+      price_out_usd_per_mtok: 15,
+    });
+    const cand = bench({
+      intelligence_index: 61,
+      price_in_usd_per_mtok: 2.99,
+      price_out_usd_per_mtok: 14.9,
+    });
+    const v = evaluateReroute(cur, cand, { minSavingsUsdPerMtok: 1 });
+    expect(v.propose).toBe(false);
+    expect(v.code).toBe("not_cheaper");
+  });
+
+  it("cannot gate without both indices or pricing → insufficient_data", () => {
+    const cur = bench({ intelligence_index: null });
+    const cand = bench({ intelligence_index: 65 });
+    expect(evaluateReroute(cur, cand).code).toBe("insufficient_data");
+
+    const cur2 = bench({ price_in_usd_per_mtok: null });
+    const cand2 = bench({ intelligence_index: 65 });
+    const v2 = evaluateReroute(cur2, cand2);
+    expect(v2.propose).toBe(false);
+    expect(v2.code).toBe("insufficient_data");
+  });
+
+  it("computes blended savings with the input/output ratio", () => {
+    // ratio 3 → blended = (3*in + out)/4
+    const cur = bench({
+      intelligence_index: 60,
+      price_in_usd_per_mtok: 4,
+      price_out_usd_per_mtok: 4,
+    }); // blended 4
+    const cand = bench({
+      intelligence_index: 60,
+      price_in_usd_per_mtok: 2,
+      price_out_usd_per_mtok: 2,
+    }); // blended 2
+    const v = evaluateReroute(cur, cand, { inputOutputRatio: 3 });
+    expect(v.projected_savings_usd_per_mtok).toBe(2);
+    expect(v.propose).toBe(true);
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-quality.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-quality.test.ts
@@ -141,3 +141,73 @@ describe("model-routing-quality — evaluateReroute (quality is the veto)", () =
     expect(v.propose).toBe(true);
   });
 });
+
+import { proposeBenchmarkReroute } from "../../../subjects/model-routing-quality.js";
+
+describe("model-routing-quality — proposeBenchmarkReroute (Tier-A pipeline)", () => {
+  const benches: ModelBenchmark[] = [
+    bench({
+      model_id: "opus",
+      intelligence_index: 70,
+      price_in_usd_per_mtok: 15,
+      price_out_usd_per_mtok: 75,
+    }),
+    bench({
+      model_id: "sonnet",
+      intelligence_index: 65,
+      price_in_usd_per_mtok: 3,
+      price_out_usd_per_mtok: 15,
+    }),
+    bench({
+      model_id: "haiku",
+      intelligence_index: 55,
+      price_in_usd_per_mtok: 0.8,
+      price_out_usd_per_mtok: 4,
+    }),
+  ];
+
+  it("proposes the best quality-gated reroute per assignment", () => {
+    // 'fast' is on opus (overkill+pricey). sonnet keeps most quality much cheaper;
+    // haiku is cheaper still but regresses quality more. With tolerance 6, sonnet
+    // (Δ-5) passes and haiku (Δ-15) is vetoed → sonnet wins.
+    const props = proposeBenchmarkReroute([{ key: "fast", model: "opus" }], benches, {
+      qualityTolerance: 6,
+    });
+    expect(props.length).toBe(1);
+    expect(props[0]!.to_model).toBe("sonnet");
+    expect(props[0]!.verdict.propose).toBe(true);
+  });
+
+  it("skips an assignment whose current model has no benchmark", () => {
+    const props = proposeBenchmarkReroute([{ key: "x", model: "unknown-model" }], benches);
+    expect(props).toEqual([]);
+  });
+
+  it("proposes nothing when the current model is already the quality leader and nothing is a safe cheaper swap", () => {
+    // opus is top quality; with strict tolerance 0 every cheaper model regresses.
+    const props = proposeBenchmarkReroute([{ key: "hard", model: "opus" }], benches, {
+      qualityTolerance: 0,
+    });
+    expect(props).toEqual([]);
+  });
+
+  it("upgrades toward higher quality when it is also not more expensive", () => {
+    // 'cheap' sits on haiku; a same-or-lower-price higher-quality model would win,
+    // but here everything better is pricier → no proposal (quality can't be bought
+    // with a cost regression). Confirms cost-safety on the upgrade direction.
+    const props = proposeBenchmarkReroute([{ key: "cheap", model: "haiku" }], benches);
+    expect(props).toEqual([]);
+  });
+
+  it("handles several assignments independently", () => {
+    const props = proposeBenchmarkReroute(
+      [
+        { key: "fast", model: "opus" },
+        { key: "cheap", model: "haiku" },
+      ],
+      benches,
+      { qualityTolerance: 6 },
+    );
+    expect(props.map((p) => p.key).sort()).toEqual(["fast"]); // only 'fast' has a safe cheaper swap
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-quality.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-quality.test.ts
@@ -211,3 +211,73 @@ describe("model-routing-quality — proposeBenchmarkReroute (Tier-A pipeline)", 
     expect(props.map((p) => p.key).sort()).toEqual(["fast"]); // only 'fast' has a safe cheaper swap
   });
 });
+
+import {
+  parseModelAssignments,
+  setModelInYaml,
+  buildRerouteEvidencePatch,
+} from "../../../subjects/model-routing-quality.js";
+
+const CFG = [
+  "modes:",
+  "  fast:",
+  "    model: claude-sonnet",
+  "    keywords:",
+  "      - quick",
+  "  slow:",
+  "    model: claude-opus",
+].join("\n");
+
+describe("model-routing-quality — config helpers", () => {
+  it("parses mode → model assignments from the modes block", () => {
+    expect(parseModelAssignments(CFG)).toEqual([
+      { key: "fast", model: "claude-sonnet" },
+      { key: "slow", model: "claude-opus" },
+    ]);
+  });
+
+  it("setModelInYaml swaps only the target mode, leaving siblings intact (#306-safe)", () => {
+    const out = setModelInYaml(CFG, "fast", "claude-haiku");
+    expect(out).toContain("model: claude-haiku"); // fast changed
+    expect(out).toContain("model: claude-opus"); // slow untouched
+    expect(out).toContain("- quick"); // keywords preserved
+    expect(parseModelAssignments(out)).toEqual([
+      { key: "fast", model: "claude-haiku" },
+      { key: "slow", model: "claude-opus" },
+    ]);
+  });
+
+  it("buildRerouteEvidencePatch turns proposals into one alternative per mode", () => {
+    const proposals = proposeBenchmarkReroute(
+      [{ key: "fast", model: "opus" }],
+      [
+        bench({
+          model_id: "opus",
+          intelligence_index: 70,
+          price_in_usd_per_mtok: 15,
+          price_out_usd_per_mtok: 75,
+        }),
+        bench({
+          model_id: "sonnet",
+          intelligence_index: 66,
+          price_in_usd_per_mtok: 3,
+          price_out_usd_per_mtok: 15,
+        }),
+      ],
+      { qualityTolerance: 6 },
+    );
+    const patch = buildRerouteEvidencePatch(
+      "modes:\n  fast:\n    model: opus\n",
+      proposals,
+      "/tmp/agentic.yaml",
+    );
+    expect(patch).not.toBeNull();
+    expect(patch!.target_path).toBe("/tmp/agentic.yaml");
+    expect(patch!.alternatives[0]!.id).toBe("reroute-fast-to-sonnet");
+    expect(patch!.alternatives[0]!.diff_or_content).toContain("model: sonnet");
+  });
+
+  it("buildRerouteEvidencePatch returns null with no proposals", () => {
+    expect(buildRerouteEvidencePatch(CFG, [], "/x")).toBeNull();
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-quality.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-quality.test.ts
@@ -174,8 +174,8 @@ describe("model-routing-quality — proposeBenchmarkReroute (Tier-A pipeline)", 
       qualityTolerance: 6,
     });
     expect(props.length).toBe(1);
-    expect(props[0]!.to_model).toBe("sonnet");
-    expect(props[0]!.verdict.propose).toBe(true);
+    expect(props[0]?.to_model).toBe("sonnet");
+    expect(props[0]?.verdict.propose).toBe(true);
   });
 
   it("skips an assignment whose current model has no benchmark", () => {
@@ -272,9 +272,9 @@ describe("model-routing-quality — config helpers", () => {
       "/tmp/agentic.yaml",
     );
     expect(patch).not.toBeNull();
-    expect(patch!.target_path).toBe("/tmp/agentic.yaml");
-    expect(patch!.alternatives[0]!.id).toBe("reroute-fast-to-sonnet");
-    expect(patch!.alternatives[0]!.diff_or_content).toContain("model: sonnet");
+    expect(patch?.target_path).toBe("/tmp/agentic.yaml");
+    expect(patch?.alternatives[0]?.id).toBe("reroute-fast-to-sonnet");
+    expect(patch?.alternatives[0]?.diff_or_content).toContain("model: sonnet");
   });
 
   it("buildRerouteEvidencePatch returns null with no proposals", () => {

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-signal.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-signal.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression tests for model-routing-signal.ts (ultra-review #292 remediation):
+ *  - a corrupt / non-SQLite / unreadable cost DB is graceful ([]/not-degraded),
+ *    never a throw that stalls the proactive loop (constructor now inside try)
+ *  - the absolute `recent > cap` degradation path honours the same >=4-day
+ *    sample discipline as the trend path (no single-outlier flip)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { readDailyCost, costSignal } from "../../../subjects/model-routing-signal.js";
+
+function makeCostDb(path: string, rows: Array<[string, number]>): void {
+  const db = new Database(path);
+  db.run("CREATE TABLE session_costs (date TEXT, cost_usd REAL)");
+  for (const [date, c] of rows)
+    db.run("INSERT INTO session_costs (date, cost_usd) VALUES (?1, ?2)", [date, c]);
+  db.close();
+}
+
+describe("model-routing-signal — graceful on a bad cost DB (no loop stall)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mr-signal-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("a corrupt / non-SQLite existing file returns [] instead of throwing", () => {
+    const bad = join(dir, "costs.db");
+    writeFileSync(bad, "this is definitely not a sqlite database\n".repeat(10));
+    // Constructor throws on this file; the fix keeps it inside the try.
+    expect(() => readDailyCost(bad)).not.toThrow();
+    expect(readDailyCost(bad)).toEqual([]);
+    expect(() => costSignal(bad, 25)).not.toThrow();
+    expect(costSignal(bad, 25).degraded).toBe(false);
+  });
+
+  it("a missing DB is still graceful", () => {
+    expect(readDailyCost(join(dir, "nope.db"))).toEqual([]);
+  });
+});
+
+describe("model-routing-signal — absolute-cost path needs >=4 days", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mr-signal-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("a single outlier day over the cap does NOT set degraded", () => {
+    const db = join(dir, "costs.db");
+    makeCostDb(db, [["2026-06-30", 30]]); // one day, $30, cap 25
+    const sig = costSignal(db, 25);
+    expect(sig.days).toBe(1);
+    expect(sig.degraded).toBe(false); // pre-fix this was true
+  });
+
+  it("recent-over-cap DOES degrade once >=4 days are present", () => {
+    const db = join(dir, "costs.db");
+    makeCostDb(db, [
+      ["2026-06-27", 2],
+      ["2026-06-28", 2],
+      ["2026-06-29", 2],
+      ["2026-06-30", 30], // recent day well over cap, with enough history
+    ]);
+    const sig = costSignal(db, 25);
+    expect(sig.days).toBe(4);
+    expect(sig.degraded).toBe(true);
+  });
+});

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-signal.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-signal.test.ts
@@ -21,6 +21,15 @@ function makeCostDb(path: string, rows: Array<[string, number]>): void {
   db.close();
 }
 
+// readDailyCost filters `date >= date('now','-30 days')`, so seed dates must be
+// generated RELATIVE to today or the fixtures fall out of the window over time
+// and the tests go stale/flaky (Copilot review on #292).
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
 describe("model-routing-signal — graceful on a bad cost DB (no loop stall)", () => {
   let dir: string;
   beforeEach(() => {
@@ -52,7 +61,7 @@ describe("model-routing-signal — absolute-cost path needs >=4 days", () => {
 
   it("a single outlier day over the cap does NOT set degraded", () => {
     const db = join(dir, "costs.db");
-    makeCostDb(db, [["2026-06-30", 30]]); // one day, $30, cap 25
+    makeCostDb(db, [[daysAgo(0), 30]]); // one day, $30, cap 25
     const sig = costSignal(db, 25);
     expect(sig.days).toBe(1);
     expect(sig.degraded).toBe(false); // pre-fix this was true
@@ -61,10 +70,10 @@ describe("model-routing-signal — absolute-cost path needs >=4 days", () => {
   it("recent-over-cap DOES degrade once >=4 days are present", () => {
     const db = join(dir, "costs.db");
     makeCostDb(db, [
-      ["2026-06-27", 2],
-      ["2026-06-28", 2],
-      ["2026-06-29", 2],
-      ["2026-06-30", 30], // recent day well over cap, with enough history
+      [daysAgo(3), 2],
+      [daysAgo(2), 2],
+      [daysAgo(1), 2],
+      [daysAgo(0), 30], // recent day well over cap, with enough history
     ]);
     const sig = costSignal(db, 25);
     expect(sig.days).toBe(4);

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-subject.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-subject.test.ts
@@ -398,7 +398,7 @@ describe("ModelRoutingSubject — healthCheck", () => {
   it("returns producer_found=false when dispatchReader is not injected", async () => {
     // Default ctor: dispatchReader=() => [], i.e. not configured.
     const s = new ModelRoutingSubject({ modesConfigPath: configPath });
-    const h = await s.healthCheck!();
+    const h = await s.healthCheck?.();
     expect(h.producer_found).toBe(false);
     expect(h.reason).toMatch(/dispatchReader not configured/);
   });
@@ -408,7 +408,7 @@ describe("ModelRoutingSubject — healthCheck", () => {
       modesConfigPath: configPath,
       dispatchReader: () => [],
     });
-    const h = await s.healthCheck!();
+    const h = await s.healthCheck?.();
     expect(h.producer_found).toBe(true);
     expect(h.sample_event_match_rate).toBe(0);
     expect(h.reason).toMatch(/0 events/);
@@ -419,7 +419,7 @@ describe("ModelRoutingSubject — healthCheck", () => {
       modesConfigPath: configPath,
       dispatchReader: () => [{ type: "dispatch", mode: "code-fix" }, { type: "other" }],
     });
-    const h = await s.healthCheck!();
+    const h = await s.healthCheck?.();
     expect(h.producer_found).toBe(true);
     expect(h.sample_event_match_rate).toBeGreaterThan(0);
   });
@@ -433,7 +433,7 @@ describe("ModelRoutingSubject — healthProbe (post-apply artifact check)", () =
       "modes:\n  fast:\n    keywords: [quick, q]\n  deep:\n    keywords: [research]\n",
       "utf8",
     );
-    const probe = await s.healthProbe!(configPath);
+    const probe = await s.healthProbe?.(configPath);
     expect(probe.failed).toBe(false);
     expect(probe.errors).toEqual([]);
   });
@@ -445,7 +445,7 @@ describe("ModelRoutingSubject — healthProbe (post-apply artifact check)", () =
       "modes:\n  fast:\n    keywords: [quick]\n  deep:\n    keywords: [quick]\n",
       "utf8",
     );
-    const probe = await s.healthProbe!(configPath);
+    const probe = await s.healthProbe?.(configPath);
     expect(probe.failed).toBe(true);
     expect(probe.errors.join(" ")).toMatch(/duplicate keyword/);
   });
@@ -453,13 +453,13 @@ describe("ModelRoutingSubject — healthProbe (post-apply artifact check)", () =
   it("invalid YAML → failed:true", async () => {
     const s = new ModelRoutingSubject({ modesConfigPath: configPath });
     writeFileSync(configPath, "modes:\n  fast: [unclosed\n", "utf8");
-    const probe = await s.healthProbe!(configPath);
+    const probe = await s.healthProbe?.(configPath);
     expect(probe.failed).toBe(true);
   });
 
   it("config absent after apply → not a break", async () => {
     const s = new ModelRoutingSubject({ modesConfigPath: configPath });
-    const probe = await s.healthProbe!(configPath);
+    const probe = await s.healthProbe?.(configPath);
     expect(probe.failed).toBe(false);
   });
 });

--- a/src/tuner/subjects/agentic-config.ts
+++ b/src/tuner/subjects/agentic-config.ts
@@ -30,9 +30,25 @@ export function toAaSlug(model: string): string {
   return CLAUDE_SLUG_ALIASES[key] ?? key;
 }
 
-/** Is this benchmark a Claude model (the only thing ClaudeClaw can run today)? */
+/**
+ * Map an AA slug (or operator model name) to a LAUNCHABLE `--model` value. ClaudeClaw
+ * runs `claude --model <x>`; AA catalog slugs like "claude-opus-4-7-non-reasoning"
+ * are NOT valid --model values, but the tier short name ("opus"/"sonnet"/"haiku")
+ * always is — and is version-agnostic, so a reroute targets a TIER, never a stale
+ * pinned id that would break the mode. Returns null for anything not a launchable
+ * Claude tier (which is also what constrains reroute candidates).
+ */
+export function toLaunchableModel(model: string): "opus" | "sonnet" | "haiku" | null {
+  const s = model.toLowerCase();
+  if (s.includes("opus")) return "opus";
+  if (s.includes("sonnet")) return "sonnet";
+  if (s.includes("haiku")) return "haiku";
+  return null;
+}
+
+/** A benchmark is a runnable candidate only if it maps to a launchable Claude tier. */
 export function isRunnableModel(b: ModelBenchmark): boolean {
-  return b.model_id.toLowerCase().includes("claude");
+  return toLaunchableModel(b.model_id) !== null;
 }
 
 export interface AgenticAssignment {

--- a/src/tuner/subjects/agentic-config.ts
+++ b/src/tuner/subjects/agentic-config.ts
@@ -1,0 +1,92 @@
+/**
+ * agentic-config — reconciles the model_routing benchmark reroute (#292) with how
+ * ClaudeClaw ACTUALLY stores routing: the `agentic` block of settings.json (a LIST
+ * of {name, model, keywords}), NOT a standalone agentic.yaml map. It also maps the
+ * operator's model names to Artificial Analysis slugs and constrains reroute
+ * candidates to models the runtime can actually invoke.
+ *
+ * Runnable-model constraint: ClaudeClaw launches `claude --model <x>`, so a reroute
+ * to a non-Claude model (minimax, command-a, …) is not applicable until an
+ * llm-router provider exists. Until then candidates are Claude-only — which is also
+ * where the real win is (e.g. claude-3-5-sonnet → claude-sonnet-5: better AND
+ * cheaper). Keep this list curated as models ship.
+ */
+import type { ModelBenchmark } from "./model-routing-benchmarks.js";
+
+/** Operator model name (settings.json) → Artificial Analysis slug. Extend as models ship. */
+export const CLAUDE_SLUG_ALIASES: Record<string, string> = {
+  sonnet: "claude-sonnet-5",
+  opus: "claude-opus-4-7-non-reasoning",
+  haiku: "claude-3-5-haiku",
+  "claude-3-5-sonnet": "claude-35-sonnet",
+  "claude-3-5-haiku": "claude-3-5-haiku",
+  "claude-3-haiku": "claude-3-haiku",
+  "claude-sonnet-5": "claude-sonnet-5",
+};
+
+/** Normalize an operator model name to the AA slug used for benchmark lookup. */
+export function toAaSlug(model: string): string {
+  const key = model.trim().toLowerCase();
+  return CLAUDE_SLUG_ALIASES[key] ?? key;
+}
+
+/** Is this benchmark a Claude model (the only thing ClaudeClaw can run today)? */
+export function isRunnableModel(b: ModelBenchmark): boolean {
+  return b.model_id.toLowerCase().includes("claude");
+}
+
+export interface AgenticAssignment {
+  /** Mode name (settings.json agentic.modes[].name). */
+  mode: string;
+  /** Operator model name as written in the config. */
+  model: string;
+  /** The AA slug used to look this model up in the benchmark set. */
+  aaSlug: string;
+}
+
+/**
+ * Read `agentic.modes` from a settings.json string. Returns [] gracefully on parse
+ * failure, a disabled block, or no modes — a config problem must never throw into
+ * the proactive loop.
+ */
+export function readAgenticModes(settingsContent: string): AgenticAssignment[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(settingsContent);
+  } catch {
+    return [];
+  }
+  const agentic = (parsed as { agentic?: unknown })?.agentic as { modes?: unknown } | undefined;
+  const modes = agentic?.modes;
+  if (!Array.isArray(modes)) return [];
+  const out: AgenticAssignment[] = [];
+  for (const m of modes) {
+    if (!m || typeof m !== "object") continue;
+    const r = m as Record<string, unknown>;
+    const mode = typeof r.name === "string" ? r.name.trim() : "";
+    const model = typeof r.model === "string" ? r.model.trim() : "";
+    if (!mode || !model) continue;
+    out.push({ mode, model, aaSlug: toAaSlug(model) });
+  }
+  return out;
+}
+
+/**
+ * Set the `model` of a specific mode in a settings.json string, preserving the rest
+ * byte-for-byte via a structural JSON round-trip. Returns the original string
+ * unchanged if the mode is absent or the JSON can't be parsed (never corrupts).
+ */
+export function setAgenticModel(settingsContent: string, mode: string, newModel: string): string {
+  let parsed: { agentic?: { modes?: Array<{ name?: string; model?: string }> } };
+  try {
+    parsed = JSON.parse(settingsContent);
+  } catch {
+    return settingsContent;
+  }
+  const modes = parsed.agentic?.modes;
+  if (!Array.isArray(modes)) return settingsContent;
+  const target = modes.find((m) => m && m.name === mode);
+  if (!target) return settingsContent;
+  target.model = newModel;
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}

--- a/src/tuner/subjects/anthropic-benchmarks.ts
+++ b/src/tuner/subjects/anthropic-benchmarks.ts
@@ -1,0 +1,38 @@
+/**
+ * anthropic-benchmarks — Tier-A-for-Claude coding scores from Anthropic's OWN
+ * published SWE-bench Verified figures, filling the gap where the Artificial
+ * Analysis free tier leaves Claude (especially Opus) coding_index null.
+ *
+ * Scale: SWE-bench Verified % sits on ~the same 0-100 range as AA's coding_index
+ * (e.g. Sonnet 5: AA coding 71.5 ≈ SWE 72.7), so it drops in cleanly for gating.
+ *
+ * ⚠️ CURATED SEED — verify + extend from Anthropic's official model cards. Public
+ * sources report SWE-bench under different harnesses and disagree by several
+ * points, so only high-confidence, single-version figures are seeded here; every
+ * other model is left to the intelligence-composite fallback rather than guessed.
+ * Keyed by Artificial Analysis slug. Last touched 2026-07.
+ */
+import type { ModelBenchmark } from "./model-routing-benchmarks.js";
+
+export const ANTHROPIC_SWE_BENCH_VERIFIED: Record<string, number> = {
+  // Opus 4.7 — Anthropic-reported SWE-bench Verified ≈ 82.0 (AA leaves this null).
+  "claude-opus-4-7-non-reasoning": 82.0,
+  // Sonnet 5 — already has an AA coding score (71.5); seeded for consistency (72.7).
+  "claude-sonnet-5": 72.7,
+};
+
+export const ANTHROPIC_SOURCE = "https://www.anthropic.com/ (SWE-bench Verified, per model card)";
+
+/**
+ * Fill coding_index for Claude models from Anthropic's published SWE-bench where
+ * AA left it null. Never OVERWRITES a value AA already provides (AA is the neutral
+ * cross-provider measure); only fills gaps. Pure — returns a new array.
+ */
+export function enrichWithAnthropicCoding(benchmarks: ModelBenchmark[]): ModelBenchmark[] {
+  return benchmarks.map((b) => {
+    if (b.coding_index !== null) return b;
+    const swe = ANTHROPIC_SWE_BENCH_VERIFIED[b.model_id.toLowerCase()];
+    if (swe === undefined) return b;
+    return { ...b, coding_index: swe, source: `${b.source} + ${ANTHROPIC_SOURCE}` };
+  });
+}

--- a/src/tuner/subjects/model-routing-benchmarks.ts
+++ b/src/tuner/subjects/model-routing-benchmarks.ts
@@ -175,10 +175,13 @@ export async function getModelBenchmarks(
     const cached = readBenchmarkCache(opts.cachePath, ttlMs, nowMs);
     if (cached) return applyFilter(cached, opts.models);
   }
-  const fresh = await fetchModelBenchmarks(opts);
+  // Fetch the FULL set for the cache (never the caller's models filter — caching a
+  // filtered result would poison the cache for a later unfiltered read). Filter on
+  // the way out instead.
+  const fresh = await fetchModelBenchmarks({ ...opts, models: undefined });
   if (fresh.length > 0) {
     if (opts.cachePath) writeBenchmarkCache(opts.cachePath, fresh, nowMs);
-    return fresh;
+    return applyFilter(fresh, opts.models);
   }
   // Fetch yielded nothing — fall back to a stale cache (ignore TTL) if any.
   if (opts.cachePath && existsSync(opts.cachePath)) {

--- a/src/tuner/subjects/model-routing-benchmarks.ts
+++ b/src/tuner/subjects/model-routing-benchmarks.ts
@@ -69,12 +69,21 @@ export function parseArtificialAnalysis(raw: unknown, fetchedAtIso: string): Mod
     const slug = typeof r.slug === "string" ? r.slug : typeof r.id === "string" ? r.id : null;
     if (!slug) continue;
     const pricing = (r.pricing ?? {}) as Record<string, unknown>;
+    // Intelligence scores live under `evaluations` in the live v2 response
+    // (the flat top-level form is kept as a fallback for older snapshots).
+    const evals = (r.evaluations ?? {}) as Record<string, unknown>;
     out.push({
       model_id: slug,
       name: typeof r.name === "string" ? r.name : slug,
-      intelligence_index: num(r.artificial_analysis_intelligence_index),
-      coding_index: num(r.artificial_analysis_coding_index),
-      agentic_index: num(r.artificial_analysis_agentic_index),
+      intelligence_index: num(
+        evals.artificial_analysis_intelligence_index ?? r.artificial_analysis_intelligence_index,
+      ),
+      coding_index: num(
+        evals.artificial_analysis_coding_index ?? r.artificial_analysis_coding_index,
+      ),
+      agentic_index: num(
+        evals.artificial_analysis_agentic_index ?? r.artificial_analysis_agentic_index,
+      ),
       price_in_usd_per_mtok: num(pricing.price_1m_input_tokens),
       price_out_usd_per_mtok: num(pricing.price_1m_output_tokens),
       price_cache_hit_usd_per_mtok: num(pricing.price_1m_cache_hit_tokens),

--- a/src/tuner/subjects/model-routing-benchmarks.ts
+++ b/src/tuner/subjects/model-routing-benchmarks.ts
@@ -1,0 +1,203 @@
+/**
+ * model-routing-benchmarks — Tier-A quality provenance for the proactive
+ * model_routing face (#292, phase 1). Pulls PUBLISHED, objective, cross-provider
+ * benchmark + pricing data (Artificial Analysis Intelligence Index) so a routing
+ * proposal can be gated on QUALITY — not just local cost — before it ever reaches
+ * the own-workload bench (#80). Kept OUT of model-routing-subject.ts to respect
+ * the ≤800-line per-subject budget: this is a standalone provider the subject/
+ * scout reads, not subject logic.
+ *
+ * Free API: GET /api/v2/language/models/free, header `x-api-key`, 1000 req/day.
+ * Attribution to https://artificialanalysis.ai/ is REQUIRED for any use of the
+ * free tier — see ATTRIBUTION. Network + clock are injectable so tests are
+ * deterministic and never hit the wire.
+ */
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+export const ATTRIBUTION = "https://artificialanalysis.ai/";
+const DEFAULT_ENDPOINT = "https://artificialanalysis.ai/api/v2/language/models/free";
+/** Benchmarks move on model releases, not minutes — refresh at most daily. */
+export const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface ModelBenchmark {
+  /** Artificial Analysis slug, e.g. "claude-4-8-opus". */
+  model_id: string;
+  name: string;
+  /** Composite quality index (higher = better). null when AA has no score. */
+  intelligence_index: number | null;
+  coding_index: number | null;
+  agentic_index: number | null;
+  price_in_usd_per_mtok: number | null;
+  price_out_usd_per_mtok: number | null;
+  price_cache_hit_usd_per_mtok: number | null;
+  /** Attribution — always ATTRIBUTION for AA-sourced rows. */
+  source: string;
+  /** ISO timestamp this row was fetched (for cache TTL + audit). */
+  fetched_at: string;
+}
+
+type FetchLike = (
+  url: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+export interface FetchBenchmarksOptions {
+  apiKey?: string;
+  /** Restrict to these AA slugs (case-insensitive). Omit = all returned. */
+  models?: string[];
+  fetchImpl?: FetchLike;
+  endpoint?: string;
+  /** Injected clock (ms). Omit uses a fixed 0 — callers pass a real stamp. */
+  nowMs?: number;
+}
+
+function num(x: unknown): number | null {
+  return typeof x === "number" && Number.isFinite(x) ? x : null;
+}
+
+/**
+ * Parse a raw AA list response (`{ data: [...] }`) into ModelBenchmark[].
+ * Defensive: unknown shapes / missing fields degrade to null, never throw.
+ */
+export function parseArtificialAnalysis(raw: unknown, fetchedAtIso: string): ModelBenchmark[] {
+  const data = (raw as { data?: unknown })?.data;
+  if (!Array.isArray(data)) return [];
+  const out: ModelBenchmark[] = [];
+  for (const row of data) {
+    if (!row || typeof row !== "object") continue;
+    const r = row as Record<string, unknown>;
+    const slug = typeof r.slug === "string" ? r.slug : typeof r.id === "string" ? r.id : null;
+    if (!slug) continue;
+    const pricing = (r.pricing ?? {}) as Record<string, unknown>;
+    out.push({
+      model_id: slug,
+      name: typeof r.name === "string" ? r.name : slug,
+      intelligence_index: num(r.artificial_analysis_intelligence_index),
+      coding_index: num(r.artificial_analysis_coding_index),
+      agentic_index: num(r.artificial_analysis_agentic_index),
+      price_in_usd_per_mtok: num(pricing.price_1m_input_tokens),
+      price_out_usd_per_mtok: num(pricing.price_1m_output_tokens),
+      price_cache_hit_usd_per_mtok: num(pricing.price_1m_cache_hit_tokens),
+      source: ATTRIBUTION,
+      fetched_at: fetchedAtIso,
+    });
+  }
+  return out;
+}
+
+/**
+ * Fetch published benchmarks from Artificial Analysis. Graceful: returns [] on a
+ * missing key, non-200, network error, or malformed body — a benchmark outage
+ * must never stall the proactive loop (same contract as the cost signal reader).
+ */
+export async function fetchModelBenchmarks(
+  opts: FetchBenchmarksOptions = {},
+): Promise<ModelBenchmark[]> {
+  const apiKey = opts.apiKey ?? process.env.ARTIFICIAL_ANALYSIS_API_KEY;
+  if (!apiKey) return [];
+  const doFetch = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined);
+  if (!doFetch) return [];
+  const fetchedAt = new Date(opts.nowMs ?? 0).toISOString();
+  let rows: ModelBenchmark[] = [];
+  try {
+    const res = await doFetch(opts.endpoint ?? DEFAULT_ENDPOINT, {
+      headers: { "x-api-key": apiKey },
+    });
+    if (!res.ok) return [];
+    rows = parseArtificialAnalysis(await res.json(), fetchedAt);
+  } catch {
+    return [];
+  }
+  if (opts.models && opts.models.length > 0) {
+    const want = new Set(opts.models.map((m) => m.toLowerCase()));
+    rows = rows.filter((r) => want.has(r.model_id.toLowerCase()));
+  }
+  return rows;
+}
+
+interface CacheFile {
+  fetched_at_ms: number;
+  attribution: string;
+  benchmarks: ModelBenchmark[];
+}
+
+/** Read the on-disk cache if present AND fresh (< ttlMs old). null otherwise. */
+export function readBenchmarkCache(
+  path: string,
+  ttlMs: number,
+  nowMs: number,
+): ModelBenchmark[] | null {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as CacheFile;
+    if (!Array.isArray(parsed.benchmarks)) return null;
+    if (typeof parsed.fetched_at_ms !== "number") return null;
+    if (nowMs - parsed.fetched_at_ms > ttlMs) return null;
+    return parsed.benchmarks;
+  } catch {
+    return null;
+  }
+}
+
+export function writeBenchmarkCache(
+  path: string,
+  benchmarks: ModelBenchmark[],
+  nowMs: number,
+): void {
+  try {
+    const body: CacheFile = { fetched_at_ms: nowMs, attribution: ATTRIBUTION, benchmarks };
+    writeFileSync(path, JSON.stringify(body, null, 2), "utf8");
+  } catch {
+    // best-effort cache; a write failure must not break the fetch path.
+  }
+}
+
+/**
+ * Cache-first accessor: return fresh cache when available, else fetch, persist,
+ * and return. On a fetch failure with a STALE cache present, prefer the stale
+ * cache over nothing (benchmarks age slowly; stale beats empty for the gate).
+ */
+export async function getModelBenchmarks(
+  opts: FetchBenchmarksOptions & { cachePath?: string; ttlMs?: number },
+): Promise<ModelBenchmark[]> {
+  const nowMs = opts.nowMs ?? 0;
+  const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+  if (opts.cachePath) {
+    const cached = readBenchmarkCache(opts.cachePath, ttlMs, nowMs);
+    if (cached) return applyFilter(cached, opts.models);
+  }
+  const fresh = await fetchModelBenchmarks(opts);
+  if (fresh.length > 0) {
+    if (opts.cachePath) writeBenchmarkCache(opts.cachePath, fresh, nowMs);
+    return fresh;
+  }
+  // Fetch yielded nothing — fall back to a stale cache (ignore TTL) if any.
+  if (opts.cachePath && existsSync(opts.cachePath)) {
+    try {
+      const stale = JSON.parse(readFileSync(opts.cachePath, "utf8")) as CacheFile;
+      if (Array.isArray(stale.benchmarks)) return applyFilter(stale.benchmarks, opts.models);
+    } catch {
+      // ignore
+    }
+  }
+  return [];
+}
+
+function applyFilter(rows: ModelBenchmark[], models?: string[]): ModelBenchmark[] {
+  if (!models || models.length === 0) return rows;
+  const want = new Set(models.map((m) => m.toLowerCase()));
+  return rows.filter((r) => want.has(r.model_id.toLowerCase()));
+}
+
+// Standalone smoke: `bun model-routing-benchmarks.ts [slug ...]`. Needs
+// ARTIFICIAL_ANALYSIS_API_KEY in the env; prints the fetched rows as JSON.
+if (import.meta.main) {
+  const models = process.argv.slice(2);
+  const rows = await fetchModelBenchmarks({
+    models: models.length ? models : undefined,
+    nowMs: Date.now(),
+  });
+  console.log(
+    JSON.stringify({ attribution: ATTRIBUTION, count: rows.length, benchmarks: rows }, null, 2),
+  );
+}

--- a/src/tuner/subjects/model-routing-quality.ts
+++ b/src/tuner/subjects/model-routing-quality.ts
@@ -1,0 +1,123 @@
+/**
+ * model-routing-quality — the QUALITY-FIRST reroute gate for the proactive
+ * model_routing face (#292, phase "P4 core"). Pure decision logic kept out of
+ * model-routing-subject.ts (≤800-line budget). Combines the published quality
+ * signal (Artificial Analysis Intelligence Index, via model-routing-benchmarks)
+ * with cost. The rule Simon set: QUALITY is the veto, cost is only the tiebreaker
+ * — never propose a reroute that regresses quality, even if it is cheaper.
+ *
+ * This is the Tier-A gate (published, objective, cross-provider). A candidate
+ * that survives it goes to the own-workload bench (#80) for Tier-B confirmation
+ * before anything is applied.
+ */
+import type { ModelBenchmark } from "./model-routing-benchmarks.js";
+
+export interface RerouteVerdict {
+  /** Whether to surface this reroute as a candidate at all. */
+  propose: boolean;
+  /** Machine tag for the reason (telemetry + tests). */
+  code:
+    | "quality_regression" // candidate is meaningfully worse → vetoed
+    | "not_cheaper" // quality ok but no cost win → nothing to gain
+    | "insufficient_data" // missing index/pricing → cannot gate, stay put
+    | "quality_win" // candidate is better AND not more expensive
+    | "cost_win_quality_held"; // quality within tolerance AND cheaper
+  reason: string;
+  /** candidate.intelligence_index − current.intelligence_index (null if unknown). */
+  quality_delta: number | null;
+  /** Blended $/Mtok saved (current − candidate), null if pricing unknown. */
+  projected_savings_usd_per_mtok: number | null;
+}
+
+export interface RerouteGateOptions {
+  /**
+   * How much Intelligence-Index drop is tolerable in exchange for a cost win.
+   * 0 = zero tolerance (candidate must be ≥ current). Small positive = allow a
+   * marginally-lower-quality-but-cheaper swap. Default 0 (quality strict).
+   */
+  qualityTolerance?: number;
+  /** Blend weight for input vs output tokens when estimating $/Mtok. */
+  inputOutputRatio?: number; // e.g. 3 → price ≈ (3*in + out) / 4
+  /** Minimum blended $/Mtok saving to bother proposing. */
+  minSavingsUsdPerMtok?: number;
+}
+
+function blendedPrice(b: ModelBenchmark, ratio: number): number | null {
+  const pin = b.price_in_usd_per_mtok;
+  const pout = b.price_out_usd_per_mtok;
+  if (pin === null || pout === null) return null;
+  return (ratio * pin + pout) / (ratio + 1);
+}
+
+/**
+ * Decide whether rerouting `current` → `candidate` is worth proposing, quality
+ * first. Never proposes a quality regression beyond tolerance; among quality-safe
+ * options, requires a real cost win above the noise floor.
+ */
+export function evaluateReroute(
+  current: ModelBenchmark,
+  candidate: ModelBenchmark,
+  opts: RerouteGateOptions = {},
+): RerouteVerdict {
+  const tol = opts.qualityTolerance ?? 0;
+  const ratio = opts.inputOutputRatio ?? 3;
+  const minSavings = opts.minSavingsUsdPerMtok ?? 0;
+
+  const qCur = current.intelligence_index;
+  const qCand = candidate.intelligence_index;
+  const pCur = blendedPrice(current, ratio);
+  const pCand = blendedPrice(candidate, ratio);
+
+  // Cannot gate on quality without both indices, nor on cost without pricing.
+  if (qCur === null || qCand === null || pCur === null || pCand === null) {
+    return {
+      propose: false,
+      code: "insufficient_data",
+      reason:
+        "Missing Intelligence Index or pricing for one of the models — cannot gate on quality, staying put.",
+      quality_delta: qCur !== null && qCand !== null ? qCand - qCur : null,
+      projected_savings_usd_per_mtok: pCur !== null && pCand !== null ? pCur - pCand : null,
+    };
+  }
+
+  const qualityDelta = qCand - qCur;
+  const savings = pCur - pCand;
+
+  // VETO: quality regression beyond tolerance — reject even if cheaper.
+  if (qualityDelta < -tol) {
+    return {
+      propose: false,
+      code: "quality_regression",
+      reason: `Candidate Intelligence Index ${qCand} is ${(-qualityDelta).toFixed(
+        1,
+      )} below current ${qCur} (tolerance ${tol}). Quality is the veto — not proposed even though it saves $${savings.toFixed(2)}/Mtok.`,
+      quality_delta: qualityDelta,
+      projected_savings_usd_per_mtok: savings,
+    };
+  }
+
+  // Quality is safe. Now cost is the tiebreaker: require a real saving.
+  if (savings <= minSavings) {
+    return {
+      propose: false,
+      code: "not_cheaper",
+      reason: `Quality holds (Δ ${qualityDelta.toFixed(1)}) but no cost win above the floor ($${savings.toFixed(
+        2,
+      )}/Mtok ≤ $${minSavings}/Mtok) — nothing to gain.`,
+      quality_delta: qualityDelta,
+      projected_savings_usd_per_mtok: savings,
+    };
+  }
+
+  // Propose. Distinguish a strict quality win from a within-tolerance cost win.
+  const strictWin = qualityDelta >= 0;
+  return {
+    propose: true,
+    code: strictWin ? "quality_win" : "cost_win_quality_held",
+    reason: strictWin
+      ? `Candidate is at least as good (Δ ${qualityDelta.toFixed(1)}) AND saves $${savings.toFixed(2)}/Mtok.`
+      : `Candidate is within tolerance (Δ ${qualityDelta.toFixed(1)}, ≤ ${tol}) and saves $${savings.toFixed(2)}/Mtok.`,
+    quality_delta: qualityDelta,
+    projected_savings_usd_per_mtok: savings,
+  };
+}

--- a/src/tuner/subjects/model-routing-quality.ts
+++ b/src/tuner/subjects/model-routing-quality.ts
@@ -46,6 +46,12 @@ export interface RerouteGateOptions {
    * higher overall while it is actually WORSE at code. Default "intelligence".
    */
   qualityMetric?: "intelligence" | "coding" | "agentic";
+  /**
+   * When the requested metric is missing for a model (AA's free tier has no Opus
+   * coding/agentic), fall back to the intelligence COMPOSITE for both models.
+   * Default true. The composite already folds in coding-heavy benchmarks.
+   */
+  metricFallback?: boolean;
 }
 
 function blendedPrice(b: ModelBenchmark, ratio: number): number | null {
@@ -71,26 +77,36 @@ export function evaluateReroute(
   const ratio = opts.inputOutputRatio ?? 3;
   const minSavings = opts.minSavingsUsdPerMtok ?? 0;
 
-  const metricField = (
-    {
-      intelligence: "intelligence_index",
-      coding: "coding_index",
-      agentic: "agentic_index",
-    } as const
-  )[opts.qualityMetric ?? "intelligence"];
-  const qCur = current[metricField];
-  const qCand = candidate[metricField];
+  const FIELD = {
+    intelligence: "intelligence_index",
+    coding: "coding_index",
+    agentic: "agentic_index",
+  } as const;
+  const primaryMetric = opts.qualityMetric ?? "intelligence";
+  let usedMetric: "intelligence" | "coding" | "agentic" = primaryMetric;
+  let qCur = current[FIELD[primaryMetric]];
+  let qCand = candidate[FIELD[primaryMetric]];
+  // Metric fallback (#292): if the requested sub-score is missing for either
+  // model, fall back to the intelligence composite for BOTH — a fair (if coarser)
+  // comparison, since the composite already includes coding-heavy benchmarks.
+  if (
+    (qCur === null || qCand === null) &&
+    primaryMetric !== "intelligence" &&
+    (opts.metricFallback ?? true)
+  ) {
+    usedMetric = "intelligence";
+    qCur = current.intelligence_index;
+    qCand = candidate.intelligence_index;
+  }
   const pCur = blendedPrice(current, ratio);
   const pCand = blendedPrice(candidate, ratio);
-
-  const metric = opts.qualityMetric ?? "intelligence";
 
   // Quality gate needs both indices. Without them we cannot judge quality at all.
   if (qCur === null || qCand === null) {
     return {
       propose: false,
       code: "insufficient_data",
-      reason: `Missing ${metric} score for one of the models — cannot gate on quality, staying put.`,
+      reason: `Missing ${usedMetric} score for one of the models — cannot gate on quality, staying put.`,
       quality_delta: null,
       projected_savings_usd_per_mtok: pCur !== null && pCand !== null ? pCur - pCand : null,
     };
@@ -104,7 +120,7 @@ export function evaluateReroute(
     return {
       propose: false,
       code: "quality_regression",
-      reason: `Candidate ${metric} score ${qCand} is ${(-qualityDelta).toFixed(
+      reason: `Candidate ${usedMetric} score ${qCand} is ${(-qualityDelta).toFixed(
         1,
       )} below current ${qCur} (tolerance ${tol}). Quality is the veto.`,
       quality_delta: qualityDelta,

--- a/src/tuner/subjects/model-routing-quality.ts
+++ b/src/tuner/subjects/model-routing-quality.ts
@@ -221,7 +221,13 @@ export function setModelInYaml(content: string, mode: string, newModel: string):
       out.push(line);
       continue;
     }
-    if (inMode && line.trim().length > 0 && !line.startsWith(`${modeIndent} `)) inMode = false;
+    if (
+      inMode &&
+      line.trim().length > 0 &&
+      !line.trim().startsWith("#") &&
+      !line.startsWith(`${modeIndent} `)
+    )
+      inMode = false;
     if (inMode) {
       const m = line.match(/^(\s*model:\s*)["']?[A-Za-z0-9._-]+["']?\s*$/);
       if (m) {

--- a/src/tuner/subjects/model-routing-quality.ts
+++ b/src/tuner/subjects/model-routing-quality.ts
@@ -121,3 +121,51 @@ export function evaluateReroute(
     projected_savings_usd_per_mtok: savings,
   };
 }
+
+/** A concrete, quality-gated reroute the proactive face can surface. */
+export interface RerouteProposal {
+  /** The config key / mode whose model would change. */
+  key: string;
+  from_model: string;
+  to_model: string;
+  verdict: RerouteVerdict;
+}
+
+/** Rank two accepted verdicts: more savings first, then higher quality delta. */
+function betterProposal(a: RerouteVerdict, b: RerouteVerdict): boolean {
+  const sa = a.projected_savings_usd_per_mtok ?? -Infinity;
+  const sb = b.projected_savings_usd_per_mtok ?? -Infinity;
+  if (sa !== sb) return sa > sb;
+  return (a.quality_delta ?? -Infinity) > (b.quality_delta ?? -Infinity);
+}
+
+/**
+ * The Tier-A pipeline: for each current model assignment, find the best
+ * quality-gated reroute among the published benchmarks. Returns at most one
+ * proposal per key (the best by savings, then quality). An assignment whose
+ * current model has no benchmark is skipped (can't gate → stay put). Pure:
+ * assignments + benchmarks in, proposals out — no I/O, no web, fully testable.
+ */
+export function proposeBenchmarkReroute(
+  assignments: Array<{ key: string; model: string }>,
+  benchmarks: ModelBenchmark[],
+  opts: RerouteGateOptions = {},
+): RerouteProposal[] {
+  const byId = new Map(benchmarks.map((b) => [b.model_id.toLowerCase(), b]));
+  const proposals: RerouteProposal[] = [];
+  for (const a of assignments) {
+    const current = byId.get(a.model.toLowerCase());
+    if (!current) continue;
+    let best: RerouteProposal | null = null;
+    for (const cand of benchmarks) {
+      if (cand.model_id.toLowerCase() === a.model.toLowerCase()) continue;
+      const verdict = evaluateReroute(current, cand, opts);
+      if (!verdict.propose) continue;
+      if (!best || betterProposal(verdict, best.verdict)) {
+        best = { key: a.key, from_model: a.model, to_model: cand.model_id, verdict };
+      }
+    }
+    if (best) proposals.push(best);
+  }
+  return proposals;
+}

--- a/src/tuner/subjects/model-routing-quality.ts
+++ b/src/tuner/subjects/model-routing-quality.ts
@@ -40,12 +40,20 @@ export interface RerouteGateOptions {
   inputOutputRatio?: number; // e.g. 3 → price ≈ (3*in + out) / 4
   /** Minimum blended $/Mtok saving to bother proposing. */
   minSavingsUsdPerMtok?: number;
+  /**
+   * Which published index to gate quality on. A CODING/ops agent (e.g. Greg)
+   * should use "coding" — the general "intelligence" composite can rank a model
+   * higher overall while it is actually WORSE at code. Default "intelligence".
+   */
+  qualityMetric?: "intelligence" | "coding" | "agentic";
 }
 
 function blendedPrice(b: ModelBenchmark, ratio: number): number | null {
   const pin = b.price_in_usd_per_mtok;
   const pout = b.price_out_usd_per_mtok;
-  if (pin === null || pout === null) return null;
+  // Non-positive prices mean MISSING data (AA returns 0/0 for unpriced models);
+  // a bogus "free" model must never manufacture a cost win. Treat as unknown.
+  if (pin === null || pout === null || pin <= 0 || pout <= 0) return null;
   return (ratio * pin + pout) / (ratio + 1);
 }
 
@@ -63,40 +71,64 @@ export function evaluateReroute(
   const ratio = opts.inputOutputRatio ?? 3;
   const minSavings = opts.minSavingsUsdPerMtok ?? 0;
 
-  const qCur = current.intelligence_index;
-  const qCand = candidate.intelligence_index;
+  const metricField = (
+    {
+      intelligence: "intelligence_index",
+      coding: "coding_index",
+      agentic: "agentic_index",
+    } as const
+  )[opts.qualityMetric ?? "intelligence"];
+  const qCur = current[metricField];
+  const qCand = candidate[metricField];
   const pCur = blendedPrice(current, ratio);
   const pCand = blendedPrice(candidate, ratio);
 
-  // Cannot gate on quality without both indices, nor on cost without pricing.
-  if (qCur === null || qCand === null || pCur === null || pCand === null) {
+  const metric = opts.qualityMetric ?? "intelligence";
+
+  // Quality gate needs both indices. Without them we cannot judge quality at all.
+  if (qCur === null || qCand === null) {
     return {
       propose: false,
       code: "insufficient_data",
-      reason:
-        "Missing Intelligence Index or pricing for one of the models — cannot gate on quality, staying put.",
-      quality_delta: qCur !== null && qCand !== null ? qCand - qCur : null,
+      reason: `Missing ${metric} score for one of the models — cannot gate on quality, staying put.`,
+      quality_delta: null,
       projected_savings_usd_per_mtok: pCur !== null && pCand !== null ? pCur - pCand : null,
     };
   }
 
   const qualityDelta = qCand - qCur;
-  const savings = pCur - pCand;
 
-  // VETO: quality regression beyond tolerance — reject even if cheaper.
+  // VETO: quality regression beyond tolerance — decided on QUALITY ALONE, so it
+  // fires even when pricing is missing (a cheaper-but-worse model is still out).
   if (qualityDelta < -tol) {
     return {
       propose: false,
       code: "quality_regression",
-      reason: `Candidate Intelligence Index ${qCand} is ${(-qualityDelta).toFixed(
+      reason: `Candidate ${metric} score ${qCand} is ${(-qualityDelta).toFixed(
         1,
-      )} below current ${qCur} (tolerance ${tol}). Quality is the veto — not proposed even though it saves $${savings.toFixed(2)}/Mtok.`,
+      )} below current ${qCur} (tolerance ${tol}). Quality is the veto.`,
       quality_delta: qualityDelta,
-      projected_savings_usd_per_mtok: savings,
+      projected_savings_usd_per_mtok: pCur !== null && pCand !== null ? pCur - pCand : null,
     };
   }
 
-  // Quality is safe. Now cost is the tiebreaker: require a real saving.
+  // Quality is safe. A cost decision needs real pricing on BOTH models — a 0/0
+  // "free" model was already nulled by blendedPrice, so it lands here, not as a
+  // bogus saving.
+  if (pCur === null || pCand === null) {
+    return {
+      propose: false,
+      code: "insufficient_data",
+      reason:
+        "Quality is safe but pricing is missing/zero for one of the models — no trustworthy cost signal, staying put.",
+      quality_delta: qualityDelta,
+      projected_savings_usd_per_mtok: null,
+    };
+  }
+
+  const savings = pCur - pCand;
+
+  // Cost is the tiebreaker: require a real saving.
   if (savings <= minSavings) {
     return {
       propose: false,

--- a/src/tuner/subjects/model-routing-quality.ts
+++ b/src/tuner/subjects/model-routing-quality.ts
@@ -169,3 +169,90 @@ export function proposeBenchmarkReroute(
   }
   return proposals;
 }
+
+import type { EvidencePatch } from "../wisecron/evidence-driven.js";
+
+function escapeReQuality(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Extract `mode → model` assignments from an agentic.yaml `modes:` block. Tracks
+ * the (indented) mode header and pairs it with its `model:` line. Indent-aware so
+ * a comment or sibling never mis-binds (same discipline as the YAML editors).
+ */
+export function parseModelAssignments(content: string): Array<{ key: string; model: string }> {
+  const lines = content.split("\n");
+  const out: Array<{ key: string; model: string }> = [];
+  let mode: string | null = null;
+  let modeIndent = "";
+  for (const line of lines) {
+    const header = line.match(/^(\s*)([A-Za-z0-9_-]+):\s*$/);
+    if (header) {
+      mode = header[2] ?? null;
+      modeIndent = header[1] ?? "";
+      continue;
+    }
+    const m = line.match(/^(\s*)model:\s*["']?([A-Za-z0-9._-]+)["']?\s*$/);
+    if (m && mode && (m[1]?.length ?? 0) > modeIndent.length) {
+      out.push({ key: mode, model: m[2]! });
+      mode = null;
+    }
+  }
+  return out;
+}
+
+/**
+ * Set the `model:` for a specific mode block to `newModel`, preserving comments +
+ * ordering. Indent-aware block scope (exits on a sibling/dedent) so a reroute of
+ * one mode never rewrites another — the #306 hazard, avoided by construction.
+ */
+export function setModelInYaml(content: string, mode: string, newModel: string): string {
+  const lines = content.split("\n");
+  const out: string[] = [];
+  let inMode = false;
+  let modeIndent = "";
+  const header = new RegExp(`^(\\s*)${escapeReQuality(mode)}:\\s*$`);
+  for (const line of lines) {
+    const h = line.match(header);
+    if (h) {
+      inMode = true;
+      modeIndent = h[1] ?? "";
+      out.push(line);
+      continue;
+    }
+    if (inMode && line.trim().length > 0 && !line.startsWith(`${modeIndent} `)) inMode = false;
+    if (inMode) {
+      const m = line.match(/^(\s*model:\s*)["']?[A-Za-z0-9._-]+["']?\s*$/);
+      if (m) {
+        out.push(`${m[1]}${newModel}`);
+        inMode = false;
+        continue;
+      }
+    }
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+/**
+ * Turn quality-gated reroute proposals into an EvidencePatch the subject applies
+ * itself (a CONFIG patch, in its own modes file — never a plugin, never engine
+ * code). One alternative per proposal so the operator picks which mode to reroute.
+ */
+export function buildRerouteEvidencePatch(
+  content: string,
+  proposals: RerouteProposal[],
+  targetPath: string,
+): EvidencePatch | null {
+  if (proposals.length === 0) return null;
+  return {
+    target_path: targetPath,
+    alternatives: proposals.map((p) => ({
+      id: `reroute-${p.key}-to-${p.to_model}`,
+      label: `Route '${p.key}' ${p.from_model} → ${p.to_model}`,
+      diff_or_content: setModelInYaml(content, p.key, p.to_model),
+      tradeoff: p.verdict.reason,
+    })),
+  };
+}

--- a/src/tuner/subjects/model-routing-quality.ts
+++ b/src/tuner/subjects/model-routing-quality.ts
@@ -181,9 +181,10 @@ function betterProposal(a: RerouteVerdict, b: RerouteVerdict): boolean {
 export function proposeBenchmarkReroute(
   assignments: Array<{ key: string; model: string }>,
   benchmarks: ModelBenchmark[],
-  opts: RerouteGateOptions = {},
+  opts: RerouteGateOptions & { candidateFilter?: (b: ModelBenchmark) => boolean } = {},
 ): RerouteProposal[] {
   const byId = new Map(benchmarks.map((b) => [b.model_id.toLowerCase(), b]));
+  const canUse = opts.candidateFilter ?? (() => true);
   const proposals: RerouteProposal[] = [];
   for (const a of assignments) {
     const current = byId.get(a.model.toLowerCase());
@@ -191,6 +192,7 @@ export function proposeBenchmarkReroute(
     let best: RerouteProposal | null = null;
     for (const cand of benchmarks) {
       if (cand.model_id.toLowerCase() === a.model.toLowerCase()) continue;
+      if (!canUse(cand)) continue;
       const verdict = evaluateReroute(current, cand, opts);
       if (!verdict.propose) continue;
       if (!best || betterProposal(verdict, best.verdict)) {

--- a/src/tuner/subjects/model-routing-signal.ts
+++ b/src/tuner/subjects/model-routing-signal.ts
@@ -23,8 +23,14 @@ export function median(xs: number[]): number {
 /** Per-day median session cost over the recent window (oldest first). Graceful: [] if no DB. */
 export function readDailyCost(dbPath: string, limitDays = 30): DayCost[] {
   if (!existsSync(dbPath)) return [];
-  const db = new Database(dbPath, { readonly: true });
+  // The constructor itself can throw (corrupt/partially-written DB, non-SQLite
+  // file, EACCES from a differently-privileged writer) — keep it INSIDE the try
+  // so the documented "graceful: [] on any failure" contract actually holds and
+  // a bad cost DB can never stall the proactive loop (matches the sibling
+  // session-cost / host-telemetry readers).
+  let db: Database | null = null;
   try {
+    db = new Database(dbPath, { readonly: true });
     const rows = db
       .query(
         "SELECT date, cost_usd FROM session_costs WHERE date >= date('now', '-' || ?1 || ' days') ORDER BY date",
@@ -42,7 +48,11 @@ export function readDailyCost(dbPath: string, limitDays = 30): DayCost[] {
   } catch {
     return [];
   } finally {
-    db.close();
+    try {
+      db?.close();
+    } catch {
+      // best-effort close
+    }
   }
 }
 
@@ -75,9 +85,16 @@ export interface CostSignal {
 /** The degradation verdict: cost trending up (above noise floor) = degraded. */
 export function costSignal(dbPath: string, maxRecentUsd = Infinity): CostSignal {
   const days = readDailyCost(dbPath);
-  const recent = days.length ? days[days.length - 1]!.medianUsd : 0;
+  const lastDay = days.at(-1);
+  const recent = lastDay ? lastDay.medianUsd : 0;
   const trend = costTrend(days);
-  const degraded = trend === "degrading" || recent > maxRecentUsd;
+  // Both degradation paths must share the same sample discipline: costTrend
+  // already refuses a verdict below 4 days, and the absolute `recent > cap`
+  // branch now does too — otherwise a single outlier day on a fresh/sparse DB
+  // (e.g. one $30 batch job on day one) would flip `degraded` and fire a
+  // spurious proactive proposal.
+  const enoughSamples = days.length >= 4;
+  const degraded = enoughSamples && (trend === "degrading" || recent > maxRecentUsd);
   return { value: Math.round(recent * 1e4) / 1e4, trend, degraded, days: days.length };
 }
 

--- a/src/tuner/subjects/model-routing-signal.ts
+++ b/src/tuner/subjects/model-routing-signal.ts
@@ -1,0 +1,87 @@
+/**
+ * model-routing-signal — the model_routing subject's LOCAL degradation signal:
+ * the trend of per-session cost. Rising cost = routing could be cheaper/better →
+ * a trigger to research a routing technique. Reads the same `session_costs` store
+ * the session_cost telemetry stream uses (date, cost_usd per session). Local only.
+ */
+import { existsSync } from "node:fs";
+import { Database } from "bun:sqlite";
+
+export interface DayCost {
+  date: string;
+  medianUsd: number;
+  sessions: number;
+}
+
+export function median(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m]! : (s[m - 1]! + s[m]!) / 2;
+}
+
+/** Per-day median session cost over the recent window (oldest first). Graceful: [] if no DB. */
+export function readDailyCost(dbPath: string, limitDays = 30): DayCost[] {
+  if (!existsSync(dbPath)) return [];
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const rows = db
+      .query(
+        "SELECT date, cost_usd FROM session_costs WHERE date >= date('now', '-' || ?1 || ' days') ORDER BY date",
+      )
+      .all(limitDays) as Array<{ date: string; cost_usd: number }>;
+    const byDay = new Map<string, number[]>();
+    for (const r of rows) {
+      const arr = byDay.get(r.date) ?? [];
+      arr.push(r.cost_usd);
+      byDay.set(r.date, arr);
+    }
+    return [...byDay.entries()]
+      .map(([date, xs]) => ({ date, medianUsd: median(xs), sessions: xs.length }))
+      .sort((a, b) => (a.date < b.date ? -1 : 1));
+  } catch {
+    return [];
+  } finally {
+    db.close();
+  }
+}
+
+/** Trend of the daily medians: recent half vs older half, with a relative + absolute floor. */
+export function costTrend(
+  days: DayCost[],
+  tol = 0.15,
+  minAbsUsd = 0.5,
+): "improving" | "stable" | "degrading" {
+  if (days.length < 4) return "stable";
+  const mid = Math.floor(days.length / 2);
+  const avg = (xs: DayCost[]) => xs.reduce((a, d) => a + d.medianUsd, 0) / xs.length;
+  const older = avg(days.slice(0, mid));
+  const recent = avg(days.slice(mid));
+  if (Math.abs(recent - older) <= minAbsUsd) return "stable"; // below noise floor
+  if (older === 0) return recent > 0 ? "degrading" : "stable";
+  const delta = (recent - older) / older;
+  if (delta > tol) return "degrading";
+  if (delta < -tol) return "improving";
+  return "stable";
+}
+
+export interface CostSignal {
+  value: number; // recent median session cost (USD)
+  trend: "improving" | "stable" | "degrading";
+  degraded: boolean;
+  days: number;
+}
+
+/** The degradation verdict: cost trending up (above noise floor) = degraded. */
+export function costSignal(dbPath: string, maxRecentUsd = Infinity): CostSignal {
+  const days = readDailyCost(dbPath);
+  const recent = days.length ? days[days.length - 1]!.medianUsd : 0;
+  const trend = costTrend(days);
+  const degraded = trend === "degrading" || recent > maxRecentUsd;
+  return { value: Math.round(recent * 1e4) / 1e4, trend, degraded, days: days.length };
+}
+
+if (import.meta.main) {
+  const dbPath = process.argv[2] ?? `${process.env.HOME}/agent/data/costs.db`;
+  console.log(`[model-routing-signal] ${JSON.stringify(costSignal(dbPath))}`);
+}

--- a/src/tuner/subjects/model-routing-subject.ts
+++ b/src/tuner/subjects/model-routing-subject.ts
@@ -29,9 +29,17 @@ import {
   type LocalSignal,
   type StructuredEvidence,
   type EvidenceVerdict,
+  type EvidencePatch,
   meetsEvidenceBar,
 } from "../wisecron/evidence-driven.js";
 import { costSignal } from "./model-routing-signal.js";
+import { getModelBenchmarks, type ModelBenchmark } from "./model-routing-benchmarks.js";
+import {
+  buildRerouteEvidencePatch,
+  parseModelAssignments,
+  proposeBenchmarkReroute,
+  type RerouteGateOptions,
+} from "./model-routing-quality.js";
 
 /** Recent median session cost (USD) above which routing is "expensive" regardless of trend. */
 const MODEL_ROUTING_MAX_RECENT_USD = 25;
@@ -61,6 +69,10 @@ export interface ModelRoutingSubjectConfig {
   modesConfigPath?: string;
   /** Injected dispatch-event reader. */
   dispatchReader?: (since: Date) => Array<Record<string, unknown>>;
+  /** Injected published-benchmark provider (Artificial Analysis by default). */
+  benchmarkProvider?: (models: string[]) => Promise<ModelBenchmark[]>;
+  /** Quality/cost gate tuning for the benchmark reroute. */
+  rerouteGate?: RerouteGateOptions;
 }
 
 export class ModelRoutingSubject
@@ -77,6 +89,8 @@ export class ModelRoutingSubject
   private readonly dispatchReader: (since: Date) => Array<Record<string, unknown>>;
   private readonly dispatchReaderInjected: boolean;
   private readonly costDbPath: string;
+  private readonly benchmarkProvider: (models: string[]) => Promise<ModelBenchmark[]>;
+  private readonly rerouteGate: RerouteGateOptions;
 
   constructor(opts: ModelRoutingSubjectConfig = {}) {
     super();
@@ -87,6 +101,9 @@ export class ModelRoutingSubject
     this.dispatchReaderInjected = opts.dispatchReader !== undefined;
     this.dispatchReader = opts.dispatchReader ?? (() => []);
     this.costDbPath = expandHome(opts.costDbPath ?? join(homedir(), "agent", "data", "costs.db"));
+    this.benchmarkProvider =
+      opts.benchmarkProvider ?? ((models) => getModelBenchmarks({ models, nowMs: Date.now() }));
+    this.rerouteGate = opts.rerouteGate ?? {};
   }
 
   // ── Proactive face: EvidenceDrivenSubject (cost signal + faisceau de preuves) ──
@@ -141,6 +158,34 @@ export class ModelRoutingSubject
   async confirm(before: LocalSignal): Promise<boolean> {
     const after = await this.localSignal();
     return after.value < before.value;
+  }
+
+  /**
+   * Proactive benchmark reroute (kind:"patch"). When the local cost signal is
+   * degraded, read the operator's current model assignments, pull PUBLISHED
+   * quality+cost benchmarks (Tier A), and propose the best quality-gated reroute
+   * as a CONFIG patch the subject applies in its own modes file — quality is the
+   * veto (never a reroute that regresses quality). null when nothing is degraded,
+   * no benchmark data is available (no key/offline), or no safe reroute exists.
+   * A survivor is confirmed on the own-workload bench (#80) before apply.
+   */
+  async proposeEvidencePatch(
+    _evidence: StructuredEvidence,
+    signal: LocalSignal,
+  ): Promise<EvidencePatch | null> {
+    if (!signal.degraded) return null;
+    let content = "";
+    try {
+      content = readFileSync(this.modesConfigPath, "utf8");
+    } catch {
+      return null;
+    }
+    const assignments = parseModelAssignments(content);
+    if (assignments.length === 0) return null;
+    const benchmarks = await this.benchmarkProvider(assignments.map((a) => a.model));
+    if (benchmarks.length === 0) return null;
+    const proposals = proposeBenchmarkReroute(assignments, benchmarks, this.rerouteGate);
+    return buildRerouteEvidencePatch(content, proposals, this.modesConfigPath);
   }
 
   async collectObservations(since: Date): Promise<Observation[]> {

--- a/src/tuner/subjects/model-routing-subject.ts
+++ b/src/tuner/subjects/model-routing-subject.ts
@@ -23,6 +23,18 @@ import type { RevertibleSubject } from "../wisecron/types.js";
 import type { DateRange, Metric, TelemetryProvider } from "../../skills-tuner/core/telemetry.js";
 import { ARTIFACT_SOURCE } from "../../skills-tuner/core/telemetry.js";
 import { nonzeroRate } from "../../skills-tuner/core/aggregate.js";
+import {
+  type EvidenceDrivenSubject,
+  type ResearchSpec,
+  type LocalSignal,
+  type StructuredEvidence,
+  type EvidenceVerdict,
+  meetsEvidenceBar,
+} from "../wisecron/evidence-driven.js";
+import { costSignal } from "./model-routing-signal.js";
+
+/** Recent median session cost (USD) above which routing is "expensive" regardless of trend. */
+const MODEL_ROUTING_MAX_RECENT_USD = 25;
 
 const DEAD_DAYS = 90;
 const MISTRIGGER_RATE = 0.3;
@@ -43,13 +55,18 @@ interface RoutingStats {
  */
 export interface ModelRoutingSubjectConfig {
   llm?: LLMClient;
+  /** Path to the session-cost SQLite store (the proactive signal source). */
+  costDbPath?: string;
   /** Modes config path. Default: ~/.claude/agentic.yaml. */
   modesConfigPath?: string;
   /** Injected dispatch-event reader. */
   dispatchReader?: (since: Date) => Array<Record<string, unknown>>;
 }
 
-export class ModelRoutingSubject extends BaseSubject implements RevertibleSubject {
+export class ModelRoutingSubject
+  extends BaseSubject
+  implements RevertibleSubject, EvidenceDrivenSubject
+{
   readonly name = "model_routing";
   readonly risk_tier = "medium" as const;
   readonly auto_merge_default = false;
@@ -59,6 +76,7 @@ export class ModelRoutingSubject extends BaseSubject implements RevertibleSubjec
   private readonly modesConfigPath: string;
   private readonly dispatchReader: (since: Date) => Array<Record<string, unknown>>;
   private readonly dispatchReaderInjected: boolean;
+  private readonly costDbPath: string;
 
   constructor(opts: ModelRoutingSubjectConfig = {}) {
     super();
@@ -68,6 +86,61 @@ export class ModelRoutingSubject extends BaseSubject implements RevertibleSubjec
     );
     this.dispatchReaderInjected = opts.dispatchReader !== undefined;
     this.dispatchReader = opts.dispatchReader ?? (() => []);
+    this.costDbPath = expandHome(opts.costDbPath ?? join(homedir(), "agent", "data", "costs.db"));
+  }
+
+  // ── Proactive face: EvidenceDrivenSubject (cost signal + faisceau de preuves) ──
+
+  researchSpec(): ResearchSpec {
+    return {
+      subject: "model_routing",
+      query: "llm routing cost quality model cascade speculative decoding semantic router",
+      sourceTiers: ["enterprise", "authoritative", "papers"],
+      technique: "cost-aware-routing",
+    };
+  }
+
+  async localSignal(): Promise<LocalSignal> {
+    const c = costSignal(this.costDbPath, MODEL_ROUTING_MAX_RECENT_USD);
+    return {
+      metric: "session_cost_usd",
+      value: c.value,
+      unit: "usd",
+      degraded: c.degraded,
+      trend: c.trend,
+      sampledAt: new Date().toISOString(),
+    };
+  }
+
+  evaluate(evidence: StructuredEvidence, signal: LocalSignal): EvidenceVerdict {
+    if (!signal.degraded) {
+      return {
+        propose: false,
+        reason: `routing cost healthy (${signal.value}${signal.unit}, ${signal.trend})`,
+        kind: "recommendation",
+        confidence: 0,
+      };
+    }
+    if (!meetsEvidenceBar(evidence)) {
+      return {
+        propose: false,
+        reason: `evidence below bar for '${evidence.technique}' (${evidence.independentSources} independent, ${evidence.highTrustSources} high-trust)`,
+        kind: "recommendation",
+        confidence: 0.2,
+      };
+    }
+    const confidence = Math.round(Math.min(1, evidence.independentSources / 5) * 100) / 100;
+    return {
+      propose: true,
+      reason: `routing cost ${signal.trend} (${signal.value}${signal.unit}) + ${evidence.independentSources} independent sources for '${evidence.technique}'`,
+      kind: "recommendation",
+      confidence,
+    };
+  }
+
+  async confirm(before: LocalSignal): Promise<boolean> {
+    const after = await this.localSignal();
+    return after.value < before.value;
   }
 
   async collectObservations(since: Date): Promise<Observation[]> {
@@ -243,7 +316,8 @@ export class ModelRoutingSubject extends BaseSubject implements RevertibleSubjec
     const alt = proposal.alternatives.find((a) => a.id === alternativeId);
     if (!alt)
       throw new Error(`model-routing-subject.apply: alternative ${alternativeId} not found`);
-    // Confinement: the only file this subject may write is its managed modes config.
+    // Confinement: the only file this subject may write is its managed modes
+    // config — never engine code or anything outside it.
     this.assertManagedTarget(proposal.target_path);
 
     // Never overwrite an existing .bak. On a double-apply (e.g. an operator
@@ -357,6 +431,7 @@ export class ModelRoutingSubject extends BaseSubject implements RevertibleSubjec
    * REAL paths (parent dir dereferenced via realpath) so a symlinked parent
    * cannot smuggle the write outside the managed config.
    */
+  /** The only writable file: the managed modes config. Anything else → throw. */
   private assertManagedTarget(target: string): void {
     if (isSymlinkPath(target)) {
       throw new Error(`target_path is a symlink — refusing to write through it: ${target}`);

--- a/src/tuner/subjects/model-routing-subject.ts
+++ b/src/tuner/subjects/model-routing-subject.ts
@@ -40,6 +40,7 @@ import {
   proposeBenchmarkReroute,
   type RerouteGateOptions,
 } from "./model-routing-quality.js";
+import { readAgenticModes, setAgenticModel, isRunnableModel } from "./agentic-config.js";
 
 /** Recent median session cost (USD) above which routing is "expensive" regardless of trend. */
 const MODEL_ROUTING_MAX_RECENT_USD = 25;
@@ -73,6 +74,12 @@ export interface ModelRoutingSubjectConfig {
   benchmarkProvider?: (models: string[]) => Promise<ModelBenchmark[]>;
   /** Quality/cost gate tuning for the benchmark reroute. */
   rerouteGate?: RerouteGateOptions;
+  /**
+   * settings.json path — when set, the benchmark reroute reads the REAL agentic
+   * modes (list format) from here and constrains candidates to runnable (Claude)
+   * models, instead of the standalone agentic.yaml. This is the reconciled path.
+   */
+  settingsPath?: string;
 }
 
 export class ModelRoutingSubject
@@ -91,6 +98,7 @@ export class ModelRoutingSubject
   private readonly costDbPath: string;
   private readonly benchmarkProvider: (models: string[]) => Promise<ModelBenchmark[]>;
   private readonly rerouteGate: RerouteGateOptions;
+  private readonly settingsPath?: string;
 
   constructor(opts: ModelRoutingSubjectConfig = {}) {
     super();
@@ -112,6 +120,7 @@ export class ModelRoutingSubject
           cachePath: join(homedir(), ".claude", "tuner-benchmarks.json"),
         }));
     this.rerouteGate = opts.rerouteGate ?? {};
+    this.settingsPath = opts.settingsPath ? expandHome(opts.settingsPath) : undefined;
   }
 
   // ── Proactive face: EvidenceDrivenSubject (cost signal + faisceau de preuves) ──
@@ -182,6 +191,41 @@ export class ModelRoutingSubject
     signal: LocalSignal,
   ): Promise<EvidencePatch | null> {
     if (!signal.degraded) return null;
+    // Fetch the FULL benchmark set (empty filter) — we need CANDIDATES to reroute
+    // to, not just the models already in use.
+    const benchmarks = await this.benchmarkProvider([]);
+    if (benchmarks.length === 0) return null;
+
+    // Reconciled path: read the REAL agentic modes from settings.json (list
+    // format), look models up by their AA slug, and constrain candidates to
+    // runnable (Claude) models — the only thing `claude --model` can launch.
+    if (this.settingsPath) {
+      let raw = "";
+      try {
+        raw = readFileSync(this.settingsPath, "utf8");
+      } catch {
+        return null;
+      }
+      const modes = readAgenticModes(raw);
+      if (modes.length === 0) return null;
+      const assignments = modes.map((m) => ({ key: m.mode, model: m.aaSlug }));
+      const proposals = proposeBenchmarkReroute(assignments, benchmarks, {
+        ...this.rerouteGate,
+        candidateFilter: isRunnableModel,
+      });
+      if (proposals.length === 0) return null;
+      return {
+        target_path: this.settingsPath,
+        alternatives: proposals.map((p) => ({
+          id: `reroute-${p.key}-to-${p.to_model}`,
+          label: `Route '${p.key}' ${p.from_model} → ${p.to_model}`,
+          diff_or_content: setAgenticModel(raw, p.key, p.to_model),
+          tradeoff: p.verdict.reason,
+        })),
+      };
+    }
+
+    // Legacy standalone agentic.yaml (nested-map format).
     let content = "";
     try {
       content = readFileSync(this.modesConfigPath, "utf8");
@@ -190,11 +234,6 @@ export class ModelRoutingSubject
     }
     const assignments = parseModelAssignments(content);
     if (assignments.length === 0) return null;
-    // Fetch the FULL benchmark set (empty filter) — we need CANDIDATES to reroute
-    // to, not just the models already in use. Filtering to the current models
-    // would leave nothing to switch to.
-    const benchmarks = await this.benchmarkProvider([]);
-    if (benchmarks.length === 0) return null;
     const proposals = proposeBenchmarkReroute(assignments, benchmarks, this.rerouteGate);
     return buildRerouteEvidencePatch(content, proposals, this.modesConfigPath);
   }

--- a/src/tuner/subjects/model-routing-subject.ts
+++ b/src/tuner/subjects/model-routing-subject.ts
@@ -41,6 +41,7 @@ import {
   type RerouteGateOptions,
 } from "./model-routing-quality.js";
 import { readAgenticModes, setAgenticModel, isRunnableModel } from "./agentic-config.js";
+import { enrichWithAnthropicCoding } from "./anthropic-benchmarks.js";
 
 /** Recent median session cost (USD) above which routing is "expensive" regardless of trend. */
 const MODEL_ROUTING_MAX_RECENT_USD = 25;
@@ -193,7 +194,7 @@ export class ModelRoutingSubject
     if (!signal.degraded) return null;
     // Fetch the FULL benchmark set (empty filter) — we need CANDIDATES to reroute
     // to, not just the models already in use.
-    const benchmarks = await this.benchmarkProvider([]);
+    const benchmarks = enrichWithAnthropicCoding(await this.benchmarkProvider([]));
     if (benchmarks.length === 0) return null;
 
     // Reconciled path: read the REAL agentic modes from settings.json (list

--- a/src/tuner/subjects/model-routing-subject.ts
+++ b/src/tuner/subjects/model-routing-subject.ts
@@ -102,7 +102,15 @@ export class ModelRoutingSubject
     this.dispatchReader = opts.dispatchReader ?? (() => []);
     this.costDbPath = expandHome(opts.costDbPath ?? join(homedir(), "agent", "data", "costs.db"));
     this.benchmarkProvider =
-      opts.benchmarkProvider ?? ((models) => getModelBenchmarks({ models, nowMs: Date.now() }));
+      opts.benchmarkProvider ??
+      ((models) =>
+        getModelBenchmarks({
+          models,
+          nowMs: Date.now(),
+          // Cache the published benchmarks (24h TTL) so a proactive tick does not
+          // hit the Artificial Analysis API every run (free tier = 1000/day).
+          cachePath: join(homedir(), ".claude", "tuner-benchmarks.json"),
+        }));
     this.rerouteGate = opts.rerouteGate ?? {};
   }
 
@@ -182,7 +190,10 @@ export class ModelRoutingSubject
     }
     const assignments = parseModelAssignments(content);
     if (assignments.length === 0) return null;
-    const benchmarks = await this.benchmarkProvider(assignments.map((a) => a.model));
+    // Fetch the FULL benchmark set (empty filter) — we need CANDIDATES to reroute
+    // to, not just the models already in use. Filtering to the current models
+    // would leave nothing to switch to.
+    const benchmarks = await this.benchmarkProvider([]);
     if (benchmarks.length === 0) return null;
     const proposals = proposeBenchmarkReroute(assignments, benchmarks, this.rerouteGate);
     return buildRerouteEvidencePatch(content, proposals, this.modesConfigPath);

--- a/src/tuner/subjects/model-routing-subject.ts
+++ b/src/tuner/subjects/model-routing-subject.ts
@@ -33,7 +33,7 @@ import {
   meetsEvidenceBar,
 } from "../wisecron/evidence-driven.js";
 import { costSignal } from "./model-routing-signal.js";
-import { getModelBenchmarks, type ModelBenchmark } from "./model-routing-benchmarks.js";
+import type { ModelBenchmark } from "./model-routing-benchmarks.js";
 import {
   buildRerouteEvidencePatch,
   parseModelAssignments,
@@ -110,16 +110,12 @@ export class ModelRoutingSubject
     this.dispatchReaderInjected = opts.dispatchReader !== undefined;
     this.dispatchReader = opts.dispatchReader ?? (() => []);
     this.costDbPath = expandHome(opts.costDbPath ?? join(homedir(), "agent", "data", "costs.db"));
-    this.benchmarkProvider =
-      opts.benchmarkProvider ??
-      ((models) =>
-        getModelBenchmarks({
-          models,
-          nowMs: Date.now(),
-          // Cache the published benchmarks (24h TTL) so a proactive tick does not
-          // hit the Artificial Analysis API every run (free tier = 1000/day).
-          cachePath: join(homedir(), ".claude", "tuner-benchmarks.json"),
-        }));
+    // Feeder-frontier (governance rule): the SUBJECT never fetches the web itself.
+    // A sandboxed feeder / the research scout fetches the published benchmarks and
+    // INJECTS them via benchmarkProvider; with none injected the subject simply has
+    // no external data and proposes nothing (safe). getModelBenchmarks lives here
+    // only as the mechanism the feeder/scout calls — not wired as the default.
+    this.benchmarkProvider = opts.benchmarkProvider ?? (async () => []);
     this.rerouteGate = opts.rerouteGate ?? {};
     this.settingsPath = opts.settingsPath ? expandHome(opts.settingsPath) : undefined;
   }

--- a/src/tuner/subjects/model-routing-subject.ts
+++ b/src/tuner/subjects/model-routing-subject.ts
@@ -40,7 +40,12 @@ import {
   proposeBenchmarkReroute,
   type RerouteGateOptions,
 } from "./model-routing-quality.js";
-import { readAgenticModes, setAgenticModel, isRunnableModel } from "./agentic-config.js";
+import {
+  readAgenticModes,
+  setAgenticModel,
+  isRunnableModel,
+  toLaunchableModel,
+} from "./agentic-config.js";
 import { enrichWithAnthropicCoding } from "./anthropic-benchmarks.js";
 
 /** Recent median session cost (USD) above which routing is "expensive" regardless of trend. */
@@ -210,16 +215,23 @@ export class ModelRoutingSubject
         ...this.rerouteGate,
         candidateFilter: isRunnableModel,
       });
-      if (proposals.length === 0) return null;
-      return {
-        target_path: this.settingsPath,
-        alternatives: proposals.map((p) => ({
-          id: `reroute-${p.key}-to-${p.to_model}`,
-          label: `Route '${p.key}' ${p.from_model} → ${p.to_model}`,
-          diff_or_content: setAgenticModel(raw, p.key, p.to_model),
-          tradeoff: p.verdict.reason,
-        })),
-      };
+      // Write a LAUNCHABLE tier (opus/sonnet/haiku), NEVER the AA slug — an AA
+      // catalog slug is not a valid `--model` value and would break the mode.
+      // Skip a same-tier no-op (target tier == current tier).
+      const alternatives = proposals
+        .map((p) => {
+          const launchable = toLaunchableModel(p.to_model);
+          if (!launchable || launchable === toLaunchableModel(p.from_model)) return null;
+          return {
+            id: `reroute-${p.key}-to-${launchable}`,
+            label: `Route '${p.key}' → ${launchable}`,
+            diff_or_content: setAgenticModel(raw, p.key, launchable),
+            tradeoff: p.verdict.reason,
+          };
+        })
+        .filter((a): a is NonNullable<typeof a> => a !== null);
+      if (alternatives.length === 0) return null;
+      return { target_path: this.settingsPath, alternatives };
     }
 
     // Legacy standalone agentic.yaml (nested-map format).
@@ -509,7 +521,9 @@ export class ModelRoutingSubject
    * Returned real-path-resolved (parent dir dereferenced) for a stable compare.
    */
   managedTargets(): string[] {
-    return [realResolvePath(this.modesConfigPath)];
+    const targets = [realResolvePath(this.modesConfigPath)];
+    if (this.settingsPath) targets.push(realResolvePath(this.settingsPath));
+    return targets;
   }
 
   /**
@@ -528,8 +542,8 @@ export class ModelRoutingSubject
     if (isSymlinkPath(target)) {
       throw new Error(`target_path is a symlink — refusing to write through it: ${target}`);
     }
-    if (realResolvePath(target) !== realResolvePath(this.modesConfigPath)) {
-      throw new Error(`target_path is not the managed modes config: ${target}`);
+    if (!this.managedTargets().includes(realResolvePath(target))) {
+      throw new Error(`target_path is not a managed config: ${target}`);
     }
   }
 


### PR DESCRIPTION
## model_routing proactive evidence face [#275 — Phase 4, subject 2/3]

> **Stacked on #287** (extends its reactive model_routing subject).

Adds the **proactive** `EvidenceDrivenSubject` face to model_routing:
- local signal = median per-session cost (USD) trend (outlier-robust, noise-floored);
- when degraded, asks the feeder for convergent evidence on cost-aware routing;
- a `recommendation`-kind technique (architectural) resolves to a plugin (see #290), never engine code.

Includes the apply/revert **confinement** guard and the cost signal. Reuses the shared `EvidenceDrivenSubject` contract.

Tests green; biome clean.
