### PR TITLE
fix(tuner): model-routing YAML editors leak into sibling modes (#306)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.185",
+      "version": "2.2.186",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.185",
+  "version": "2.2.186",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/tuner/__tests__/wisecron/subjects/model-routing-subject.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/model-routing-subject.test.ts
@@ -463,3 +463,63 @@ describe("ModelRoutingSubject — healthProbe (post-apply artifact check)", () =
     expect(probe.failed).toBe(false);
   });
 });
+
+describe("ModelRoutingSubject — YAML editors don't corrupt sibling modes (#306)", () => {
+  it("proposeChange edits only the target mode in a multi-mode block", async () => {
+    const yaml = [
+      "modes:",
+      "  fast:",
+      "    model: claude-sonnet",
+      "    keywords:",
+      "      - quick",
+      "      - rapid",
+      "  slow:",
+      "    model: claude-opus",
+      "    keywords:",
+      "      - quick",
+      "      - deep",
+    ].join("\n");
+    writeFileSync(configPath, yaml, "utf8");
+    const s = new ModelRoutingSubject({ modesConfigPath: configPath });
+    const obs: Observation[] = [
+      {
+        session_id: "t",
+        observed_at: new Date(),
+        signal_type: "orphan",
+        verbatim: "{}",
+        metadata: {
+          subject: "model_routing",
+          mode: "fast",
+          keyword: "quick",
+          triggers: 0,
+          reclassify_rate: 0,
+          expensive: false,
+          age_days: 200,
+        },
+      },
+    ];
+    const clusters = await s.detectProblems(obs);
+    const cluster = clusters.find((c) => c.id === "routing-dead-keyword");
+    expect(cluster).toBeDefined();
+    const proposal = await s.proposeChange(cluster!);
+    const alt = (id: string) =>
+      proposal.alternatives.find((a) => a.id === id)?.diff_or_content ?? "";
+
+    // swap-model: fast sonnet -> haiku; slow's opus MUST survive (the #306 repro:
+    // the bug left inMode set and swapped slow's model to sonnet too).
+    const swapped = alt("swap-model");
+    expect(swapped).toContain("model: claude-haiku");
+    expect(swapped).toContain("model: claude-opus");
+
+    // remove-keyword: fast's 'quick' removed; slow's 'quick' + 'deep' untouched.
+    const removed = alt("remove-keyword");
+    expect((removed.match(/^\s*- quick$/gm) ?? []).length).toBe(1);
+    expect(removed).toContain("- rapid");
+    expect(removed).toContain("- deep");
+
+    // narrow-keyword: fast's 'quick' renamed; slow's 'quick' left as-is.
+    const narrowed = alt("narrow-keyword");
+    expect(narrowed).toContain("- quick-specific");
+    expect((narrowed.match(/^\s*- quick$/gm) ?? []).length).toBe(1);
+  });
+});

--- a/src/tuner/subjects/model-routing-subject.ts
+++ b/src/tuner/subjects/model-routing-subject.ts
@@ -565,16 +565,19 @@ function removeKeywordFromYaml(content: string, mode: string, keyword: string): 
   const lines = content.split("\n");
   const out: string[] = [];
   let inMode = false;
