### PR TITLE
fix(security/slack): defang outbound mention tokens at the send boundary (closes #336)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.209",
+      "version": "2.2.210",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.209",
+  "version": "2.2.210",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/slack/__tests__/slack.test.ts
+++ b/src/adapters/slack/__tests__/slack.test.ts
@@ -34,6 +34,7 @@ import {
   buildPermissionBlocks,
   PERMISSION_ACTION_ID_REGEX,
   mdToSlackMrkdwn,
+  defangSlackMentions,
 } from "../index";
 import type { BusCore, SendPromptRequest } from "../../../bus/core";
 import type {
@@ -1876,5 +1877,42 @@ describe("mdToSlackMrkdwn — Markdown → Slack mrkdwn (#325)", () => {
     // multi-line bold converts (dotAll); code/italic pass through unchanged.
     expect(mdToSlackMrkdwn("**two\nlines**")).toBe("*two\nlines*");
     expect(mdToSlackMrkdwn("`code` and _i_")).toBe("`code` and _i_");
+  });
+});
+
+describe("defangSlackMentions — neutralise broadcast/user tokens (#336)", () => {
+  it("defangs @channel/@here/@everyone broadcasts to inert text", () => {
+    expect(defangSlackMentions("heads up <!channel> now")).toBe("heads up @channel now");
+    expect(defangSlackMentions("<!here> and <!everyone>")).toBe("@here and @everyone");
+  });
+
+  it("defangs user and subteam mentions, preferring the display name", () => {
+    expect(defangSlackMentions("ping <@U12345>")).toBe("ping @U12345");
+    expect(defangSlackMentions("ping <@U12345|alice>")).toBe("ping @alice");
+    expect(defangSlackMentions("cc <!subteam^S1|@oncall>")).toBe("cc @oncall");
+    expect(defangSlackMentions("cc <!subteam^S1>")).toBe("cc @subteam");
+  });
+
+  it("leaves mrkdwn links and plain text untouched", () => {
+    // Must not mangle mdToSlackMrkdwn output (`<url|label>`), nor inert `@foo`.
+    expect(defangSlackMentions("see <https://x.io/y|docs>")).toBe("see <https://x.io/y|docs>");
+    expect(defangSlackMentions("just @channel plain")).toBe("just @channel plain");
+    expect(defangSlackMentions("no tokens here")).toBe("no tokens here");
+  });
+});
+
+describe("SlackAdapter — outbound mention defang at the send boundary (#336)", () => {
+  it("defangs a broadcast token in a response.text before posting", async () => {
+    adapter = await startAdapter();
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "deploy done <!channel>", origin: "slack", origin_id: "C100" },
+    });
+    await waitFor(() => api.sent.length > 0);
+    expect(api.sent[0]?.text).toBe("deploy done @channel");
+    expect(api.sent[0]?.text).not.toContain("<!channel>");
   });
 });

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -91,6 +91,30 @@ export function mdToSlackMrkdwn(md: string): string {
 }
 
 /**
+ * #336: neutralise Slack broadcast/user mention TOKENS in outbound text so
+ * model-generated or interpolated content (tool names, `err.message`, …) can't
+ * fire a real @channel/@here/@everyone/@user ping. Slack renders `<!channel>`,
+ * `<!here>`, `<!everyone>`, `<!subteam^…>` and `<@U…>` as live pings regardless
+ * of `link_names`, and there is no `allowed_mentions` equivalent — so the send
+ * boundary is the only lever (same threat class as the Discord #323 fix).
+ *
+ * Each token is rewritten to its INERT plain-text form (`@channel`, `@here`, the
+ * handle/display name…) — inert because the adapter never sets `link_names`, so
+ * a bare `@name` does not auto-link. `<url|label>` links are left untouched
+ * (they match neither `<!` nor `<@`), preserving {@link mdToSlackMrkdwn} output.
+ */
+export function defangSlackMentions(text: string): string {
+  return text
+    .replace(/<!(channel|here|everyone)>/g, "@$1")
+    .replace(/<!subteam\^[A-Z0-9]+(?:\|@?([^>]+))?>/g, (_m, name) =>
+      name ? `@${name}` : "@subteam",
+    )
+    .replace(/<@([A-Z0-9]+)(?:\|@?([^>]+))?>/g, (_m: string, id: string, name?: string) =>
+      name ? `@${name}` : `@${id}`,
+    );
+}
+
+/**
  * Cap on the `seenEventIds` LRU. Slack retries every ~1s up to 3 times,
  * so a 5k entry cap covers >1h of traffic at 1 event/sec — far beyond
  * the retry window — while bounding memory to ~5k strings (~200kB).
@@ -823,8 +847,13 @@ export class SlackAdapter {
     thread_ts?: string;
     blocks?: SlackBlock[];
   }): Promise<void> {
+    // #336: defang mention/broadcast tokens on EVERY outbound send — this is the
+    // single choke point all handlers (response.text, permission, request_human,
+    // operator_alert) route through, so no site can forget it. (Block Kit `blocks`
+    // are adapter-authored, not model output; the `text` field is the vector.)
+    const safe = { ...params, text: defangSlackMentions(params.text) };
     try {
-      const res = await this.api.postMessage(params);
+      const res = await this.api.postMessage(safe);
       if (!res.ok) {
         this.logger.error(`[slack-adapter] chat.postMessage error: ${res.error ?? "unknown"}`);
       }


### PR DESCRIPTION
Closes #336. Same threat class as #323 (the Discord `allowed_mentions` fix), lower severity.

## Problem
Model-generated / interpolated outbound text (tool names, `err.message`, …) routed through `safePostMessage` → `chat.postMessage` can contain literal Slack tokens `<!channel>`, `<!here>`, `<!everyone>`, `<!subteam^…>`, or `<@U…>`, which fire **real pings regardless of `link_names`**. Slack has no `allowed_mentions` equivalent, so the send boundary is the only lever.

## Fix
- `defangSlackMentions(text)` rewrites each token to its **inert** plain-text form (`@channel`, the display name, …) — inert because the adapter never sets `link_names`, so a bare `@name` doesn't auto-link. `<url|label>` mrkdwn links are left intact (preserves `mdToSlackMrkdwn` output).
- Applied in **`safePostMessage`** — the single choke point every handler (`response.text`, permission, `request_human`, `operator_alert`) routes through, so no send site can forget it. This follows the #323 review's altitude note: defend at the boundary, not per-call-site.

Block Kit `blocks` are adapter-authored (not model output); the `text` field is the vector, so that's what's defanged.

## Tests
- `defangSlackMentions` unit cases: each token class (broadcast / user / subteam, with and without display name) + link/plain passthrough.
- End-to-end: a `response.text` carrying `<!channel>` is defanged before `chat.postMessage`.

All 83 slack-suite tests pass; `tsc` and biome clean (FakeBus baseline errors unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
