### PR TITLE
fix(tuner): memory shrink relocates trimmed detail into topic files (closes #310)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.191",
+      "version": "2.2.192",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.191",
+  "version": "2.2.192",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { MemorySubject } from "../../../subjects/memory-subject.js";
@@ -117,6 +117,125 @@ describe("MemorySubject — detectProblems", () => {
     // cluster; only a truly empty observation set yields no proposal.
     const clusters = await s.detectProblems([]);
     expect(clusters).toEqual([]);
+  });
+});
+
+describe("MemorySubject — relocate-then-shorten (shrink apply)", () => {
+  // A >200-char hook so the shrink path actually shortens the line.
+  const LONG_HOOK =
+    "vacances ON depuis le 2 juillet, attend la date de retour pour désarmer ; " +
+    "fix lumières-de-jour appliqué le 8 juillet avec gating crépuscule astral ; " +
+    "bug _original_setpoints chauffage jamais restauré après le mode, à fixer avant l'hiver sinon consigne froide";
+
+  function shrinkProposal(shrunkIndex: string): Proposal {
+    return {
+      id: 2,
+      cluster_id: "memory-index-cleanup",
+      subject: "memory",
+      kind: "patch",
+      target_path: indexPath,
+      pattern_signature: "sig",
+      created_at: new Date(),
+      signature: "sig",
+      alternatives: [{ id: "shrink", label: "lbl", tradeoff: "", diff_or_content: shrunkIndex }],
+    };
+  }
+
+  it("appends trimmed detail to the topic when it is not already there", async () => {
+    seed(`# Memory Index\n\n- [Vac](vac.md) — ${LONG_HOOK}\n`);
+    writeFileSync(join(tmpDir, "vac.md"), "# Vac\n\nDétail existant sans le hook.\n", "utf8");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    await s.apply(shrinkProposal("# Memory Index\n\n- [Vac](vac.md) — vacances ON…\n"), "shrink");
+
+    const index = readFileSync(indexPath, "utf8");
+    const entry = index.split("\n").find((l) => l.startsWith("- [Vac]")) ?? "";
+    expect(entry.length).toBeLessThanOrEqual(200);
+    const topic = readFileSync(join(tmpDir, "vac.md"), "utf8");
+    expect(topic).toContain("Index overflow (relocated by tuner)");
+    expect(topic).toContain("consigne froide"); // the trimmed tail landed in the topic
+  });
+
+  it("does not append when the detail already exists in the topic (whitespace-normalized)", async () => {
+    seed(`# Memory Index\n\n- [Vac](vac.md) — ${LONG_HOOK}\n`);
+    // Same content, different wrapping/whitespace.
+    writeFileSync(
+      join(tmpDir, "vac.md"),
+      `# Vac\n\n${LONG_HOOK.replace(/ ; /g, " ;\n")}\n`,
+      "utf8",
+    );
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    const before = readFileSync(join(tmpDir, "vac.md"), "utf8");
+    await s.apply(shrinkProposal("# Memory Index\n\n- [Vac](vac.md) — vacances ON…\n"), "shrink");
+
+    expect(readFileSync(join(tmpDir, "vac.md"), "utf8")).toBe(before); // untouched
+    const entry =
+      readFileSync(indexPath, "utf8")
+        .split("\n")
+        .find((l) => l.startsWith("- [Vac]")) ?? "";
+    expect(entry.length).toBeLessThanOrEqual(200);
+  });
+
+  it("keeps the line LONG when the topic file is missing (no place to relocate)", async () => {
+    seed(`# Memory Index\n\n- [Ghost](ghost.md) — ${LONG_HOOK}\n`);
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    await s.apply(
+      shrinkProposal("# Memory Index\n\n- [Ghost](ghost.md) — vacances ON…\n"),
+      "shrink",
+    );
+
+    const entry =
+      readFileSync(indexPath, "utf8")
+        .split("\n")
+        .find((l) => l.startsWith("- [Ghost]")) ?? "";
+    expect(entry).toContain("consigne froide"); // full hook preserved in the index
+    expect(existsSync(join(tmpDir, "ghost.md"))).toBe(false); // nothing created
+  });
+
+  it("refuses to relocate outside the memory dir (traversal pointer) — keeps the line long", async () => {
+    const outside = join(tmpDir, "..", `outside-${Date.now()}.md`);
+    writeFileSync(outside, "# outside\n", "utf8");
+    const rel = `../${outside.split("/").pop()}`;
+    seed(`# Memory Index\n\n- [Evil](${rel}) — ${LONG_HOOK}\n`);
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    await s.apply(shrinkProposal(`# Memory Index\n\n- [Evil](${rel}) — vacances ON…\n`), "shrink");
+
+    const entry =
+      readFileSync(indexPath, "utf8")
+        .split("\n")
+        .find((l) => l.startsWith("- [Evil]")) ?? "";
+    expect(entry).toContain("consigne froide"); // kept long
+    expect(readFileSync(outside, "utf8")).toBe("# outside\n"); // never written
+    rmSync(outside, { force: true });
+  });
+
+  it("refuses a symlinked topic (append would leak outside) — keeps the line long", async () => {
+    const outside = join(tmpDir, "..", `slink-target-${Date.now()}.md`);
+    writeFileSync(outside, "# real target\n", "utf8");
+    symlinkSync(outside, join(tmpDir, "vac.md"));
+    seed(`# Memory Index\n\n- [Vac](vac.md) — ${LONG_HOOK}\n`);
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    await s.apply(shrinkProposal("# Memory Index\n\n- [Vac](vac.md) — vacances ON…\n"), "shrink");
+
+    const entry =
+      readFileSync(indexPath, "utf8")
+        .split("\n")
+        .find((l) => l.startsWith("- [Vac]")) ?? "";
+    expect(entry).toContain("consigne froide"); // kept long
+    expect(readFileSync(outside, "utf8")).toBe("# real target\n"); // link target untouched
+    rmSync(outside, { force: true });
+  });
+
+  it("topic appends are additive: existing topic content is preserved", async () => {
+    seed(`# Memory Index\n\n- [Vac](vac.md) — ${LONG_HOOK}\n`);
+    writeFileSync(join(tmpDir, "vac.md"), "# Vac\n\nContenu original important.\n", "utf8");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    await s.apply(shrinkProposal("# Memory Index\n\n- [Vac](vac.md) — vacances ON…\n"), "shrink");
+
+    const topic = readFileSync(join(tmpDir, "vac.md"), "utf8");
+    expect(topic).toContain("Contenu original important.");
+    expect(topic.indexOf("Contenu original important.")).toBeLessThan(
+      topic.indexOf("Index overflow"),
+    );
   });
 });
 

