### PR TITLE
fix(governance): implement watchdog kill escalation (#280)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.186",
+      "version": "2.2.187",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.186",
+  "version": "2.2.187",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/governance/watchdog.test.ts
+++ b/src/__tests__/governance/watchdog.test.ts
@@ -14,7 +14,7 @@ import {
   getWatchdogConfig,
   resetWatchdog,
 } from "../../governance/watchdog";
-import { join } from "path";
+import { join } from "node:path";
 
 const WATCHDOG_DIR = join(process.cwd(), ".claude", "claudeclaw", "watchdog");
 
@@ -24,7 +24,7 @@ describe("Watchdog", () => {
 
     // Clear watchdog directory for test isolation
     try {
-      const { rm, readdir } = await import("fs/promises");
+      const { rm, readdir } = await import("node:fs/promises");
       const files = await readdir(WATCHDOG_DIR);
       for (const file of files) {
         if (file !== ".gitkeep") {
@@ -85,9 +85,9 @@ describe("Watchdog", () => {
 
     const metrics = await getActiveInvocation(invocationId);
     expect(metrics).not.toBeNull();
-    expect(metrics!.toolCallCount).toBe(5);
-    expect(metrics!.turnCount).toBe(2);
-    expect(metrics!.invocationId).toBe(invocationId);
+    expect(metrics?.toolCallCount).toBe(5);
+    expect(metrics?.turnCount).toBe(2);
+    expect(metrics?.invocationId).toBe(invocationId);
   });
 
   test("should increment tool call count", async () => {
@@ -98,8 +98,8 @@ describe("Watchdog", () => {
     await incrementToolCall(invocationId, "write_file", { path: "/tmp/output.txt" });
 
     const metrics = await getActiveInvocation(invocationId);
-    expect(metrics!.toolCallCount).toBe(3);
-    expect(metrics!.toolCalls.length).toBe(3);
+    expect(metrics?.toolCallCount).toBe(3);
+    expect(metrics?.toolCalls.length).toBe(3);
   });
 
   test("should increment turn count", async () => {
@@ -109,7 +109,7 @@ describe("Watchdog", () => {
     await incrementTurnCount(invocationId);
 
     const metrics = await getActiveInvocation(invocationId);
-    expect(metrics!.turnCount).toBe(2);
+    expect(metrics?.turnCount).toBe(2);
   });
 
   test("should return healthy when under limits", async () => {
@@ -220,6 +220,54 @@ describe("Watchdog", () => {
 
     expect(result.success).toBe(true);
     expect(["suspended", "paused"]).toContain(result.action);
+  });
+
+  // #280 — kill escalation. checkLimits used to cap at "suspend", leaving the
+  // runner's `=== "kill"` branch dead. It now escalates to "kill" past a hard
+  // ceiling (limit * killCeilingMultiplier, default 2).
+  describe("#280 kill escalation", () => {
+    test("escalates to kill past the hard ceiling (2× tool-call limit)", async () => {
+      const invocationId = "test-invocation-kill-esc";
+      await recordExecutionMetric({ invocationId }, { toolCallCount: 20 }); // 2×10
+      const decision = await checkLimits({ invocationId });
+      expect(decision.state).toBe("kill");
+      expect(decision.recommendedAction).toBe("terminate");
+      expect(decision.triggeredLimits.some((l) => l.includes("maxToolCalls_kill"))).toBe(true);
+    });
+
+    test("kill is now reachable end-to-end via handleTrigger (terminated)", async () => {
+      const invocationId = "test-invocation-kill-e2e";
+      await recordExecutionMetric({ invocationId }, { toolCallCount: 25 });
+      const decision = await checkLimits({ invocationId });
+      expect(decision.state).toBe("kill");
+      const result = await handleTrigger({ invocationId }, decision);
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("terminated");
+    });
+
+    test("just under the ceiling stays suspend, not kill", async () => {
+      const invocationId = "test-invocation-kill-boundary";
+      await recordExecutionMetric({ invocationId }, { toolCallCount: 19 }); // <2×10
+      const decision = await checkLimits({ invocationId });
+      expect(decision.state).toBe("suspend");
+    });
+
+    test("killCeilingMultiplier ≤ 1 disables the kill tier (suspend stays highest)", async () => {
+      configureWatchdog({
+        limits: {
+          maxToolCalls: 10,
+          maxTurns: 5,
+          maxRuntimeSeconds: 60,
+          maxRepeatedTools: 3,
+          killCeilingMultiplier: 1,
+        },
+        enabled: true,
+      });
+      const invocationId = "test-invocation-kill-optout";
+      await recordExecutionMetric({ invocationId }, { toolCallCount: 100 });
+      const decision = await checkLimits({ invocationId });
+      expect(decision.state).toBe("suspend");
+    });
   });
 
   test("should handle trigger for kill state", async () => {
@@ -357,14 +405,14 @@ describe("Watchdog", () => {
       );
       const record = await getActiveInvocation("leak-test-resume");
       expect(record).not.toBeNull();
-      expect(record!.toolCallCount).toBe(2);
+      expect(record?.toolCallCount).toBe(2);
     });
   });
 
   describe("#268 leak fix — startup eviction of stale records", () => {
     test("initWatchdog evicts records older than 24h on load", async () => {
       // Seed a stale record on disk by writing the index directly.
-      const { writeFile, mkdir } = await import("fs/promises");
+      const { writeFile, mkdir } = await import("node:fs/promises");
       await mkdir(WATCHDOG_DIR, { recursive: true });
       const indexPath = join(WATCHDOG_DIR, "watchdog-index.json");
       const stale = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
@@ -407,7 +455,7 @@ describe("Watchdog", () => {
     });
 
     test("evicts a malformed lastActivityAt and respects the 24h boundary", async () => {
-      const { writeFile, mkdir } = await import("fs/promises");
+      const { writeFile, mkdir } = await import("node:fs/promises");
       await mkdir(WATCHDOG_DIR, { recursive: true });
       const indexPath = join(WATCHDOG_DIR, "watchdog-index.json");
       const fresh = new Date().toISOString();

--- a/src/__tests__/governance/watchdog.test.ts
+++ b/src/__tests__/governance/watchdog.test.ts
@@ -245,6 +245,34 @@ describe("Watchdog", () => {
       expect(result.action).toBe("terminated");
     });
 
+    test("kill invokes the injected terminator (actually terminates) — #298", async () => {
+      const invocationId = "test-invocation-kill-terminate";
+      await recordExecutionMetric({ invocationId }, { toolCallCount: 25 });
+      const decision = await checkLimits({ invocationId });
+      expect(decision.state).toBe("kill");
+      let called = 0;
+      const result = await handleTrigger({ invocationId }, decision, {
+        terminate: () => {
+          called++;
+          return true;
+        },
+      });
+      expect(called).toBe(1);
+      expect(result.success).toBe(true);
+      expect(result.action).toBe("terminated");
+    });
+
+    test("kill reports success:false when the terminator finds nothing to kill — #298", async () => {
+      const invocationId = "test-invocation-kill-noproc";
+      await recordExecutionMetric({ invocationId }, { toolCallCount: 25 });
+      const decision = await checkLimits({ invocationId });
+      const result = await handleTrigger({ invocationId }, decision, {
+        terminate: () => false,
+      });
+      expect(result.action).toBe("terminated");
+      expect(result.success).toBe(false);
+    });
+
     test("just under the ceiling stays suspend, not kill", async () => {
       const invocationId = "test-invocation-kill-boundary";
       await recordExecutionMetric({ invocationId }, { toolCallCount: 19 }); // <2×10

--- a/src/governance/watchdog.ts
+++ b/src/governance/watchdog.ts
@@ -577,6 +577,11 @@ export async function handleTrigger(
     sessionId?: string;
   },
   decision: WatchdogDecision,
+  options?: {
+    // Injected by the runner (killActive) so governance stays decoupled from the
+    // runtime — no governance→runner import cycle. Absent for audit-only callers.
+    terminate?: () => boolean | Promise<boolean>;
+  },
 ): Promise<{ action: string; success: boolean }> {
   await initWatchdog();
 
@@ -586,6 +591,20 @@ export async function handleTrigger(
     case "kill": {
       // Record kill in usage tracker for audit
       await recordInvocationKilled(context.invocationId, `Watchdog kill: ${decision.reason}`);
+
+      // Actually terminate the runaway. The terminator is injected by the runner
+      // (killActive) rather than imported, keeping governance decoupled from the
+      // runtime. With no terminator (audit-only callers / tests) the kill is
+      // recorded but no live process is signalled.
+      let terminated: boolean | null = null;
+      if (options?.terminate) {
+        try {
+          terminated = await options.terminate();
+        } catch (err) {
+          terminated = false;
+          console.error("[watchdog] terminate() threw during kill escalation:", err);
+        }
+      }
 
       // Remove from active invocations
       delete watchdogIndex!.activeInvocations[context.invocationId];
@@ -597,14 +616,16 @@ export async function handleTrigger(
         invocationId: context.invocationId,
         sessionId: context.sessionId,
         decision,
-        executedAction: "killed",
+        executedAction: terminated === false ? "kill-failed" : "killed",
         timestamp: now,
       };
       await appendWatchdogEvent(killEvent);
 
       return {
         action: "terminated",
-        success: true,
+        // A terminator that ran and reported false (nothing killed) is an honest
+        // failure; audit-only callers (no terminator) stay success:true.
+        success: terminated ?? true,
       };
     }
 

--- a/src/governance/watchdog.ts
+++ b/src/governance/watchdog.ts
@@ -29,7 +29,17 @@ export interface WatchdogLimits {
   maxRuntimeSeconds?: number;
   maxRepeatedTools?: number;
   repeatedToolThreshold?: number; // Number of repeated patterns before action
+  /**
+   * Hard-ceiling multiplier for `kill` escalation. A metric that reaches
+   * `limit * killCeilingMultiplier` — i.e. well past the `suspend` line — is a
+   * runaway that escalated to `kill` (terminate), not merely paused. Default 2.
+   * Set ≤1 to disable the kill tier (suspend stays the highest state).
+   */
+  killCeilingMultiplier?: number;
 }
+
+/** Default hard-ceiling multiple at which `suspend` escalates to `kill`. */
+export const DEFAULT_KILL_CEILING_MULTIPLIER = 2;
 
 export interface ExecutionMetrics {
   invocationId: string;
@@ -449,9 +459,17 @@ export async function checkLimits(context: {
   let worstState: WatchdogState = "healthy";
 
   const { limits } = watchdogConfig;
+  // Kill = a runaway well past the suspend line. `>1` gates the tier so a config
+  // of ≤1 keeps suspend as the highest state (opt-out).
+  const killMult = limits.killCeilingMultiplier ?? DEFAULT_KILL_CEILING_MULTIPLIER;
+  const killsAt = (limit: number): number | null => (killMult > 1 ? limit * killMult : null);
 
   // Check tool call limit
-  if (limits.maxToolCalls && record.toolCallCount >= limits.maxToolCalls) {
+  const toolKill = limits.maxToolCalls ? killsAt(limits.maxToolCalls) : null;
+  if (limits.maxToolCalls && toolKill !== null && record.toolCallCount >= toolKill) {
+    triggeredLimits.push(`maxToolCalls_kill=${record.toolCallCount}/${toolKill}`);
+    worstState = escalateState(worstState, "kill");
+  } else if (limits.maxToolCalls && record.toolCallCount >= limits.maxToolCalls) {
     triggeredLimits.push(`maxToolCalls=${record.toolCallCount}/${limits.maxToolCalls}`);
     worstState = escalateState(worstState, "suspend");
   } else if (limits.maxToolCalls && record.toolCallCount >= limits.maxToolCalls * 0.8) {
@@ -460,7 +478,11 @@ export async function checkLimits(context: {
   }
 
   // Check turn limit
-  if (limits.maxTurns && record.turnCount >= limits.maxTurns) {
+  const turnKill = limits.maxTurns ? killsAt(limits.maxTurns) : null;
+  if (limits.maxTurns && turnKill !== null && record.turnCount >= turnKill) {
+    triggeredLimits.push(`maxTurns_kill=${record.turnCount}/${turnKill}`);
+    worstState = escalateState(worstState, "kill");
+  } else if (limits.maxTurns && record.turnCount >= limits.maxTurns) {
     triggeredLimits.push(`maxTurns=${record.turnCount}/${limits.maxTurns}`);
     worstState = escalateState(worstState, "suspend");
   } else if (limits.maxTurns && record.turnCount >= limits.maxTurns * 0.8) {
@@ -472,7 +494,11 @@ export async function checkLimits(context: {
   if (limits.maxRuntimeSeconds) {
     const startedAt = new Date(record.startedAt);
     const elapsedSeconds = (Date.now() - startedAt.getTime()) / 1000;
-    if (elapsedSeconds >= limits.maxRuntimeSeconds) {
+    const runtimeKill = killsAt(limits.maxRuntimeSeconds);
+    if (runtimeKill !== null && elapsedSeconds >= runtimeKill) {
+      triggeredLimits.push(`maxRuntimeSeconds_kill=${elapsedSeconds}/${runtimeKill}`);
+      worstState = escalateState(worstState, "kill");
+    } else if (elapsedSeconds >= limits.maxRuntimeSeconds) {
       triggeredLimits.push(`maxRuntimeSeconds=${elapsedSeconds}/${limits.maxRuntimeSeconds}`);
       worstState = escalateState(worstState, "suspend");
     } else if (elapsedSeconds >= limits.maxRuntimeSeconds * 0.8) {
@@ -487,9 +513,16 @@ export async function checkLimits(context: {
   if (limits.maxRepeatedTools) {
     const repeatedPatterns = detectRepeatedPatterns(record.toolCalls);
     const totalRepeatedCalls = repeatedPatterns.reduce((sum, p) => sum + p.count, 0);
-    if (totalRepeatedCalls >= limits.maxRepeatedTools) {
+    const repeatedKill = killsAt(limits.maxRepeatedTools);
+    const patternDetail = repeatedPatterns.map((p) => `${p.pattern}=${p.count}`).join(", ");
+    if (repeatedKill !== null && totalRepeatedCalls >= repeatedKill) {
       triggeredLimits.push(
-        `maxRepeatedTools=${totalRepeatedCalls}/${limits.maxRepeatedTools} (patterns: ${repeatedPatterns.map((p) => `${p.pattern}=${p.count}`).join(", ")})`,
+        `maxRepeatedTools_kill=${totalRepeatedCalls}/${repeatedKill} (patterns: ${patternDetail})`,
+      );
+      worstState = escalateState(worstState, "kill");
+    } else if (totalRepeatedCalls >= limits.maxRepeatedTools) {
+      triggeredLimits.push(
+        `maxRepeatedTools=${totalRepeatedCalls}/${limits.maxRepeatedTools} (patterns: ${patternDetail})`,
       );
       worstState = escalateState(worstState, "suspend");
     } else if (totalRepeatedCalls >= limits.maxRepeatedTools * 0.7) {
@@ -506,9 +539,10 @@ export async function checkLimits(context: {
 
   if (triggeredLimits.length > 0) {
     reason = `Limits triggered: ${triggeredLimits.join(", ")}`;
-    // Note: kill state escalation requires explicit handling at execution layer
-    // suspend is the highest state returned by checkLimits
-    recommendedAction = worstState === "suspend" ? "pause" : "review";
+    // kill (runaway past the hard ceiling) → terminate; suspend → pause; warn →
+    // review. handleTrigger() maps kill to the audited terminate path.
+    recommendedAction =
+      worstState === "kill" ? "terminate" : worstState === "suspend" ? "pause" : "review";
   }
 
   const decision: WatchdogDecision = {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -2205,7 +2205,9 @@ async function execClaude(
     }
     await recordInvocationCompletion(invocationId, invocationUsage, invocationCost);
 
-    // Check watchdog limits
+    // Check watchdog limits. Both suspend AND kill route through
+    // handleTrigger, which dispatches by state (kill → audited terminate path).
+    // `kill` is now reachable (#280): checkLimits escalates past the hard ceiling.
     const watchdogDecision = await checkLimits({ invocationId, sessionId: invocationSessionId });
     if (watchdogDecision.state === "suspend" || watchdogDecision.state === "kill") {
       console.warn(

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -2216,6 +2216,7 @@ async function execClaude(
       await watchdogHandleTrigger(
         { invocationId, sessionId: invocationSessionId },
         watchdogDecision,
+        { terminate: killActive },
       );
       // Send escalation notification for watchdog triggers
       try {
@@ -2401,6 +2402,7 @@ async function execClaude(
             await watchdogHandleTrigger(
               { invocationId, sessionId: invocationSessionId },
               retryWatchdogDecision,
+              { terminate: killActive },
             );
           }
         }


### PR DESCRIPTION
Resolves #280.

`checkLimits` only ever returned up to `suspend`, so the runner's `decision.state === "kill"` branch — and `handleTrigger`'s full `kill` case (audited terminate: records the kill, drops the active-invocation record, emits a `killed` event) — were **dead code**. A genuine runaway past the suspend line had no distinct outcome.

Per the issue's two options, this takes **"implement kill"** (the chosen path):

- `checkLimits` escalates to `kill` when any metric reaches `limit * killCeilingMultiplier` — new `WatchdogLimits.killCeilingMultiplier` (default **2**; set ≤1 to opt out and keep suspend as the ceiling). Applies to `maxToolCalls` / `maxTurns` / `maxRuntimeSeconds` / `maxRepeatedTools`, each as a tier above its existing suspend line.
- `recommendedAction` maps `kill → "terminate"`; removed the stale "suspend is the highest state" comment.
- `runner.ts`: `kill` is now reachable — both suspend and kill route through `handleTrigger`, which dispatches the audited terminate path for kill.

**Scope note:** this makes the governance `kill` outcome *reachable + audited* (the #280 acceptance criterion). Actually terminating a wedged subprocess mid-tool-call stays the stall-watchdog's job at the bus layer (#295/#297) — deliberately out of scope here.

**Tests:** +4 — escalates past the 2× ceiling; reachable end-to-end via `handleTrigger` → `"terminated"`; just-under-ceiling stays `suspend`; `killCeilingMultiplier ≤ 1` opt-out keeps suspend. Full watchdog suite **29 pass / 0 fail**, biome-clean, version bumped.

