### PR TITLE
feat(health): pre-auth turn-active busy signal for graceful restart (refs #315)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.197",
+      "version": "2.2.198",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.197",
+  "version": "2.2.198",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -242,6 +242,8 @@ export interface BusCore {
   /** True if the agent has a turn currently streaming (#222 reconciler reads
    *  this to skip restarting a deaf-but-mid-turn agent). */
   isAgentTurnActive(agentId: string): boolean;
+  /** #315: ids of all agents with an in-flight turn (aggregate of {@link isAgentTurnActive}). */
+  activeTurnAgents(): string[];
   ingestReply(req: IngestReplyRequest): void;
   ingestSessionEvent(e: BusEvent): void;
   ingestPermissionDecision(req: IngestPermissionDecisionRequest): void;
@@ -974,6 +976,14 @@ export class BusCoreImpl implements BusCore {
    *  the tailer, not the dead MCP socket. */
   isAgentTurnActive(agentId: string): boolean {
     return this.agentTurnActive.has(agentId);
+  }
+
+  /** #315: the ids of every agent with a turn currently in flight (prompt seen,
+   *  no `response.turn_end` yet). Exposed so an external restart/deploy guard can
+   *  drain-then-restart instead of killing a turn mid-flight. Aggregate sibling of
+   *  {@link isAgentTurnActive}. */
+  activeTurnAgents(): string[] {
+    return [...this.agentTurnActive];
   }
 
   /* ─────────────────────────────── subscriptions ─────────────────────────────── */

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1220,6 +1220,8 @@ export async function start(args: string[] = []) {
             busCoreForWebUi && busRuntimeSpawnedAgents[0]
               ? {
                   defaultAgentId: busRuntimeSpawnedAgents[0],
+                  activeTurnAgents: () =>
+                    (busCoreForWebUi as NonNullable<typeof busCoreForWebUi>).activeTurnAgents(),
                   sendPromptAndAwait: (agentId, text, sendOpts) =>
                     streamBusPrompt(
                       busCoreForWebUi as NonNullable<typeof busCoreForWebUi>,

--- a/src/ui/__tests__/api-auth-enforcement.test.ts
+++ b/src/ui/__tests__/api-auth-enforcement.test.ts
@@ -121,3 +121,72 @@ describe("/api/* web token enforcement (issue #164 PR B)", () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe("/api/health busy signal (#315)", () => {
+  // A controllable stub for the bus bridge's turn-active accessor. Casting the
+  // bridge sidesteps the (unused-here) sendPromptAndAwait result shape.
+  let activeTurns: string[] = [];
+  let busyHandle: WebServerHandle;
+  let busyBase: string;
+
+  beforeAll(() => {
+    busyHandle = startWebUi({
+      host: "127.0.0.1",
+      port: 0,
+      token: TOKEN,
+      getSnapshot: snapshot,
+      bus: {
+        defaultAgentId: "agent-0",
+        activeTurnAgents: () => activeTurns,
+        sendPromptAndAwait: async () => ({}),
+      } as unknown as NonNullable<Parameters<typeof startWebUi>[0]["bus"]>,
+    });
+    busyBase = `http://127.0.0.1:${busyHandle.port}`;
+  });
+
+  afterAll(() => busyHandle.stop());
+
+  it("omits busy/activeTurns when no bus is wired (legacy mode)", async () => {
+    const anon = await (
+      await fetch(`${base}/api/health`, { headers: { Host: `127.0.0.1:${handle.port}` } })
+    ).json();
+    expect(anon.busy).toBeUndefined();
+    expect(anon.activeTurns).toBeUndefined();
+  });
+
+  it("busy=false with no in-flight turn; ok stays true (busy is orthogonal to health)", async () => {
+    activeTurns = [];
+    const res = await fetch(`${busyBase}/api/health`, {
+      headers: { Host: `127.0.0.1:${busyHandle.port}` },
+    });
+    const j = await res.json();
+    expect(res.status).toBe(200);
+    expect(j.ok).toBe(true);
+    expect(j.busy).toBe(false);
+  });
+
+  it("busy=true while a turn is in flight; ok still true", async () => {
+    activeTurns = ["agent-0"];
+    const j = await (
+      await fetch(`${busyBase}/api/health`, { headers: { Host: `127.0.0.1:${busyHandle.port}` } })
+    ).json();
+    expect(j.ok).toBe(true);
+    expect(j.busy).toBe(true);
+  });
+
+  it("pre-auth carries ONLY the boolean; the count needs the token (#178 rule)", async () => {
+    activeTurns = ["agent-0", "agent-1"];
+    const anon = await (
+      await fetch(`${busyBase}/api/health`, { headers: { Host: `127.0.0.1:${busyHandle.port}` } })
+    ).json();
+    const authed = await (
+      await fetch(`${busyBase}/api/health`, {
+        headers: { Host: `127.0.0.1:${busyHandle.port}`, Authorization: `Bearer ${TOKEN}` },
+      })
+    ).json();
+    expect(anon.busy).toBe(true);
+    expect(anon.activeTurns).toBeUndefined(); // count not leaked pre-auth
+    expect(authed.busy).toBe(true);
+    expect(authed.activeTurns).toBe(2); // count visible with the web token
+  });
+});

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -296,9 +296,22 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
         // byte counts and configured limits require the web token.
         const mem = readMemoryPressure();
         const authed = checkToken(req, opts.token);
+        // #315: pre-auth busy signal so an external restart guard can
+        // drain-then-restart instead of killing an in-flight turn. Follows the
+        // #178 rule: the unauthenticated payload carries ONLY the boolean; the
+        // agent count requires the web token. `ok` stays true — a busy agent is
+        // not unhealthy (busy is orthogonal to health, per IETF health+json /
+        // k8s readiness guidance). Absent bus (legacy mode) → field omitted.
+        const activeTurns = opts.bus?.activeTurnAgents();
         return json({
           ok: true,
           now: Date.now(),
+          ...(activeTurns
+            ? {
+                busy: activeTurns.length > 0,
+                ...(authed ? { activeTurns: activeTurns.length } : {}),
+              }
+            : {}),
           ...(mem.supported
             ? {
                 memory: {

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -80,6 +80,13 @@ export interface BusWebUiBridge {
    * daemon boot.
    */
   defaultAgentId: string;
+  /**
+   * #315: ids of agents with an in-flight turn, for the pre-auth `/api/health`
+   * busy signal. Lets an external restart guard drain-then-restart instead of
+   * killing a turn mid-flight. Bus-derived, so absent in legacy (non-bus) mode
+   * → the health field is simply omitted.
+   */
+  activeTurnAgents: () => string[];
 }
 
 export interface BusWebUiPromptResult {


### PR DESCRIPTION
Refs #315.

## Problem

Restarting the daemon while an agent turn is in flight kills that turn silently — the pending reply is dropped. There is no signal an external deploy/restart tool can gate on to know a turn is active. (Filed as #315.)

## What this PR does — the busy-signal half

Exposes a **turn-active signal on the pre-auth `/api/health`** so external tooling can *drain-then-restart* instead of killing an in-flight turn:

- `busy: boolean` — true if any agent has a turn in flight (a `prompt` seen, no `response.turn_end` yet).
- `activeTurns: number` — the count, **only with the web token** (matches the #178 rule: the unauthenticated health payload carries boolean signals only; diagnostic detail requires the token).
- `ok` **stays `true`** while busy.

Plumbing: `BusCore` gains `activeTurnAgents(): string[]` (an aggregate sibling of the existing `isAgentTurnActive`), threaded to the web layer through the existing `BusWebUiBridge` (callback-shaped, so `server.ts` keeps no `BusCore` dependency). In legacy (non-bus) mode there is no bus, so the field is simply omitted.

## Design rationale

- **`busy` is orthogonal to health, not readiness.** A busy agent is not deadlocked and should not be evicted from routing, so `ok`/HTTP 200 is kept while busy; readiness-false / 503 is reserved for actual draining. (Kubernetes probe semantics; IETF `draft-inadarei-api-health-check` — unknown health fields are additive and MUST be ignored by consumers, so this is non-breaking.)
- **Gauge, not counter.** `activeTurns` is an integer gauge; naming avoids a `_total`/`_count` suffix (Prometheus conventions).
- **Consistent with #178.** Reuses the established pattern of putting a discriminator signal on the pre-auth `/api/health` with `ok` unchanged, boolean-only pre-auth.

## Consumer

An external restart guard reads `busy` (pre-auth, no token needed) and drains-then-waits before restarting — the two-phase graceful-shutdown pattern (flip-not-ready → wait for in-flight zero → bounded force). This PR is the signal half; a **graceful drain on `SIGTERM`** (stop accepting new prompts, let the current turn reach `turn_end` within a bounded timeout) is the natural follow-up and would let `stop()` itself honor the signal.

## Test plan

- **Unit/integration** (`src/ui/__tests__/api-auth-enforcement.test.ts`, 4 new cases): busy omitted with no bus (legacy); `busy:false` idle with `ok:true`; `busy:true` mid-turn with `ok:true`; pre-auth carries the boolean only while the count requires the token. Full `src/bus` + `src/ui` suites green (533 pass, 0 fail).
- **Live, end-to-end on a running bus-mode daemon**: `/api/health` reported `busy:false` at idle, `busy:true` continuously throughout an injected in-flight turn, and `busy:false` after `turn_end` — confirming the real wiring (`BusCore.activeTurnAgents()` → bridge → health), not just the stubbed test.
- No new lint errors; no new `tsc` errors (baseline diff on the touched files is unchanged).

Draft: opening for direction on the exposure surface (health field vs a dedicated status route) before finalizing — happy to adjust.