--- a/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, symlinkSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { MemorySubject } from "../../../subjects/memory-subject.js";

--- a/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
+++ b/src/tuner/__tests__/wisecron/subjects/memory-subject.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, symlinkSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { MemorySubject } from "../../../subjects/memory-subject.js";
@@ -223,6 +223,36 @@ describe("MemorySubject — relocate-then-shorten (shrink apply)", () => {
     expect(entry).toContain("consigne froide"); // kept long
     expect(readFileSync(outside, "utf8")).toBe("# real target\n"); // link target untouched
     rmSync(outside, { force: true });
+  });
+
+  it("two long lines sharing one topic append the overflow only once (review #1)", async () => {
+    seed(`# Memory Index\n\n- [Vac](vac.md) — ${LONG_HOOK}\n- [Vac bis](vac.md) — ${LONG_HOOK}\n`);
+    writeFileSync(join(tmpDir, "vac.md"), "# Vac\n", "utf8");
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    await s.apply(
+      shrinkProposal(
+        "# Memory Index\n\n- [Vac](vac.md) — vacances ON…\n- [Vac bis](vac.md) — vacances ON…\n",
+      ),
+      "shrink",
+    );
+    const topic = readFileSync(join(tmpDir, "vac.md"), "utf8");
+    const occurrences = topic.split("Index overflow (relocated by tuner)").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("keeps the line long when the topic pointer is a DIRECTORY (review #2)", async () => {
+    mkdirSync(join(tmpDir, "weird.md"), { recursive: true });
+    seed(`# Memory Index\n\n- [Weird](weird.md) — ${LONG_HOOK}\n`);
+    const s = new MemorySubject({ memoryIndex: indexPath });
+    await s.apply(
+      shrinkProposal("# Memory Index\n\n- [Weird](weird.md) — vacances ON…\n"),
+      "shrink",
+    );
+    const entry =
+      readFileSync(indexPath, "utf8")
+        .split("\n")
+        .find((l) => l.startsWith("- [Weird]")) ?? "";
+    expect(entry).toContain("consigne froide"); // pas de crash EISDIR, ligne gardée longue
   });
 
   it("topic appends are additive: existing topic content is preserved", async () => {

--- a/src/tuner/subjects/memory-subject.ts
+++ b/src/tuner/subjects/memory-subject.ts
@@ -172,18 +172,26 @@ function relocateOverflow(
     if (
       !topicPath.startsWith(resolvedDir + sep) ||
       !existsSync(topicPath) ||
-      lstatSync(topicPath).isSymbolicLink()
+      lstatSync(topicPath).isSymbolicLink() ||
+      !lstatSync(topicPath).isFile()
     ) {
       keptLong++;
       return ol;
     }
 
     const newHook = (nl.match(ENTRY_RE)?.[3] ?? "").replace(/…\s*$/u, "").trim();
+    // Non-prefix shortening (LLM paraphrase) → on relocalise le hook ENTIER :
+    // plus verbeux que strictement nécessaire, mais le seul choix qui garantit
+    // zéro perte sans diff sémantique. Tradeoff assumé (review #311 finding 3).
     const lost = oldHook.startsWith(newHook) ? oldHook.slice(newHook.length).trim() : oldHook;
     if (lost.length === 0) return nl;
 
+    // "Already there" doit couvrir le fichier ET les blocs déjà en file pour
+    // ce topic dans CETTE passe : deux lignes d'index pointant le même topic
+    // (slug dupliqué) ne doivent pas déposer deux fois le même overflow.
+    const queued = (appends.get(topicPath) ?? []).join(" ");
     const topic = readFileSync(topicPath, "utf8");
-    if (normalizeWs(topic).includes(normalizeWs(lost))) return nl; // already there
+    if (normalizeWs(`${topic} ${queued}`).includes(normalizeWs(lost))) return nl;
 
     const blocks = appends.get(topicPath) ?? [];
     // Full original hook (not just the tail) so the relocated note reads

--- a/src/tuner/subjects/memory-subject.ts
+++ b/src/tuner/subjects/memory-subject.ts
@@ -6,9 +6,10 @@ import {
   renameSync,
   statSync,
   lstatSync,
+  appendFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, resolve } from "node:path";
+import { basename, dirname, resolve, sep } from "node:path";
 import { BaseSubject } from "../../skills-tuner/subjects/base.js";
 import { sanitizeObservationContent } from "../../skills-tuner/core/security.js";
 import type { LLMClient } from "../../skills-tuner/core/llm.js";
@@ -118,6 +119,82 @@ function shortenIndexLine(line: string): string {
   if (budget <= 0) return `${line.slice(0, MAX_INDEX_LINE_CHARS - 1)}…`;
   const hook = (m[2] as string).slice(0, budget).replace(/\s+\S*$/, "");
   return `${head}${hook}…`;
+}
+
+const normalizeWs = (s: string): string => s.replace(/\s+/g, " ").trim();
+
+interface RelocationResult {
+  content: string;
+  /** absolute topic path → overflow blocks to append (additive-only). */
+  appends: Map<string, string[]>;
+  relocated: number;
+  keptLong: number;
+}
+
+/**
+ * Relocate-then-shorten: make the shrink label ("detail stays in topics") true
+ * BY CONSTRUCTION instead of by hope. For every index line the reconciled
+ * content shortens, verify the trimmed detail actually exists in the entry's
+ * topic file; when it does not, queue an additive append of the full original
+ * hook to the topic — only then is the shortened line accepted. An entry whose
+ * topic is missing, or whose pointer escapes the memory dir (traversal), has
+ * nowhere safe to hold the detail: its line is KEPT LONG (no information loss,
+ * ever) and left for dedup-dead / a human.
+ *
+ * Pairing is positional: reconcileToLive maps live lines 1:1 in order, so
+ * old/new lines at the same offset describe the same entry.
+ */
+function relocateOverflow(
+  oldContent: string,
+  newContent: string,
+  memDir: string,
+): RelocationResult {
+  const oldLines = oldContent.split("\n");
+  const newLines = newContent.split("\n");
+  const appends = new Map<string, string[]>();
+  let relocated = 0;
+  let keptLong = 0;
+  const resolvedDir = resolve(memDir);
+
+  const out = newLines.map((nl, i) => {
+    const ol = oldLines[i];
+    if (ol === undefined || ol === nl || !ol.startsWith("- [")) return nl;
+    if (nl.length >= ol.length) return nl; // not a shortening
+    const m = ol.match(ENTRY_RE);
+    if (!m) return nl;
+    const oldHook = (m[3] ?? "").trim();
+    if (oldHook.length === 0) return nl;
+
+    const topicPath = resolve(resolvedDir, m[2] as string);
+    // Confinement (traversal), existence, and M3-style symlink refusal:
+    // appendFileSync follows links, so a symlinked topic could leak the
+    // append outside the memory dir.
+    if (
+      !topicPath.startsWith(resolvedDir + sep) ||
+      !existsSync(topicPath) ||
+      lstatSync(topicPath).isSymbolicLink()
+    ) {
+      keptLong++;
+      return ol;
+    }
+
+    const newHook = (nl.match(ENTRY_RE)?.[3] ?? "").replace(/…\s*$/u, "").trim();
+    const lost = oldHook.startsWith(newHook) ? oldHook.slice(newHook.length).trim() : oldHook;
+    if (lost.length === 0) return nl;
+
+    const topic = readFileSync(topicPath, "utf8");
+    if (normalizeWs(topic).includes(normalizeWs(lost))) return nl; // already there
+
+    const blocks = appends.get(topicPath) ?? [];
+    // Full original hook (not just the tail) so the relocated note reads
+    // standalone in the topic file.
+    blocks.push(`\n**Index overflow (relocated by tuner):** ${oldHook}\n`);
+    appends.set(topicPath, blocks);
+    relocated++;
+    return nl;
+  });
+
+  return { content: out.join("\n"), appends, relocated, keptLong };
 }
 // `- [Title](file.md) — hook` shape — em-dash or ASCII hyphen separator.
 const ENTRY_RE = /^- \[([^\]]+)\]\(([^)]+\.md)\)(?:\s+[—-]\s+(.+))?$/;
@@ -364,10 +441,12 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
       alternatives: [
         {
           id: "shrink",
-          label: "Shrink: rewrite over-long entries to one line (detail stays in topics)",
+          label:
+            "Shrink: rewrite over-long entries to one line (relocates trimmed detail into topics)",
           diff_or_content: shrunk,
           tradeoff:
-            "Cuts per-session context cost + long-line count toward 0; keeps every entry + link.",
+            "Cuts per-session context cost + long-line count toward 0; keeps every entry + link; " +
+            "detail trimmed from a line is appended to its topic file when not already there.",
         },
         {
           id: "dedup-dead",
@@ -408,6 +487,7 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
     // An UNKNOWN id -> an external/research proposal carrying the full new index in
     // diff_or_content. validate() gates the result either way.
     let newContent: string;
+    let relocationAppends: Map<string, string[]> | null = null;
     if (isKnownStrategy(alternativeId)) {
       newContent = applyStrategy(current, this.memoryIndex, alternativeId);
     } else {
@@ -432,6 +512,12 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
       // always succeeds on the current state and NEVER drops a live pointer.
       newContent = reconcileToLive(explicit, current);
       const memDir = dirname(this.memoryIndex);
+      // Relocate-then-shorten: trimmed detail must EXIST in the topic file
+      // before the shortened line is accepted; otherwise it is appended there
+      // (additive-only), or the line is kept long. See relocateOverflow.
+      const relocation = relocateOverflow(current, newContent, memDir);
+      newContent = relocation.content;
+      relocationAppends = relocation.appends;
       const liveBefore = [...current.matchAll(/\]\(([^)]+\.md)\)/g)]
         .map((m) => m[1] as string)
         .filter((file) => existsSync(resolve(memDir, file)));
@@ -455,6 +541,14 @@ export class MemorySubject extends BaseSubject implements RevertibleSubject, Evi
     }
     if (existsSync(this.memoryIndex)) {
       copyFileSync(this.memoryIndex, `${this.memoryIndex}.bak`);
+    }
+    // Topic appends FIRST, index write second: the appends are additive-only,
+    // so a failure between the two duplicates information (index still long)
+    // instead of losing it (index shortened, detail nowhere).
+    if (relocationAppends) {
+      for (const [topicPath, blocks] of relocationAppends) {
+        appendFileSync(topicPath, blocks.join(""), "utf8");
+      }
     }
     // Atomic: write a temp then rename so a mid-write failure can't truncate the index.
     const tmpPath = `${this.memoryIndex}.tmp`;


### PR DESCRIPTION
## What

Closes #310 — makes the memory shrink's promise ("detail stays in topics") true **by construction** instead of by hope.

## The change: relocate-then-shorten

At apply time, for every index line the reconciled content shortens:

1. The trimmed-away detail is computed (old hook minus kept prefix, `…` stripped).
2. It's containment-checked (whitespace-normalized) against the entry's topic file.
3. **Missing there → the full original hook is appended to the topic first** (an additive-only `**Index overflow (relocated by tuner):**` block), then the shortened line is accepted.
4. A topic that is missing, a symlink, or reached via a traversal-shaped pointer has nowhere *safe* to hold the detail → the line is **kept long**. The invariant is: no information loss, ever — worst case the index stays verbose.

Ordering matters: topic appends happen **before** the atomic index write, so a mid-apply failure duplicates information (index still long + note in topic) rather than losing it.

## Security notes

- Topic writes are confined: `resolve()` within the memory dir + `startsWith(dir + sep)` (the pointer comes from index content, so it's treated as untrusted — same class as the existing M3 checks).
- `appendFileSync` follows symlinks, so a symlinked topic is refused outright (M3-style), not just resolved.
- Appends are additive-only; no file creation, no rewrites.

## Tests

6 new (relocation to topic, normalized containment skip, missing topic keeps line long, traversal pointer refused, symlinked topic refused, append is additive and ordered after existing content) — memory-subject suites 45/45, full CI suite list locally 1023 pass / 0 fail, build smoke clean.

Also validated against a copy of a real production index: a 250-char entry shortened to 197 with its unique detail landing in the topic file.

Follow-up idea (not in this PR, mentioned in #310): recurrence awareness at the gate for signatures that re-fire after repeated applies.
