### PR TITLE
feat(ui): live Kanban board of subagent activity (#294)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.183",
+      "version": "2.2.184",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.183",
+  "version": "2.2.184",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.planning/kanban-live/SPEC.md
+++ b/.planning/kanban-live/SPEC.md
@@ -1,0 +1,139 @@
+# SPEC — Live Kanban board of subagent activity (#294 option B)
+
+## 1. Problem statement
+
+The Web UI ships a **half-built Kanban board**: `src/ui/services/kanban.ts` defines the
+`KanbanBoard`/`KanbanCard` model, the `readKanban`/`writeKanban` persistence, and two
+mutators — `addCardToColumn(column, card)` and `moveCard(id, toColumn, patch?)` — but those
+two mutators have **zero callers**. The only writes today come from the manual `POST /api/kanban`
+"+ Add task" path (`src/ui/server.ts:825`). So the board is a static scratchpad, not a view of
+anything the daemon is actually doing. Issue #294 option B: make it a **live view of subagent
+(Task/Agent) activity** driven off the bus, reusing the mutators that already exist.
+
+## 2. Current behaviour (as-is, with refs)
+
+- **The mutators are unwired.** `addCardToColumn` / `moveCard` (`src/ui/services/kanban.ts:49,58`)
+  each do a read-modify-write of `.claude/claudeclaw/kanban.json`. Nothing in the codebase calls
+  them; the board only changes when a human POSTs a whole board to `/api/kanban`.
+- **The bus already observes every subagent spawn/finish.** The JSONL tailer emits
+  `response.tool_use` (`{id, name, input}`) and `tool_result` (`{tool_use_id, …}`) per session
+  (`src/bus/jsonl-tailer.ts`), plus `session.agent_name`, `session.init`, `session.end`.
+  `BusCore.subscribe(filter, handler)` (`src/bus/core.ts:897`) fans these to any subscriber.
+  A subagent dispatch surfaces as a `response.tool_use` with `name === "Agent"` (or `"Task"`),
+  and its completion as the matching `tool_result` (`tool_use_id === id`).
+- **The proven signal, but per-chat only.** `src/ui/server.ts:778` already maps the runner's
+  `AgentStreamEvent` to SSE `agent_spawn`/`agent_done` — but only for the single interactive
+  chat runner, not globally. The bus path sees *every* session, which is what a board wants.
+- **No serialization guard exists** on the two file mutators: two near-simultaneous bus events
+  would each read-modify-write the same JSON and lose one update.
+
+## 3. Target behaviour (to-be)
+
+A new **`KanbanTracker`** (`src/bus/kanban-tracker.ts`), a pure `BusCore` subscriber (mirrors
+`StallWatchdog`'s structure/quality), that turns subagent lifecycle into board cards:
+
+1. **Spawn → card in `in_progress`.** On `response.tool_use` where `payload.name` is `"Agent"`
+   or `"Task"`: create `{ id: payload.id, title: (input.description ?? input.prompt ?? "subagent").slice(0,120),
+   started_at: ISO(ts), agent_type }` and `addCard("in_progress", card)`. The tool_use `id` is
+   tracked in an in-memory live set keyed by id, and remembered against its session.
+2. **Finish → card to `done`.** On `tool_result` whose `tool_use_id` matches a **tracked** live
+   agent card: `moveCard(id, "done", { completed_at: ISO(ts) })` and drop it from the live set.
+   A `tool_result` for any non-agent tool (unknown id) is ignored — the live set is the filter.
+3. **Orphan sweep.** On `session.end` / `session.init` for a session, every still-open agent card
+   belonging to that session is swept to `done` with `{ completed_at: ISO(ts),
+   agent_type: <type> + " (orphaned)" }` and dropped — the board never accumulates zombie
+   in-progress cards from a crashed/rotated/restarted session (mirrors StallWatchdog's
+   `outstanding.clear()` on the same events).
+4. **`agent_type` resolution (cheap, no over-engineering).** Prefer `input.subagent_type` (the
+   Task/Agent tool's own parameter — the most accurate); else the parent session's cached
+   `session.agent_name`; else the literal `"subagent"`.
+5. **Done-column retention.** After every move-to-done, cap the `done` column to the newest
+   `maxDoneCards` (default 50) via `capDoneColumn` so the board file can't grow unbounded.
+
+**Safety (load-bearing):**
+
+- **Never throw into the bus.** `ingest()` wraps its body; any error is swallowed + logged so a
+  kanban failure can never break the bus handler / take down a session's event flow.
+- **Serialized writes.** `addCardToColumn`/`moveCard`/cap are each a read-modify-write on one
+  JSON file; concurrent bus events race and lose updates. All kanban ops are chained through a
+  single in-tracker promise queue (a tiny mutex), so they apply strictly in order with no lost
+  update. `ingest()` stays synchronous (like StallWatchdog) and merely *enqueues* the async write.
+
+Net: the board becomes a live, self-cleaning view of subagent activity for free off the existing
+bus events, reusing the already-written (but unused) mutators, with the manual "+ Add task" path
+untouched.
+
+## 4. Architecture decisions (frozen)
+
+- **V1 feed = subagent (Task/Agent) lifecycle ONLY, via a global `BusCore` subscriber.** No cron
+  cards, no per-session/main-agent cards — those are **phase 2** (deferred). Rationale: the
+  Task/Agent tool_use → tool_result pair is the cleanest, already-proven start/finish signal, and
+  a global bus subscriber sees every session (unlike the per-chat runner SSE path). Structure/
+  quality mirrors `StallWatchdog`: pure `ingest`, injected deps for testability, never throws into
+  the bus, no unref'd timer needed.
+- **Injected deps, bound in production to bus + kanban service.** Ctor takes
+  `{ subscribe(handler), addCard(col, card), moveCard(id, col, patch), capDone(max), now(), log? }`
+  so tests feed a fake bus + recorder mutators + injected clock; production binds them to
+  `bus.subscribe(...)`, the kanban service functions, and `Date.now`.
+- **Card lifecycle = one card per subagent tool_use id.** `in_progress` on spawn → `done` on the
+  matching `tool_result`, or `done (orphaned)` on session end/init. Card `id` **is** the
+  `tool_use` id, so spawn/finish correlate with zero extra bookkeeping and re-adds are idempotent
+  (a duplicate tool_use for a live id is ignored).
+- **Orphan policy = sweep-on-session-boundary, not a timer.** `session.end`/`session.init` are the
+  authoritative "this session's in-flight work is gone" signals (same ones StallWatchdog clears
+  on); sweeping there is deterministic and needs no periodic tick. In-memory state is intentionally
+  ephemeral — a daemon restart legitimately starts with no live cards.
+- **Single-writer via an in-tracker promise queue.** The kanban JSON is a single shared file and
+  the mutators are read-modify-write; the tracker is the one component issuing bus-driven writes,
+  so serializing *inside* the tracker (chain every op on one promise) is sufficient and keeps the
+  mutator signatures unchanged. (Rejected: a file lock / changing the mutators to be atomic — more
+  surface than needed for one writer.)
+- **Retention = cap `done` to newest N on each move (default 50), not a timer.** Capping on write
+  bounds file growth without a sweep loop. `capDoneColumn(board, max)` is a pure fn added to the
+  kanban service; `capDoneCards(max)` is its read-cap-write convenience, called through the same
+  serialized queue.
+- **Gated ON by default, overridable** via `settings.kanban.enabled` (mirrors how bus features
+  flag). Absent config ⇒ enabled. `enabled:false` ⇒ `start()` is a no-op subscriber-wise.
+- **In-memory only.** Matches `StallWatchdog` / `src/watchdog.ts`: a restarted daemon has no live
+  subagents to track, so nothing is persisted beyond the board file itself.
+
+## 5. Key file references
+
+**New:**
+- `src/bus/kanban-tracker.ts` — the `KanbanTracker` subscriber: config
+  (`KanbanTrackerConfig { enabled, maxDoneCards }` + `DEFAULT_KANBAN_CONFIG`), injected
+  `KanbanTrackerDeps`, synchronous `ingest(BusEvent)` (never throws), serialized write queue,
+  live-card + per-session tracking, orphan sweep, `agent_type` resolution, `start()`/`stop()`.
+- `src/bus/__tests__/kanban-tracker.test.ts` — fake bus + recorder `addCard`/`moveCard`/`capDone`
+  + injected clock. Covers spawn→in_progress, finish→done, non-Agent tool_use ignored, unknown
+  tool_result ignored, session.end orphan sweep, write serialization / no lost update, plus a
+  `capDoneColumn` unit test.
+
+**Modify:**
+- `src/ui/services/kanban.ts` — add `capDoneColumn(board, max=50)` (pure; keep newest `max`) and
+  `capDoneCards(max=50)` (read-cap-write convenience). Existing helper signatures unchanged.
+- `src/commands/start.ts` — instantiate `KanbanTracker` in the deferred-spawn block right after
+  `attachScheduler` (bus + agents up), deps bound to `bus.subscribe(...)` + the kanban service +
+  `Date.now`; `start()` it; `stop()` it in `shutdown()` alongside `busRuntimeHandle.stop()` and in
+  the deferred-spawn rollback. Gated on `currentSettings.kanban?.enabled !== false`.
+- `src/config.ts` — add optional `kanban?: KanbanSettings { enabled: boolean }` to `Settings` and
+  parse it (default enabled when the block is present but `enabled` isn't `false`).
+
+**Reference (reuse, do not duplicate):**
+- `src/bus/stall-watchdog.ts` — the structural/quality template (pure ingest, injected deps,
+  session-keyed state, `outstanding.clear()` on session.end/init, `start()/stop()`).
+- `src/bus/core.ts:897` (`subscribe`), `src/bus/core-subscription.ts` (`SubscriptionFilter`
+  topic filter), `src/bus/jsonl-tailer.ts` (event topics/shapes).
+- `src/ui/services/kanban.ts:49,58` (`addCardToColumn` / `moveCard` — the mutators being wired).
+
+## 6. Out of scope (deferred)
+
+- **Cron/scheduled-job cards** and **per-session / main-agent cards** — phase 2. V1 is
+  subagent-only.
+- **A `todo` feed.** V1 never writes `todo`; cards are born `in_progress`. (The manual "+ Add task"
+  path can still create `todo` cards and is left working.)
+- **Live push to the browser** (SSE/websocket board updates). The board file is updated live;
+  the UI still polls `GET /api/kanban`. Real-time push is a later UI concern.
+- **Persisting tracker state across daemon restarts** — intentionally not done (in-memory only).
+- **Reconciling manual cards with tracked cards** — the manual POST path owns whatever the human
+  puts there; the tracker only ever touches cards keyed by a real subagent tool_use id.

--- a/src/bus/__tests__/kanban-tracker.test.ts
+++ b/src/bus/__tests__/kanban-tracker.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from "bun:test";
+import type { BusEvent, BusEventTopic } from "../types";
+import { KanbanTracker, DEFAULT_KANBAN_CONFIG, type KanbanTrackerDeps } from "../kanban-tracker";
+import { capDoneColumn, type KanbanBoard, type KanbanCard } from "../../ui/services/kanban";
+
+function evt(
+  topic: BusEventTopic,
+  ts: number,
+  payload: unknown,
+  agent = "reg",
+  session = "s1",
+): BusEvent {
+  return { ts, agent_id: agent, session_id: session, topic, payload };
+}
+
+interface Recorder {
+  added: Array<{ column: string; card: KanbanCard }>;
+  moved: Array<{ id: string; column: string; patch?: Partial<KanbanCard> }>;
+  capped: number[];
+  /** Records completion ORDER of the serialized async ops. */
+  order: string[];
+}
+
+/** Deps whose async mutators resolve on a microtask, so overlapping enqueues
+ *  would interleave if the tracker did NOT serialize them. */
+function recordingDeps(delayFirst?: boolean): {
+  deps: KanbanTrackerDeps;
+  rec: Recorder;
+} {
+  const rec: Recorder = { added: [], moved: [], capped: [], order: [] };
+  let firstAdd = true;
+  const deps: KanbanTrackerDeps = {
+    subscribe: () => () => {},
+    addCard: async (column, card) => {
+      // First add is deliberately slow (two extra microtasks) to prove ops are
+      // serialized: a second add must still land AFTER this one completes.
+      if (delayFirst && firstAdd) {
+        firstAdd = false;
+        await Promise.resolve();
+        await Promise.resolve();
+      }
+      rec.added.push({ column, card });
+      rec.order.push(`add:${card.id}`);
+    },
+    moveCard: async (id, column, patch) => {
+      rec.moved.push({ id, column, patch });
+      rec.order.push(`move:${id}`);
+    },
+    capDone: async (max) => {
+      rec.capped.push(max);
+    },
+    now: () => 123,
+    log: () => {},
+  };
+  return { deps, rec };
+}
+
+const ISO0 = new Date(0).toISOString();
+
+describe("KanbanTracker — subagent lifecycle", () => {
+  it("Agent spawn → addCard(in_progress) with started_at + agent_type", async () => {
+    const { deps, rec } = recordingDeps();
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    wd.ingest(
+      evt("response.tool_use", 0, {
+        id: "a1",
+        name: "Agent",
+        input: { description: "do a thing", subagent_type: "Explore" },
+      }),
+    );
+    await wd.flush();
+    expect(rec.added).toHaveLength(1);
+    expect(rec.added[0]?.column).toBe("in_progress");
+    expect(rec.added[0]?.card).toMatchObject({
+      id: "a1",
+      title: "do a thing",
+      started_at: ISO0,
+      agent_type: "Explore",
+    });
+  });
+
+  it("Task tool is tracked too; title falls back to prompt then truncates to 120", async () => {
+    const { deps, rec } = recordingDeps();
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    const long = "x".repeat(300);
+    wd.ingest(evt("response.tool_use", 0, { id: "t1", name: "Task", input: { prompt: long } }));
+    await wd.flush();
+    expect(rec.added[0]?.card.title).toHaveLength(120);
+    expect(rec.added[0]?.card.agent_type).toBe("subagent"); // no subagent_type/name → default
+  });
+
+  it("matching tool_result → moveCard(done, completed_at) + caps done", async () => {
+    const { deps, rec } = recordingDeps();
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    wd.ingest(evt("response.tool_use", 0, { id: "a1", name: "Agent", input: {} }));
+    wd.ingest(evt("tool_result", 5000, { tool_use_id: "a1" }));
+    await wd.flush();
+    expect(rec.moved).toHaveLength(1);
+    expect(rec.moved[0]).toMatchObject({
+      id: "a1",
+      column: "done",
+      patch: { completed_at: new Date(5000).toISOString() },
+    });
+    expect(rec.capped).toEqual([DEFAULT_KANBAN_CONFIG.maxDoneCards]);
+  });
+
+  it("a non-Agent tool_use is ignored (no card)", async () => {
+    const { deps, rec } = recordingDeps();
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    wd.ingest(evt("response.tool_use", 0, { id: "b1", name: "Bash", input: { command: "ls" } }));
+    await wd.flush();
+    expect(rec.added).toHaveLength(0);
+  });
+
+  it("a tool_result with an unknown/untracked id is ignored", async () => {
+    const { deps, rec } = recordingDeps();
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    // Bash result, and an unrelated agent result — neither was tracked.
+    wd.ingest(evt("tool_result", 100, { tool_use_id: "bash-xyz" }));
+    wd.ingest(evt("tool_result", 200, { tool_use_id: "never-spawned" }));
+    await wd.flush();
+    expect(rec.moved).toHaveLength(0);
+  });
+
+  it("session.end sweeps an open card to done (orphaned)", async () => {
+    const { deps, rec } = recordingDeps();
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    wd.ingest(
+      evt("response.tool_use", 0, { id: "a1", name: "Agent", input: { subagent_type: "Plan" } }),
+    );
+    wd.ingest(evt("session.end", 9000, {}));
+    await wd.flush();
+    expect(rec.moved).toHaveLength(1);
+    expect(rec.moved[0]).toMatchObject({
+      id: "a1",
+      column: "done",
+      patch: { completed_at: new Date(9000).toISOString(), agent_type: "Plan (orphaned)" },
+    });
+    // A later stray result for the swept card is now ignored (dropped from live set).
+    wd.ingest(evt("tool_result", 9500, { tool_use_id: "a1" }));
+    await wd.flush();
+    expect(rec.moved).toHaveLength(1);
+  });
+
+  it("session.init also sweeps orphans of that session", async () => {
+    const { deps, rec } = recordingDeps();
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    wd.ingest(evt("response.tool_use", 0, { id: "a1", name: "Agent", input: {} }));
+    wd.ingest(evt("session.init", 7000, {}));
+    await wd.flush();
+    expect(rec.moved).toHaveLength(1);
+    expect(rec.moved[0]?.patch?.agent_type).toBe("subagent (orphaned)");
+  });
+
+  it("only sweeps orphans of the ENDING session, not other sessions", async () => {
+    const { deps, rec } = recordingDeps();
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    wd.ingest(evt("response.tool_use", 0, { id: "s1a", name: "Agent", input: {} }, "reg", "s1"));
+    wd.ingest(evt("response.tool_use", 0, { id: "s2a", name: "Agent", input: {} }, "reg", "s2"));
+    wd.ingest(evt("session.end", 9000, {}, "reg", "s1"));
+    await wd.flush();
+    expect(rec.moved).toHaveLength(1);
+    expect(rec.moved[0]?.id).toBe("s1a");
+  });
+
+  it("session.agent_name cache is used as agent_type fallback", async () => {
+    const { deps, rec } = recordingDeps();
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    wd.ingest(evt("session.agent_name", 0, { agentName: "suzy" }));
+    wd.ingest(evt("response.tool_use", 1, { id: "a1", name: "Agent", input: {} }));
+    await wd.flush();
+    expect(rec.added[0]?.card.agent_type).toBe("suzy");
+  });
+
+  it("a duplicate spawn for a live id is ignored (idempotent)", async () => {
+    const { deps, rec } = recordingDeps();
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    wd.ingest(evt("response.tool_use", 0, { id: "a1", name: "Agent", input: {} }));
+    wd.ingest(evt("response.tool_use", 1, { id: "a1", name: "Agent", input: {} }));
+    await wd.flush();
+    expect(rec.added).toHaveLength(1);
+  });
+
+  it("writes are serialized — a slow add still completes before the next op (no lost update)", async () => {
+    const { deps, rec } = recordingDeps(/* delayFirst */ true);
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    // Fire two spawns back-to-back; the first add is artificially slow.
+    wd.ingest(evt("response.tool_use", 0, { id: "a1", name: "Agent", input: {} }));
+    wd.ingest(evt("response.tool_use", 1, { id: "a2", name: "Agent", input: {} }));
+    await wd.flush();
+    // Despite a1's add being slow, ops applied strictly in enqueue order.
+    expect(rec.order).toEqual(["add:a1", "add:a2"]);
+  });
+
+  it("ingest never throws even on a malformed payload", async () => {
+    const { deps } = recordingDeps();
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, deps);
+    expect(() => wd.ingest(evt("response.tool_use", 0, null))).not.toThrow();
+    expect(() => wd.ingest(evt("tool_result", 0, undefined))).not.toThrow();
+    await wd.flush();
+  });
+
+  it("disabled tracker does not subscribe", () => {
+    const { deps } = recordingDeps();
+    let subscribed = false;
+    const wd = new KanbanTracker(
+      { ...DEFAULT_KANBAN_CONFIG, enabled: false },
+      {
+        ...deps,
+        subscribe: () => {
+          subscribed = true;
+          return () => {};
+        },
+      },
+    );
+    wd.start();
+    expect(subscribed).toBe(false);
+  });
+
+  it("start() wires ingest to the bus; stop() unsubscribes + clears state", async () => {
+    const { deps, rec } = recordingDeps();
+    let handler: ((e: BusEvent) => void) | null = null;
+    let closed = false;
+    const wd = new KanbanTracker(DEFAULT_KANBAN_CONFIG, {
+      ...deps,
+      subscribe: (h) => {
+        handler = h;
+        return () => {
+          closed = true;
+        };
+      },
+    });
+    wd.start();
+    expect(handler).not.toBeNull();
+    (handler as unknown as (e: BusEvent) => void)(
+      evt("response.tool_use", 0, { id: "a1", name: "Agent", input: {} }),
+    );
+    await wd.flush();
+    expect(rec.added).toHaveLength(1);
+    wd.stop();
+    expect(closed).toBe(true);
+  });
+});
+
+/* ── capDoneColumn (pure) ──────────────────────────────────────────────────── */
+
+describe("capDoneColumn", () => {
+  const board = (n: number): KanbanBoard => ({
+    columns: {
+      todo: [],
+      in_progress: [],
+      done: Array.from({ length: n }, (_, i) => ({ id: `d${i}`, title: `d${i}` })),
+    },
+  });
+
+  it("keeps the newest `max` (head) cards and drops the rest", () => {
+    const b = capDoneColumn(board(5), 2);
+    expect(b.columns.done.map((c) => c.id)).toEqual(["d0", "d1"]);
+  });
+
+  it("leaves the board unchanged when already at/under max", () => {
+    const b = capDoneColumn(board(2), 5);
+    expect(b.columns.done).toHaveLength(2);
+  });
+
+  it("defaults to 50", () => {
+    const b = capDoneColumn(board(60));
+    expect(b.columns.done).toHaveLength(50);
+  });
+});

--- a/src/bus/kanban-tracker.ts
+++ b/src/bus/kanban-tracker.ts
@@ -1,0 +1,241 @@
+/**
+ * Kanban Tracker — turns subagent (Task/Agent) lifecycle into live board cards.
+ *
+ * The Web UI's Kanban board (`src/ui/services/kanban.ts`) shipped with working
+ * `addCardToColumn` / `moveCard` mutators but ZERO callers — a static scratchpad,
+ * not a view of anything the daemon does (#294). This subscriber wires those
+ * mutators to the bus event stream so the board becomes a LIVE view of subagent
+ * activity:
+ *
+ *   - a subagent dispatch (`response.tool_use`, name `Agent`/`Task`) → a card in
+ *     `in_progress`,
+ *   - its completion (`tool_result` with the matching `tool_use_id`) → the card
+ *     moves to `done`,
+ *   - a session ending/restarting (`session.end` / `session.init`) sweeps that
+ *     session's still-open cards to `done (orphaned)` so the board never
+ *     accumulates zombies.
+ *
+ * Structure mirrors `StallWatchdog`: a pure `BusCore` subscriber with injected
+ * deps for testability, a synchronous `ingest()` that NEVER throws into the bus,
+ * and no timer (retention is capped on each move, not swept). V1 feed is
+ * subagent-only; cron / per-session cards are phase 2.
+ *
+ * SAFETY: `addCard`/`moveCard`/cap are read-modify-write on ONE JSON file, so
+ * concurrent bus events would race and lose updates. Every kanban op is chained
+ * through a single in-tracker promise queue (a tiny mutex) so writes apply
+ * strictly in order. SPEC: `.planning/kanban-live/SPEC.md`.
+ */
+
+import type { BusEvent } from "./types";
+import type { KanbanBoard, KanbanCard } from "../ui/services/kanban";
+
+/* ── Config ──────────────────────────────────────────────────────────────── */
+
+export interface KanbanTrackerConfig {
+  enabled: boolean;
+  /** Cap the `done` column to this many newest cards after each move-to-done. */
+  maxDoneCards: number;
+}
+
+export const DEFAULT_KANBAN_CONFIG: KanbanTrackerConfig = {
+  enabled: true,
+  maxDoneCards: 50,
+};
+
+/** Board column key. */
+type Column = keyof KanbanBoard["columns"];
+
+/** Tool names that dispatch a subagent (the only signal V1 tracks). */
+const AGENT_TOOL_NAMES: ReadonlySet<string> = new Set(["Agent", "Task"]);
+
+/* ── Dependencies (injected — mirrors StallWatchdogDeps) ─────────────────── */
+
+export interface KanbanTrackerDeps {
+  /** Subscribe to the bus event stream; returns an unsubscribe fn. */
+  subscribe(handler: (e: BusEvent) => void): () => void;
+  /** Prepend a card to a column (kanban service `addCardToColumn`). */
+  addCard(column: Column, card: KanbanCard): Promise<void>;
+  /** Move a card to a column, applying a patch (kanban service `moveCard`). */
+  moveCard(id: string, column: Column, patch?: Partial<KanbanCard>): Promise<void>;
+  /** Cap the `done` column to `max` newest cards (kanban service `capDoneCards`). */
+  capDone(max: number): Promise<void>;
+  /** Clock seam (tests inject a deterministic clock). */
+  now(): number;
+  /** Optional log sink for swallowed errors. */
+  log?(message: string, err?: unknown): void;
+}
+
+/* ── Per-card tracking ───────────────────────────────────────────────────── */
+
+interface LiveCard {
+  /** `agentId session_id` key of the session that spawned this subagent. */
+  sessionKey: string;
+  /** Resolved agent_type, reused when sweeping an orphan. */
+  agentType: string;
+}
+
+/* ── The tracker ─────────────────────────────────────────────────────────── */
+
+export class KanbanTracker {
+  /** tool_use id → live in-progress agent card metadata. */
+  private readonly live = new Map<string, LiveCard>();
+  /** session key → set of live tool_use ids, for orphan sweeps. */
+  private readonly sessions = new Map<string, Set<string>>();
+  /** agent_id → last `session.agent_name`, a fallback for agent_type. */
+  private readonly agentNames = new Map<string, string>();
+  /** Serializes all kanban writes so read-modify-write ops can't lose updates. */
+  private queue: Promise<unknown> = Promise.resolve();
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(
+    private readonly config: KanbanTrackerConfig,
+    private readonly deps: KanbanTrackerDeps,
+  ) {}
+
+  private key(agentId: string, sessionId: string): string {
+    // Space delimiter (agent + session ids never contain spaces), matching
+    // StallWatchdog's session keying.
+    return `${agentId} ${sessionId}`;
+  }
+
+  /** Chain a kanban write onto the single serialized queue; errors are swallowed
+   *  + logged so one failed write never breaks the chain or the bus handler. */
+  private enqueue(fn: () => Promise<void>): void {
+    this.queue = this.queue.then(fn).catch((err) => {
+      this.deps.log?.("kanban write failed", err);
+    });
+  }
+
+  /** Await all currently-queued writes (test seam). */
+  async flush(): Promise<void> {
+    await this.queue;
+  }
+
+  /** Feed one bus event into the tracker. NEVER throws (swallows + logs). */
+  ingest(e: BusEvent): void {
+    try {
+      this.ingestInner(e);
+    } catch (err) {
+      this.deps.log?.("kanban ingest failed", err);
+    }
+  }
+
+  private ingestInner(e: BusEvent): void {
+    const key = this.key(e.agent_id, e.session_id);
+    switch (e.topic) {
+      case "session.agent_name": {
+        const name = (e.payload as { agentName?: string })?.agentName;
+        if (typeof name === "string" && name.trim()) this.agentNames.set(e.agent_id, name.trim());
+        break;
+      }
+
+      case "response.tool_use": {
+        const p = e.payload as {
+          id?: string;
+          name?: string;
+          input?: Record<string, unknown>;
+        };
+        if (!p?.id || typeof p.name !== "string" || !AGENT_TOOL_NAMES.has(p.name)) break;
+        if (this.live.has(p.id)) break; // idempotent — ignore a duplicate spawn for a live id
+
+        const input = p.input ?? {};
+        const rawTitle =
+          (typeof input.description === "string" && input.description) ||
+          (typeof input.prompt === "string" && input.prompt) ||
+          "subagent";
+        const agentType = this.resolveAgentType(e.agent_id, input);
+        const card: KanbanCard = {
+          id: p.id,
+          title: rawTitle.slice(0, 120),
+          started_at: new Date(e.ts).toISOString(),
+          agent_type: agentType,
+        };
+
+        this.live.set(p.id, { sessionKey: key, agentType });
+        let set = this.sessions.get(key);
+        if (!set) {
+          set = new Set();
+          this.sessions.set(key, set);
+        }
+        set.add(p.id);
+
+        this.enqueue(() => this.deps.addCard("in_progress", card));
+        break;
+      }
+
+      case "tool_result": {
+        const id = (e.payload as { tool_use_id?: string })?.tool_use_id;
+        if (!id) break;
+        const meta = this.live.get(id);
+        if (!meta) break; // not a tracked agent card (e.g. a Bash result) → ignore
+        this.forget(id, meta.sessionKey);
+        const completedAt = new Date(e.ts).toISOString();
+        this.enqueue(async () => {
+          await this.deps.moveCard(id, "done", { completed_at: completedAt });
+          await this.deps.capDone(this.config.maxDoneCards);
+        });
+        break;
+      }
+
+      // A session ending or (re)initialising means its in-flight subagents are
+      // gone — sweep them to done so the board never keeps zombie cards. Mirrors
+      // StallWatchdog clearing `outstanding` on the same events.
+      case "session.end":
+      case "session.init":
+        this.sweepSession(key, e.ts);
+        break;
+    }
+  }
+
+  /** Prefer the Task/Agent tool's own `subagent_type`; else the parent session's
+   *  cached agent name; else the literal "subagent". Cheap, no over-engineering. */
+  private resolveAgentType(agentId: string, input: Record<string, unknown>): string {
+    const sub = input.subagent_type;
+    if (typeof sub === "string" && sub.trim()) return sub.trim();
+    const cached = this.agentNames.get(agentId);
+    if (cached) return cached;
+    return "subagent";
+  }
+
+  private forget(id: string, sessionKey: string): void {
+    this.live.delete(id);
+    const set = this.sessions.get(sessionKey);
+    if (set) {
+      set.delete(id);
+      if (set.size === 0) this.sessions.delete(sessionKey);
+    }
+  }
+
+  private sweepSession(key: string, ts: number): void {
+    const ids = this.sessions.get(key);
+    if (!ids || ids.size === 0) {
+      this.sessions.delete(key);
+      return;
+    }
+    const completedAt = new Date(ts).toISOString();
+    for (const id of ids) {
+      const meta = this.live.get(id);
+      this.live.delete(id);
+      const agentType = `${meta?.agentType ?? "subagent"} (orphaned)`;
+      this.enqueue(async () => {
+        await this.deps.moveCard(id, "done", { completed_at: completedAt, agent_type: agentType });
+        await this.deps.capDone(this.config.maxDoneCards);
+      });
+    }
+    this.sessions.delete(key);
+  }
+
+  /** Begin observing. No-op when disabled or already started. */
+  start(): void {
+    if (!this.config.enabled || this.unsubscribe) return;
+    this.unsubscribe = this.deps.subscribe((e) => this.ingest(e));
+  }
+
+  stop(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.live.clear();
+    this.sessions.clear();
+    this.agentNames.clear();
+  }
+}

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -474,6 +474,10 @@ export async function start(args: string[] = []) {
   // trigger routes (jobs/fire, inject, chat) instead of spawning a
   // sidecar PTY claude that would race the bus's own session.
   let busCoreForWebUi: import("../bus/core").BusCore | null = null;
+  // #294: live Kanban board of subagent activity — a global bus subscriber that
+  // turns Task/Agent tool_use → tool_result into board cards. Instantiated in the
+  // deferred-spawn block once the bus + agents are up; stopped on teardown.
+  let kanbanTracker: import("../bus/kanban-tracker").KanbanTracker | null = null;
 
   // Plugin system — initialize before gateway start
   const pluginManager = new PluginManager(process.cwd());
@@ -621,6 +625,15 @@ export async function start(args: string[] = []) {
     if (discordStopGateway) discordStopGateway();
     if (slackStopFn) slackStopFn();
     if (web) web.stop();
+    // #294: unsubscribe the kanban tracker before the bus stops.
+    if (kanbanTracker) {
+      try {
+        kanbanTracker.stop();
+      } catch (err) {
+        console.error("[kanban-tracker] shutdown failed", err);
+      }
+      kanbanTracker = null;
+    }
     if (busRuntimeHandle) {
       try {
         await busRuntimeHandle.stop();
@@ -954,6 +967,48 @@ export async function start(args: string[] = []) {
       });
       busRuntimeHandle.attachScheduler(schedulerHandle);
 
+      // #294: mount the live Kanban tracker now that the bus + agents are up.
+      // A pure global bus subscriber — maps subagent (Task/Agent) tool_use →
+      // tool_result onto the Web UI board via the (previously unwired) kanban
+      // mutators. Gated ON by default (`settings.kanban.enabled`). Stopped in
+      // shutdown() and in the deferred-spawn rollback below.
+      if (currentSettings.kanban?.enabled !== false) {
+        try {
+          const { KanbanTracker } = await import("../bus/kanban-tracker");
+          const kanbanSvc = await import("../ui/services/kanban");
+          const bus = busRuntimeHandle.bus;
+          kanbanTracker = new KanbanTracker(
+            { enabled: true, maxDoneCards: kanbanSvc.DEFAULT_MAX_DONE_CARDS },
+            {
+              subscribe: (handler) => {
+                const sub = bus.subscribe(
+                  {
+                    topics: [
+                      "response.tool_use",
+                      "tool_result",
+                      "session.end",
+                      "session.init",
+                      "session.agent_name",
+                    ],
+                  },
+                  handler,
+                );
+                return () => sub.close();
+              },
+              addCard: kanbanSvc.addCardToColumn,
+              moveCard: kanbanSvc.moveCard,
+              capDone: kanbanSvc.capDoneCards,
+              now: () => Date.now(),
+              log: (msg, err) => console.warn(`[${ts()}] kanban-tracker: ${msg}`, err),
+            },
+          );
+          kanbanTracker.start();
+        } catch (kbErr) {
+          console.warn(`[${ts()}] kanban tracker mount failed (non-fatal):`, kbErr);
+          kanbanTracker = null;
+        }
+      }
+
       // Issue #166: write the architecture doc only after the bus booted
       // end-to-end (spawn + scheduler), so a doc on disk always reflects a
       // genuinely-running bus. Best-effort — a missing doc degrades agent
@@ -979,6 +1034,17 @@ export async function start(args: string[] = []) {
         `[${ts()}] Bus runtime: deferred agent spawn failed — tearing down and falling back to legacy command surfaces`,
         spawnErr,
       );
+      // #294: tear down the kanban subscriber alongside the bus on rollback.
+      // Inside this catch, `kanbanTracker` narrows to `never` purely as a tsc
+      // error-recovery artifact cascading from the pre-existing type errors
+      // upstream in this fn (~L832); the value is correct at runtime, so cast
+      // through the real shape to keep the teardown typechecking.
+      try {
+        (kanbanTracker as { stop(): void } | null)?.stop();
+      } catch {
+        /* best-effort */
+      }
+      kanbanTracker = null;
       try {
         await busRuntimeHandle.stop();
       } catch (stopErr) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -703,6 +703,16 @@ export interface Settings {
   memorySearch: MemorySearchSettings;
   llmRouter: LlmRouterConfig;
   jobsDir?: string;
+  /**
+   * Live Kanban board of subagent activity (#294). Optional; when absent the
+   * tracker defaults ON. Set `{ enabled: false }` to disable the bus-driven
+   * board feed (the manual `/api/kanban` "+ Add task" path is unaffected).
+   */
+  kanban?: KanbanSettings;
+}
+
+export interface KanbanSettings {
+  enabled: boolean;
 }
 
 /**
@@ -1125,6 +1135,11 @@ function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Set
       typeof raw.apiToken === "string" && raw.apiToken.trim() ? raw.apiToken.trim() : undefined,
     ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim()
       ? { jobsDir: raw.jobsDir.trim() }
+      : {}),
+    // #294: live Kanban board of subagent activity. Present-but-not-false ⇒
+    // enabled; absent block leaves `kanban` undefined (tracker treats as ON).
+    ...(raw.kanban && typeof raw.kanban === "object"
+      ? { kanban: { enabled: (raw.kanban as { enabled?: unknown }).enabled !== false } }
       : {}),
   };
 }

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -1751,7 +1751,9 @@ async function loadKanban() {
 
 async function saveKanban() {
   try {
-    await fetch("/api/kanban", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(kanbanData) });
+    // mutatingFetch (not raw fetch): POST /api/kanban is CSRF-guarded, so a
+    // plain fetch 403s and the write is silently dropped (this catch swallows it).
+    await mutatingFetch("/api/kanban", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(kanbanData) });
   } catch (_) {}
 }
 

--- a/src/ui/services/kanban.ts
+++ b/src/ui/services/kanban.ts
@@ -75,3 +75,29 @@ export async function moveCard(
     await writeKanban(board);
   }
 }
+
+export const DEFAULT_MAX_DONE_CARDS = 50;
+
+/**
+ * Cap the `done` column to the newest `max` cards, in place. Cards are unshifted
+ * newest-first, so keeping the head (`slice(0, max)`) keeps the most recent.
+ * Pure — mutates + returns the given board, no I/O. Used to bound the board file
+ * so a long-lived daemon's finished-subagent cards can't grow without limit.
+ */
+export function capDoneColumn(
+  board: KanbanBoard,
+  max: number = DEFAULT_MAX_DONE_CARDS,
+): KanbanBoard {
+  if (max >= 0 && board.columns.done.length > max) {
+    board.columns.done = board.columns.done.slice(0, max);
+  }
+  return board;
+}
+
+/** read → {@link capDoneColumn} → write convenience. No-op write when already under `max`. */
+export async function capDoneCards(max: number = DEFAULT_MAX_DONE_CARDS): Promise<void> {
+  const board = await readKanban();
+  if (board.columns.done.length <= max) return;
+  capDoneColumn(board, max);
+  await writeKanban(board);
+}


### PR DESCRIPTION
Resolves #294 — takes **option B** (wire it), the choice made over the issue's default "remove".

The Kanban tab shipped with working `addCardToColumn`/`moveCard` mutators and a card shape carrying `started_at`/`completed_at`/`agent_type` — but **zero callers**: a static sticky-note board wearing an agent-tracker's clothes. This wires it to the bus so it becomes a **live view of subagent activity**.

## What it does (V1 = subagent-only feed)
A global `BusCore` subscriber (`src/bus/kanban-tracker.ts`, structured like `StallWatchdog`):
- `response.tool_use` where name is `Agent`/`Task` → a card in **in_progress** (id = tool_use id, title = description/prompt, `started_at`, `agent_type`).
- matching `tool_result` → `moveCard(…, "done", { completed_at })`, then caps the `done` column to the newest 50.
- `session.end` / `session.init` → sweeps that session's still-open cards to **done (orphaned)** so the board never accumulates zombies (mirrors `StallWatchdog` clearing `outstanding`).

Global feed = covers cron/Telegram/Discord-triggered work, not just dashboard chats. Cron cards / per-session cards are deliberately **phase 2** (SPEC §out-of-scope).

## Design notes
- **Never throws into the bus**: `ingest()` is sync + try-wrapped; every kanban write is swallowed+logged.
- **Serialized writes (load-bearing)**: `addCardToColumn`/`moveCard`/`capDone` are read-modify-write on one JSON file, so concurrent bus events would lose updates — all writes chain through a single in-tracker promise queue.
- **Injected deps** (subscribe/addCard/moveCard/capDone/now/log) → unit-testable without disk or a real bus.
- **Gated** on `settings.kanban.enabled` (defaults ON; `{ enabled: false }` disables the feed, manual "+ Add task" unaffected).
- **No front-end changes**: the existing 10s GET poll + `renderKanbanCard` (already renders timestamps) pick up server-side moves.
- **Wiring**: mounted in `start.ts` after the bus+agents are up (deferred-spawn block), non-fatal; `stop()` in `shutdown()` and the rollback path.

## Tests / checks
- `src/bus/__tests__/kanban-tracker.test.ts` — **17 pass** (spawn→in_progress; finish→done+cap; non-Agent tool ignored; unknown result ignored; session.end + session.init orphan sweep; session isolation; agent_name fallback; idempotent dup spawn; **write serialization / no-lost-update**; ingest-never-throws; disabled → no subscribe; start/stop; `capDoneColumn`).
- Biome clean; `tsc` adds **no new errors** (start.ts stays at its pre-existing count). Version bumped.

SPEC: `.planning/kanban-live/SPEC.md`.
