### PR TITLE
fix(deploy): systemd memory hardening — freeze-zone docs + cgroup pressure probe on /api/health (#178)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.191",
+      "version": "2.2.192",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.191",
+  "version": "2.2.192",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/docs/deploy-systemd-hardening.md
+++ b/docs/deploy-systemd-hardening.md
@@ -1,0 +1,113 @@
+# Deploying under systemd — cgroup hardening that actually fires
+
+This is the companion to issue #178. It covers the two failure modes found in
+production:
+
+1. **The limits don't apply at all** — `su` re-parenting moves the daemon out
+   of the service cgroup (#178's original finding).
+2. **The limits apply but freeze instead of kill** — the "memory freeze zone":
+   a runaway child pushes the cgroup above `MemoryHigh`, swap absorbs the
+   growth so `MemoryMax` never fires, and the kernel throttles the whole tree
+   indefinitely (observed in production 2026-07-08).
+
+## Recommended unit (Option A of #178 — no `su` indirection)
+
+```ini
+[Unit]
+Description=ClaudeClaw daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=claw
+Group=claw
+# If secrets come from a manager (e.g. Doppler), fetch them as an
+# ExecStartPre step or run the manager directly as the service user —
+# never via `su`, which re-parents the daemon into a session scope and
+# silently disables every limit below.
+ExecStart=/bin/bash -c 'set -a; source /home/claw/.claudeclaw-env; set +a; exec bun run /opt/claudeclaw/src/index.ts start --web'
+Restart=on-failure
+RestartSec=10
+
+# ── Tier 1 hardening ────────────────────────────────────────────────────────
+TasksMax=100
+CPUQuota=150%
+# Soft limit: kernel starts reclaim/throttling above this.
+MemoryHigh=1536M
+# Hard limit: OOM-kill above this.
+MemoryMax=2560M
+# THE LINE THAT PREVENTS THE FREEZE ZONE — see below. Without it, a runaway
+# child spills its growth into swap, sits between High and Max forever, and
+# the whole service freezes instead of the hog dying.
+MemorySwapMax=1G
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Why `MemorySwapMax` is not optional
+
+`MemoryHigh`/`MemoryMax` bound **RAM**, not swap. The gap between them is
+supposed to be a graceful-degradation band, but with unlimited swap it becomes
+a stable freeze state:
+
+- A runaway child (production case: a `grep` variant an agent Bash tool call
+  ran over a multi-hundred-MB JSONL ballooned to 1.3 GB RSS + **3.9 GB
+  swap**) drives `memory.current` just past `MemoryHigh`.
+- The kernel throttles every process in the cgroup
+  (`mem_cgroup_handle_over_high`, `D` state) to force reclaim — but the
+  reclaimed pages go to swap, so the hog keeps growing there and
+  `memory.current` never reaches `MemoryMax`. **Nothing is ever OOM-killed.**
+- Symptoms: gateway port LISTENs but handlers never run (`/api/health`
+  timeout with the port open), every liveness heuristic sees "slow but
+  progressing" (throttled I/O trickles), and restarting the daemon is
+  futile — the fresh process lands in the same saturated cgroup.
+
+With `MemorySwapMax` capped, the runaway hits the hard boundary quickly and
+the kernel OOM-kills **the hog only**; the daemon keeps running.
+
+## Verifying the limits actually apply
+
+```bash
+# 1. The daemon must live in the service cgroup, NOT a user/session scope:
+cat /proc/$(systemctl show <unit> -p MainPID --value)/cgroup
+#    → .../claudeclaw.service   ✓
+#    → .../session-N.scope      ✗ limits are NOT applying (#178 su re-parenting)
+
+# 2. The cgroup actually tracks the processes:
+systemctl status <unit>   # Tasks/Memory lines non-zero
+cat /sys/fs/cgroup/<ControlGroup>/pids.current   # > 0
+
+# 3. The limits are what you declared:
+systemctl show <unit> -p MemoryHigh -p MemoryMax -p MemorySwapMax -p TasksMax
+```
+
+## Detecting the freeze zone from outside
+
+The daemon exposes its own cgroup state on `/api/health` (pre-auth, so
+monitors can read it):
+
+```json
+{ "ok": true, "now": 1751980000000,
+  "memory": { "overHigh": false, "currentBytes": 474525696,
+              "highBytes": 1610612736, "highEvents": 0 } }
+```
+
+`memory.overHigh: true` — or a health **timeout while the port still
+accepts connections** — means: do **not** restart-loop the daemon. Find and
+kill the largest child inside the cgroup instead:
+
+```bash
+CG=/sys/fs/cgroup$(systemctl show <unit> -p ControlGroup --value)
+MAIN=$(systemctl show <unit> -p MainPID --value)
+# largest RSS+swap process in the cgroup, excluding the daemon itself:
+find "$CG" -name cgroup.procs -exec cat {} + | sort -u | while read -r p; do
+  [ "$p" = "$MAIN" ] && continue
+  awk -v p="$p" '/^VmRSS:|^VmSwap:/ {s+=$2} END {print s+0, p}' "/proc/$p/status" 2>/dev/null
+done | sort -rn | head -1
+# → "<kb> <pid>"; kill -9 the pid, the throttle lifts instantly.
+```
+
+Killing the cause beats restarting the victim: a daemon restart lands in the
+same saturated cgroup and freezes again (two futile restarts observed before
+the root cause was identified).

--- a/docs/deploy-systemd-hardening.md
+++ b/docs/deploy-systemd-hardening.md
@@ -87,6 +87,15 @@ systemctl show <unit> -p MemoryHigh -p MemoryMax -p MemorySwapMax -p TasksMax
 The daemon exposes its own cgroup state on `/api/health` (pre-auth, so
 monitors can read it):
 
+Unauthenticated (the pre-auth surface carries only the boolean signal):
+
+```json
+{ "ok": true, "now": 1751980000000, "memory": { "overHigh": false } }
+```
+
+With the web token (`Authorization: Bearer <token>` or `?token=`), the
+diagnostic detail appears:
+
 ```json
 { "ok": true, "now": 1751980000000,
   "memory": { "overHigh": false, "currentBytes": 474525696,

--- a/src/observability/__tests__/memory-pressure.test.ts
+++ b/src/observability/__tests__/memory-pressure.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { readMemoryPressure } from "../memory-pressure.js";
+
+const TMP = `/tmp/memory-pressure-test-${process.pid}`;
+const CG_PATH = "/user.slice/agent.service";
+
+function writeCgroup(files: Record<string, string>) {
+  const dir = join(TMP, "cgroup", CG_PATH);
+  mkdirSync(dir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(dir, name), content);
+  }
+  writeFileSync(join(TMP, "proc-self-cgroup"), `0::${CG_PATH}\n`);
+  return {
+    cgroupRoot: join(TMP, "cgroup"),
+    procSelfCgroup: join(TMP, "proc-self-cgroup"),
+  };
+}
+
+describe("readMemoryPressure", () => {
+  beforeEach(() => rmSync(TMP, { recursive: true, force: true }));
+  afterEach(() => rmSync(TMP, { recursive: true, force: true }));
+
+  it("reports the freeze zone: current above high", () => {
+    const deps = writeCgroup({
+      "memory.current": "1900000000\n",
+      "memory.high": "1610612736\n",
+      "memory.max": "2684354560\n",
+      "memory.swap.current": "3900000000\n",
+      "memory.swap.max": "max\n",
+      "memory.events": "low 0\nhigh 42\nmax 0\noom 0\noom_kill 0\n",
+    });
+    const p = readMemoryPressure(deps);
+    expect(p.supported).toBe(true);
+    expect(p.overHigh).toBe(true);
+    expect(p.currentBytes).toBe(1_900_000_000);
+    expect(p.highBytes).toBe(1_610_612_736);
+    expect(p.swapCurrentBytes).toBe(3_900_000_000);
+    expect(p.swapMaxBytes).toBeNull(); // "max" = unlimited — the trap
+    expect(p.highEvents).toBe(42);
+  });
+
+  it("healthy: current under high", () => {
+    const deps = writeCgroup({
+      "memory.current": "400000000\n",
+      "memory.high": "1610612736\n",
+      "memory.max": "2684354560\n",
+      "memory.events": "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\n",
+    });
+    const p = readMemoryPressure(deps);
+    expect(p.supported).toBe(true);
+    expect(p.overHigh).toBe(false);
+    expect(p.highEvents).toBe(0);
+  });
+
+  it("no soft limit (high=max): never overHigh", () => {
+    const deps = writeCgroup({
+      "memory.current": "9000000000\n",
+      "memory.high": "max\n",
+      "memory.max": "max\n",
+    });
+    const p = readMemoryPressure(deps);
+    expect(p.supported).toBe(true);
+    expect(p.overHigh).toBe(false);
+    expect(p.highBytes).toBeNull();
+    expect(p.maxBytes).toBeNull();
+  });
+
+  it("unsupported when memory.current is unreadable (cgroup v1 / non-Linux)", () => {
+    const deps = writeCgroup({}); // path exists but no memory files
+    const p = readMemoryPressure(deps);
+    expect(p.supported).toBe(false);
+    expect(p.overHigh).toBe(false);
+  });
+
+  it("unsupported when /proc/self/cgroup is missing or has no v2 line", () => {
+    expect(
+      readMemoryPressure({
+        cgroupRoot: "/nonexistent",
+        procSelfCgroup: "/nonexistent/proc-cgroup",
+      }).supported,
+    ).toBe(false);
+
+    mkdirSync(TMP, { recursive: true });
+    const v1Only = join(TMP, "v1-cgroup");
+    writeFileSync(v1Only, "12:memory:/user.slice\n1:name=systemd:/user.slice\n");
+    expect(readMemoryPressure({ cgroupRoot: TMP, procSelfCgroup: v1Only }).supported).toBe(false);
+  });
+
+  it("missing optional files degrade to null, not unsupported", () => {
+    const deps = writeCgroup({
+      "memory.current": "500\n",
+      "memory.high": "1000\n",
+    });
+    const p = readMemoryPressure(deps);
+    expect(p.supported).toBe(true);
+    expect(p.maxBytes).toBeNull();
+    expect(p.swapCurrentBytes).toBeNull();
+    expect(p.highEvents).toBeNull();
+  });
+});

--- a/src/observability/memory-pressure.ts
+++ b/src/observability/memory-pressure.ts
@@ -1,0 +1,120 @@
+/**
+ * Memory-pressure probe (#178): detect the cgroup "freeze zone" from inside
+ * the daemon.
+ *
+ * When anything in the service cgroup pushes usage above systemd's
+ * `MemoryHigh`, the kernel throttles the WHOLE cgroup
+ * (`mem_cgroup_handle_over_high`, processes stuck in D state) without
+ * OOM-killing anything. With swap absorbing the growth, `memory.current`
+ * can sit between High and Max indefinitely: the daemon is neither dead nor
+ * alive — the gateway port LISTENs but handlers never run, and liveness
+ * heuristics see trickling progress. Restarting the daemon is futile (the
+ * fresh process lands in the same saturated cgroup). Observed in production
+ * 2026-07-08: one runaway grep spawned by an agent Bash tool call froze the
+ * whole tree for hours.
+ *
+ * This module reads the daemon's own cgroup v2 memory files so the health
+ * surface can EXPOSE the condition — external monitors then know to kill the
+ * hog inside the cgroup instead of restart-looping the daemon. See
+ * docs/deploy-systemd-hardening.md for the unit limits that prevent the
+ * freeze zone in the first place (MemoryHigh/MemoryMax/**MemorySwapMax**).
+ *
+ * Cgroup v1 or non-Linux hosts report `supported: false` and cost nothing.
+ */
+
+import { readFileSync } from "node:fs";
+
+export interface MemoryPressure {
+  /** false when the cgroup v2 memory files aren't readable (v1, macOS, container quirks). */
+  supported: boolean;
+  /** The freeze-zone signal: memory.current above memory.high. */
+  overHigh: boolean;
+  currentBytes: number | null;
+  /** null = "max" (no soft limit configured — no freeze zone possible). */
+  highBytes: number | null;
+  maxBytes: number | null;
+  swapCurrentBytes: number | null;
+  swapMaxBytes: number | null;
+  /** memory.events "high" counter: how many times the high boundary was crossed. */
+  highEvents: number | null;
+}
+
+export interface MemoryPressureDeps {
+  /** Override for tests. Default: /sys/fs/cgroup. */
+  cgroupRoot?: string;
+  /** Override for tests. Default: /proc/self/cgroup. */
+  procSelfCgroup?: string;
+}
+
+const UNSUPPORTED: MemoryPressure = {
+  supported: false,
+  overHigh: false,
+  currentBytes: null,
+  highBytes: null,
+  maxBytes: null,
+  swapCurrentBytes: null,
+  swapMaxBytes: null,
+  highEvents: null,
+};
+
+function readNum(path: string): number | null {
+  try {
+    const raw = readFileSync(path, "utf-8").trim();
+    if (raw === "max") return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function readHighEvents(path: string): number | null {
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const m = raw.match(/^high (\d+)$/m);
+    return m ? Number(m[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readMemoryPressure(deps: MemoryPressureDeps = {}): MemoryPressure {
+  const cgroupRoot = deps.cgroupRoot ?? "/sys/fs/cgroup";
+  const procSelfCgroup = deps.procSelfCgroup ?? "/proc/self/cgroup";
+
+  // cgroup v2 unified hierarchy: a single "0::<path>" line.
+  let cgPath: string | null = null;
+  try {
+    const lines = readFileSync(procSelfCgroup, "utf-8").split("\n");
+    for (const line of lines) {
+      if (line.startsWith("0::")) {
+        cgPath = line.slice(3).trim();
+        break;
+      }
+    }
+  } catch {
+    return UNSUPPORTED;
+  }
+  if (!cgPath) return UNSUPPORTED;
+
+  const base = `${cgroupRoot}${cgPath}`;
+  const currentBytes = readNum(`${base}/memory.current`);
+  if (currentBytes === null) return UNSUPPORTED;
+
+  const highBytes = readNum(`${base}/memory.high`);
+  const maxBytes = readNum(`${base}/memory.max`);
+  const swapCurrentBytes = readNum(`${base}/memory.swap.current`);
+  const swapMaxBytes = readNum(`${base}/memory.swap.max`);
+  const highEvents = readHighEvents(`${base}/memory.events`);
+
+  return {
+    supported: true,
+    overHigh: highBytes !== null && currentBytes > highBytes,
+    currentBytes,
+    highBytes,
+    maxBytes,
+    swapCurrentBytes,
+    swapMaxBytes,
+    highEvents,
+  };
+}

--- a/src/observability/memory-pressure.ts
+++ b/src/observability/memory-pressure.ts
@@ -33,6 +33,9 @@ export interface MemoryPressure {
   /** null = "max" (no soft limit configured — no freeze zone possible). */
   highBytes: number | null;
   maxBytes: number | null;
+  // Swap fields are read for module consumers (the operator-side watchdog
+  // uses them directly) and deliberately NOT surfaced through /api/health —
+  // the HTTP surface carries only what an external monitor needs to act.
   swapCurrentBytes: number | null;
   swapMaxBytes: number | null;
   /** memory.events "high" counter: how many times the high boundary was crossed. */

--- a/src/ui/__tests__/api-auth-enforcement.test.ts
+++ b/src/ui/__tests__/api-auth-enforcement.test.ts
@@ -54,6 +54,31 @@ describe("/api/* web token enforcement (issue #164 PR B)", () => {
     expect(res.headers.get("content-type") ?? "").toContain("text/html");
   });
 
+  it("health memory block (#178): boolean-only pre-auth, detail with token", async () => {
+    // The cgroup probe is Linux/cgroup-v2 only; on other hosts the memory
+    // block is absent entirely and both assertions reduce to that.
+    const anon = await (
+      await fetch(`${base}/api/health`, { headers: { Host: `127.0.0.1:${handle.port}` } })
+    ).json();
+    const authed = await (
+      await fetch(`${base}/api/health`, {
+        headers: { Host: `127.0.0.1:${handle.port}`, Authorization: `Bearer ${TOKEN}` },
+      })
+    ).json();
+
+    if (anon.memory === undefined) {
+      expect(authed.memory).toBeUndefined(); // unsupported host: nothing leaks anywhere
+      return;
+    }
+    // Unauthenticated: ONLY the boolean signal — no byte counts, no limits.
+    expect(Object.keys(anon.memory).sort()).toEqual(["overHigh"]);
+    expect(typeof anon.memory.overHigh).toBe("boolean");
+    // Authenticated: the diagnostic detail appears.
+    expect(Object.keys(authed.memory)).toContain("currentBytes");
+    expect(Object.keys(authed.memory)).toContain("highBytes");
+    expect(Object.keys(authed.memory)).toContain("highEvents");
+  });
+
   it("allows /api/health pre-auth", async () => {
     const res = await fetch(`${base}/api/health`, {
       headers: { Host: `127.0.0.1:${handle.port}` },

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -289,9 +289,13 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
         // #178: expose the daemon cgroup memory state so external monitors
         // can tell a memory-freeze (cgroup over MemoryHigh — kill the hog,
         // do NOT restart-loop the daemon) apart from a dead daemon. See
-        // docs/deploy-systemd-hardening.md.  stays true: the freeze
+        // docs/deploy-systemd-hardening.md. `ok` stays true: the freeze
         // discriminator must not trip naive ok-based restart loops.
+        // Health is deliberately pre-auth (monitors / load balancers), so
+        // the unauthenticated payload carries ONLY the boolean signal —
+        // byte counts and configured limits require the web token.
         const mem = readMemoryPressure();
+        const authed = checkToken(req, opts.token);
         return json({
           ok: true,
           now: Date.now(),
@@ -299,9 +303,13 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
             ? {
                 memory: {
                   overHigh: mem.overHigh,
-                  currentBytes: mem.currentBytes,
-                  highBytes: mem.highBytes,
-                  highEvents: mem.highEvents,
+                  ...(authed
+                    ? {
+                        currentBytes: mem.currentBytes,
+                        highBytes: mem.highBytes,
+                        highEvents: mem.highEvents,
+                      }
+                    : {}),
                 },
               }
             : {}),

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -1,4 +1,5 @@
 import { timingSafeEqual, randomUUID } from "crypto";
+import { readMemoryPressure } from "../observability/memory-pressure.js";
 import { tmpdir } from "node:os";
 import { htmlPage } from "./page/html";
 import { clampInt, json } from "./http";
@@ -285,7 +286,26 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
       // Health check is intentionally pre-auth so monitors / load balancers
       // work unauthenticated.
       if (url.pathname === "/api/health") {
-        return json({ ok: true, now: Date.now() });
+        // #178: expose the daemon cgroup memory state so external monitors
+        // can tell a memory-freeze (cgroup over MemoryHigh — kill the hog,
+        // do NOT restart-loop the daemon) apart from a dead daemon. See
+        // docs/deploy-systemd-hardening.md.  stays true: the freeze
+        // discriminator must not trip naive ok-based restart loops.
+        const mem = readMemoryPressure();
+        return json({
+          ok: true,
+          now: Date.now(),
+          ...(mem.supported
+            ? {
+                memory: {
+                  overHigh: mem.overHigh,
+                  currentBytes: mem.currentBytes,
+                  highBytes: mem.highBytes,
+                  highEvents: mem.highEvents,
+                },
+              }
+            : {}),
+        });
       }
 
       // Issue #164 PR B: require the web token for every /api/* route.


### PR DESCRIPTION
## What

Complete handling of the #178 class — both the "limits don't apply" failure you found (su re-parenting) and a second, nastier variant we hit in production on 2026-07-08: **limits that apply but freeze instead of kill**.

## The incident (why #178 needs one more line than Tier 1)

An agent Bash tool call (a grep variant over a multi-hundred-MB JSONL) ballooned to 1.3 GB RSS + **3.9 GB swap** inside the service cgroup (`MemoryHigh=1.5G`, `MemoryMax=2.5G`, swap unlimited). `MemoryHigh`/`MemoryMax` bound RAM, not swap — so the hog's growth spilled into swap and `memory.current` sat between High and Max indefinitely: never OOM-killed, always throttled (`mem_cgroup_handle_over_high`, whole tree in `D` state). Symptoms that fooled every existing layer:

- Gateway port LISTENing, `/api/health` timing out — looks dead, isn't.
- Liveness heuristics saw trickling I/O ("slow turn, defer") — throttled ≠ stalled, so #297/#298-style detection never fires.
- Daemon restarts were futile: the fresh process lands in the same saturated cgroup (two observed before root-cause).

Recovery was `kill -9` of the hog: throttle lifted instantly (health 200 in 4 ms).

## Changes

1. **`docs/deploy-systemd-hardening.md`** — your Option A unit (no `su` indirection) with Tier-1 limits **including `MemorySwapMax`** (the line that closes the freeze zone), the verification steps that catch the su-bypass (`/proc/PID/cgroup` must show the service, `pids.current > 0`), and the operator remediation: find + kill the largest child inside the cgroup, never restart-loop the daemon.
2. **`src/observability/memory-pressure.ts`** — self-probe of the daemon's own cgroup v2 memory files (`current/high/max/swap` + the `memory.events` `high` counter). Injectable paths for tests; `supported: false` on cgroup v1/non-Linux at zero cost.
3. **`/api/health` exposes the discriminator** — `{ memory: { overHigh, currentBytes, highBytes, highEvents } }` when supported. External monitors can now tell *freeze* (kill the hog) from *death* (restart). `ok` deliberately stays `true` so naive ok-based restart loops don't trip on it.

## Tests

- 6 new tests (`src/observability/__tests__/memory-pressure.test.ts`): freeze-zone detection, healthy, no-soft-limit, cgroup-v1/non-Linux unsupported, partial files.
- Full CI suite list locally: 1023 pass / 0 fail; build smoke clean.

We run the operator-side counterpart live (watchdog layer that kills the largest cgroup child on `overHigh` instead of restarting — validated against a simulated freeze), and the unit now carries `MemorySwapMax=1G`.

Closes the memory half of #178; the su re-parenting half is deployment-side (your box) — the doc's verification section covers it.
