### PR TITLE
fix(bus): give the warn-only critical escalation its own latch (closes #322)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.198",
+      "version": "2.2.204",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.198",
+  "version": "2.2.204",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/stall-watchdog.test.ts
+++ b/src/bus/__tests__/stall-watchdog.test.ts
@@ -27,7 +27,7 @@ function evt(
 
 function stateWith(tools: Array<{ id: string; name: string; startedAt: number }>) {
   const s = newSessionState("reg", "s1", 0);
-  for (const t of tools) s.outstanding.set(t.id, { ...t, warned: false });
+  for (const t of tools) s.outstanding.set(t.id, { ...t, warned: false, criticalWarned: false });
   return s;
 }
 
@@ -430,5 +430,21 @@ describe("stop() while a kill is mid-flight", () => {
 
     expect(calls.restart).toBe(0); // no restart started after stop() began
     expect(calls.recordKill).toBe(0); // and the kill aborted before recording
+  });
+
+  it("warn-only mode fires BOTH warn and critical for one tool crossing both ceilings (#322)", async () => {
+    const { deps, rec } = recordingDeps();
+    const warnOnly = { ...DEFAULT_STALL_CONFIG, action: "warn" as const };
+    const wd = new StallWatchdog(warnOnly, deps);
+    wd.ingest(evt("response.tool_use", 0, { id: "b1", name: "Bash" }));
+    // cross the warn ceiling (past 300s, before the 900s kill ceiling) → soft warn
+    await wd.sweep((C.bash.warnSeconds + 1) * 1000);
+    // later cross the kill ceiling → the critical "NOT restarting" escalation must
+    // still fire, even though the soft warn already latched (the #322 bug).
+    await wd.sweep((C.bash.killSeconds + 1) * 1000);
+    expect(rec.notify.some((n) => n.level === "warn")).toBe(true);
+    const crit = rec.notify.find((n) => n.level === "critical");
+    expect(crit).toBeDefined();
+    expect(crit?.message).toContain("NOT restarting");
   });
 });

--- a/src/bus/stall-watchdog.ts
+++ b/src/bus/stall-watchdog.ts
@@ -173,6 +173,9 @@ interface OutstandingTool {
   startedAt: number;
   /** True once a `warn` has been emitted, so we don't ping every sweep. */
   warned: boolean;
+  /** #322: separate latch for the warn-only CRITICAL escalation, so it
+   *  fires once even after the soft `warned` latch is already set. */
+  criticalWarned: boolean;
 }
 
 export interface SessionStallState {
@@ -328,7 +331,13 @@ export class StallWatchdog {
       case "response.tool_use": {
         const p = e.payload as { id?: string; name?: string };
         if (p?.id && p?.name) {
-          s.outstanding.set(p.id, { id: p.id, name: p.name, startedAt: e.ts, warned: false });
+          s.outstanding.set(p.id, {
+          id: p.id,
+          name: p.name,
+          startedAt: e.ts,
+          warned: false,
+          criticalWarned: false,
+        });
         }
         break;
       }
@@ -374,8 +383,8 @@ export class StallWatchdog {
       if (this.config.action === "warn") {
         // warn-only mode: flag at the kill ceiling but never restart.
         const t = s.outstanding.get(decision.toolUseId);
-        if (t && !t.warned) {
-          t.warned = true;
+        if (t && !t.criticalWarned) {
+          t.criticalWarned = true;
           this.deps.notify(
             "critical",
             `Session ${s.agentId} \`${decision.tool}\` outstanding ` +

--- a/src/bus/stall-watchdog.ts
+++ b/src/bus/stall-watchdog.ts
@@ -332,12 +332,12 @@ export class StallWatchdog {
         const p = e.payload as { id?: string; name?: string };
         if (p?.id && p?.name) {
           s.outstanding.set(p.id, {
-          id: p.id,
-          name: p.name,
-          startedAt: e.ts,
-          warned: false,
-          criticalWarned: false,
-        });
+            id: p.id,
+            name: p.name,
+            startedAt: e.ts,
+            warned: false,
+            criticalWarned: false,
+          });
         }
         break;
       }


### PR DESCRIPTION
Closes #322.

## Problem

`sweep()` had two notify branches sharing one per-tool `warned` latch:
- the **soft warn** at the warn ceiling (`stall-watchdog.ts:359`);
- the **critical** "past kill ceiling, NOT restarting" escalation used in warn-only mode (`action: "warn"`).

`evaluateStall` returns `warn` before `kill` (ceilings are ordered warn-then-kill), so the first sweep past the warn ceiling sets `t.warned = true`. When the tool later crosses the **kill** ceiling, the critical branch finds `t.warned` already true and its `notify("critical", …)` never fires. In warn-only mode the operator gets the soft "outstanding for 120s" notice and **never** the critical escalation — the one that says the tool blew through the kill ceiling. Since #301 delivers these to chat surfaces (not just the log), the missing alert is a visible gap. Not a problem in the default `action: "restart"` mode, where the kill path never consults the latch.

## Fix

Give the critical escalation its own latch: add `criticalWarned: boolean` to `OutstandingTool`; the warn-only critical branch gates on `!t.criticalWarned` / sets it. Now both alerts fire once each for a tool that crosses both ceilings.

## Test

New case in `stall-watchdog.test.ts`: in warn-only mode a tool crosses the warn ceiling then the kill ceiling; asserts **both** a `warn` and a `critical` ("NOT restarting") notify arrive. It is a genuine regression test — it **fails without the src fix** (the critical is `undefined`) and passes with it (verified by stash-reverting only the source).

## Note

Found via an adversarial review pass that also caught a second `OutstandingTool` construction site (a test helper) needing the new field — fixed, so `tsc` is unchanged (repo-wide 452, no new errors). Full `src/bus` suite green (504 pass, 0 fail); verified the daemon still boots clean with the change.
