### PR TITLE
fix(telegram): ack already-resolved pending actions distinctly from not-found (closes #314)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.210",
+      "version": "2.2.211",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.210",
+  "version": "2.2.211",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/commands/__tests__/telegram-pending-ack.test.ts
+++ b/src/commands/__tests__/telegram-pending-ack.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "bun:test";
+import { ackForAlready } from "../telegram.js";
+
+// #314: a pending-action button tapped after it was already resolved must ack
+// the PRIOR decision + when, not the alarming "not found". ackForAlready parses
+// the resolver's `already:<decision>:<resolved_at>` string.
+describe("ackForAlready (#314)", () => {
+  it("names the prior decision and renders the timestamp DD/MM HH:MM", () => {
+    expect(ackForAlready("already:approve:2026-07-16T11:51:00")).toBe(
+      "✅ Déjà approuvé (16/07 11:51)",
+    );
+    expect(ackForAlready("already:reject:2026-07-16T09:05:12")).toBe(
+      "❌ Déjà rejeté (16/07 09:05)",
+    );
+    expect(ackForAlready("already:skip:2026-07-16T09:05:12")).toBe("⏸ Déjà reporté (16/07 09:05)");
+  });
+
+  it("maps decision synonyms (cancel/rejected/skipped)", () => {
+    expect(ackForAlready("already:cancel:2026-01-02T03:04:00")).toBe(
+      "❌ Déjà rejeté (02/01 03:04)",
+    );
+    expect(ackForAlready("already:rejected:2026-01-02T03:04:00")).toBe(
+      "❌ Déjà rejeté (02/01 03:04)",
+    );
+    expect(ackForAlready("already:skipped:2026-01-02T03:04:00")).toBe(
+      "⏸ Déjà reporté (02/01 03:04)",
+    );
+  });
+
+  it("omits the timestamp when absent or unparseable, defaults to approved", () => {
+    expect(ackForAlready("already:approve")).toBe("✅ Déjà approuvé");
+    expect(ackForAlready("already:approve:not-a-date")).toBe("✅ Déjà approuvé");
+    // Unknown decision string → treated as the approve default (informative, not alarming).
+    expect(ackForAlready("already:done:2026-07-16T11:51:00")).toBe(
+      "✅ Déjà approuvé (16/07 11:51)",
+    );
+  });
+});

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1824,6 +1824,30 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
   }
 }
 
+/**
+ * Ack for an `already:<decision>:<resolved_at>` resolution (#314) — the user
+ * tapped a pending-action button whose action was resolved earlier (a
+ * double-tap, a Telegram callback retry after a slow ack, or a duplicate
+ * notification). Names the PRIOR decision and when it happened, so the ack is
+ * informative instead of the alarming "not found" the boolean resolver forced.
+ *
+ * `resolved_at` is the ISO timestamp the resolver reports; it is rendered
+ * `DD/MM HH:MM` when parseable, omitted otherwise.
+ */
+export function ackForAlready(resolution: string): string {
+  const rest = resolution.slice("already:".length);
+  const sep = rest.indexOf(":");
+  const decision = (sep === -1 ? rest : rest.slice(0, sep)).toLowerCase();
+  const at = sep === -1 ? "" : rest.slice(sep + 1);
+  // "2026-07-16T11:51…" → " (16/07 11:51)"
+  const m = at.match(/^\d{4}-(\d{2})-(\d{2})T(\d{2}:\d{2})/);
+  const when = m ? ` (${m[2]}/${m[1]} ${m[3]})` : "";
+  if (decision === "reject" || decision === "cancel" || decision === "rejected")
+    return `❌ Déjà rejeté${when}`;
+  if (decision === "skip" || decision === "skipped") return `⏸ Déjà reporté${when}`;
+  return `✅ Déjà approuvé${when}`;
+}
+
 // --- Callback query handler ---
 
 async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> {
@@ -1896,7 +1920,12 @@ async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> 
               "python3",
               [
                 "-c",
-                "import sys; sys.path.insert(0, sys.argv[1]); from pending import resolve_pending; ok = resolve_pending(int(sys.argv[2]), sys.argv[3]); print('ok' if ok else 'not_found')",
+                // #314: prefer the richer `resolve_pending_ex`
+                // (ok|not_found|already:<decision>:<at>) when the operator's lib
+                // provides it, so an already-resolved tap is distinguishable from
+                // a genuinely unknown/expired one; fall back to the boolean
+                // `resolve_pending` otherwise (zero regression for older libs).
+                "import sys; sys.path.insert(0, sys.argv[1]); import pending; f = getattr(pending, 'resolve_pending_ex', None); print(f(int(sys.argv[2]), sys.argv[3]) if f else ('ok' if pending.resolve_pending(int(sys.argv[2]), sys.argv[3]) else 'not_found'))",
                 pendingLibPath,
                 actionId,
                 decision,
@@ -1913,8 +1942,11 @@ async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> 
           if (decLower === "skip") ackText = "⏸ Plus tard";
           else if (decLower === "reject" || decLower === "cancel") ackText = "❌ Rejeté";
           else ackText = "✅ Approuvé";
+        } else if (result.stdout.startsWith("already:")) {
+          // #314: already resolved — ack the prior decision, not "not found".
+          ackText = ackForAlready(result.stdout);
         } else {
-          ackText = "⚠️ Action introuvable ou déjà traitée";
+          ackText = "⚠️ Action introuvable";
         }
         // Edit original message to show decision
         if (query.message) {


### PR DESCRIPTION
Closes #314.

## Problem
`handleCallbackQuery` in `src/commands/telegram.ts` mapped **every** non-`ok` resolution to `⚠️ Action introuvable ou déjà traitée`. A user who double-taps a decision button — or whose tap is retried by Telegram after a slow ack — got that alarming "action lost" warning even though their **first** tap already succeeded, indistinguishable from a genuinely unknown/expired action. The boolean `resolve_pending` collapses "unknown id" and "already resolved" into one `False`.

## Fix (the shape you proposed in #314)
- The inline resolver prefers `resolve_pending_ex` → `ok | not_found | already:<decision>:<resolved_at>` when the operator's `pending` lib exposes it, and **falls back** to the boolean `resolve_pending` otherwise — zero regression for existing operator libs:
  ```py
  import pending; f = getattr(pending, 'resolve_pending_ex', None)
  print(f(id, decision) if f else ('ok' if pending.resolve_pending(id, decision) else 'not_found'))
  ```
- `already:` acks the **prior** decision + when via the new exported `ackForAlready` (`✅ Déjà approuvé (16/07 11:51)`, `❌ Déjà rejeté …`, `⏸ Déjà reporté …` — matching the existing French acks in this handler). Genuine misses now ack the narrower `⚠️ Action introuvable`.
- The original message is still edited + keyboard dropped for `already:` (correct: it reflects the settled decision).

## Resolver protocol (operator-provided)
`pending` is not shipped here. A resolver implementing `resolve_pending_ex(action_id, decision)` returns:
- `"ok"` — resolved now,
- `"not_found"` — unknown/expired id,
- `"already:<decision>:<iso_ts>"` — already resolved earlier (e.g. `already:approve:2026-07-16T11:51:00`).

Libs without it keep the boolean `resolve_pending` path unchanged.

## Tests
Unit tests for `ackForAlready`: decision synonyms (cancel/rejected/skipped), `DD/MM HH:MM` timestamp render, and absent/unparseable timestamp. The `execFile` integration in the legacy runtime isn't unit-harnessed (consistent with the rest of that handler); the pure parsing/formatting logic is fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