+  let modeIndent = "";
   for (const line of lines) {
-    if (
-      new RegExp(`^\\s{2,}${escapeRe(mode)}:\\s*$`).test(line) ||
-      new RegExp(`^${escapeRe(mode)}:\\s*$`).test(line)
-    ) {
+    const modeHeader = line.match(new RegExp(`^(\\s*)${escapeRe(mode)}:\\s*$`));
+    if (modeHeader) {
       inMode = true;
+      modeIndent = modeHeader[1] ?? "";
       out.push(line);
       continue;
     }
-    if (inMode && /^\S/.test(line)) inMode = false;
+    // Exit the target mode's block on the first non-blank line indented no deeper
+    // than the header (a sibling mode or a dedent) — NOT only at column 0, which
+    // let edits bleed into sibling modes in an indented `modes:` block (#306).
+    if (inMode && line.trim().length > 0 && !line.startsWith(`${modeIndent} `)) inMode = false;
     if (inMode && new RegExp(`^\\s*-\\s+["']?${escapeRe(keyword)}["']?\\s*$`).test(line)) continue;
     out.push(line);
   }
@@ -590,16 +593,19 @@ function renameKeywordInYaml(
   const lines = content.split("\n");
   const out: string[] = [];
   let inMode = false;
+  let modeIndent = "";
   for (const line of lines) {
-    if (
-      new RegExp(`^\\s{2,}${escapeRe(mode)}:\\s*$`).test(line) ||
-      new RegExp(`^${escapeRe(mode)}:\\s*$`).test(line)
-    ) {
+    const modeHeader = line.match(new RegExp(`^(\\s*)${escapeRe(mode)}:\\s*$`));
+    if (modeHeader) {
       inMode = true;
+      modeIndent = modeHeader[1] ?? "";
       out.push(line);
       continue;
     }
-    if (inMode && /^\S/.test(line)) inMode = false;
+    // Exit the target mode's block on the first non-blank line indented no deeper
+    // than the header (a sibling mode or a dedent) — NOT only at column 0, which
+    // let edits bleed into sibling modes in an indented `modes:` block (#306).
+    if (inMode && line.trim().length > 0 && !line.startsWith(`${modeIndent} `)) inMode = false;
     if (inMode) {
       const m = line.match(new RegExp(`^(\\s*-\\s+)["']?${escapeRe(keyword)}["']?\\s*$`));
       if (m) {
@@ -616,16 +622,19 @@ function swapModelInYaml(content: string, mode: string): string {
   const lines = content.split("\n");
   const out: string[] = [];
   let inMode = false;
+  let modeIndent = "";
   for (const line of lines) {
-    if (
-      new RegExp(`^\\s{2,}${escapeRe(mode)}:\\s*$`).test(line) ||
-      new RegExp(`^${escapeRe(mode)}:\\s*$`).test(line)
-    ) {
+    const modeHeader = line.match(new RegExp(`^(\\s*)${escapeRe(mode)}:\\s*$`));
+    if (modeHeader) {
       inMode = true;
+      modeIndent = modeHeader[1] ?? "";
       out.push(line);
       continue;
     }
-    if (inMode && /^\S/.test(line)) inMode = false;
+    // Exit the target mode's block on the first non-blank line indented no deeper
+    // than the header (a sibling mode or a dedent) — NOT only at column 0, which
+    // let edits bleed into sibling modes in an indented `modes:` block (#306).
+    if (inMode && line.trim().length > 0 && !line.startsWith(`${modeIndent} `)) inMode = false;
     if (inMode && /^\s*model:\s*/.test(line)) {
       out.push(line.replace(/sonnet/g, "haiku").replace(/opus/g, "sonnet"));
       continue;


### PR DESCRIPTION
## What

Fixes the sibling-mode corruption in the three line-based YAML editors in `src/tuner/subjects/model-routing-subject.ts` — `swapModelInYaml`, `removeKeywordFromYaml`, `renameKeywordInYaml`.

Closes #306.

## The bug

Each editor only exited the target mode's block on a **column-0** line:

```ts
if (inMode && /^\S/.test(line)) inMode = false;
```

In a normal indented `modes:` block the sibling mode headers are indented (`  slow:`), so `/^\S/` never matches, `inMode` never resets, and every edit after the target mode is applied to the **sibling modes** too. It's the governed **apply path**, and the corrupt output still passes `validate()` + `healthProbe()`, so nothing downstream catches it — silent config corruption, exactly what the confinement/validation story exists to prevent.

## The fix

Capture the target header's indentation when `inMode` is set, and exit the block on the first non-blank line indented **no deeper than the header** (a sibling mode or a dedent):

```ts
const modeHeader = line.match(new RegExp(`^(\\s*)${escapeRe(mode)}:\\s*$`));
if (modeHeader) { inMode = true; modeIndent = modeHeader[1] ?? ""; out.push(line); continue; }
if (inMode && line.trim().length > 0 && !line.startsWith(`${modeIndent} `)) inMode = false;
```

Applied identically to all three editors. Also unifies the two header regexes into one that captures the indent.

## Test

Adds a **two-mode** regression (`fast` + `slow` sharing a `quick` keyword) asserting all three alternatives from `proposeChange` leave the sibling `slow` mode untouched — its model, and its shared keyword, survive.

Verified the test **fails on the pre-fix code** (the swap-model alternative rewrote `slow`'s `claude-opus` → `claude-sonnet`) and **passes after**. Full `model-routing-subject` suite: **29 pass / 0 fail**. `bun run lint` clean (no new errors), versions bumped.
