### PR TITLE
feat(webui): surface operator alerts on the dashboard via polled /api/state (closes #325)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.211",
+      "version": "2.2.212",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.211",
+  "version": "2.2.212",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/operator-alert-buffer.test.ts
+++ b/src/bus/__tests__/operator-alert-buffer.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "bun:test";
+import { OperatorAlertBuffer, DEFAULT_MAX_OPERATOR_ALERTS } from "../operator-alert-buffer.js";
+import type { BusEvent } from "../types";
+
+function alert(text: string, level: "warn" | "critical" = "warn", ts = 1, agent = "reg"): BusEvent {
+  return {
+    ts,
+    agent_id: agent,
+    session_id: "s1",
+    topic: "system.operator_alert",
+    payload: { level, text, source: "stall-watchdog" },
+  };
+}
+
+describe("OperatorAlertBuffer (#325)", () => {
+  it("records alerts oldest-first with level/source/agent", () => {
+    const buf = new OperatorAlertBuffer();
+    buf.ingest(alert("first", "warn", 10, "reg"));
+    buf.ingest(alert("second", "critical", 20, "suzy"));
+    const recent = buf.recent();
+    expect(recent).toHaveLength(2);
+    expect(recent[0]).toEqual({
+      ts: 10,
+      agentId: "reg",
+      level: "warn",
+      text: "first",
+      source: "stall-watchdog",
+    });
+    expect(recent[1]?.level).toBe("critical");
+    expect(recent[1]?.agentId).toBe("suzy");
+  });
+
+  it("drops an alert with no usable text", () => {
+    const buf = new OperatorAlertBuffer();
+    buf.ingest({
+      ts: 1,
+      agent_id: "reg",
+      session_id: "s",
+      topic: "system.operator_alert",
+    } as unknown as BusEvent);
+    buf.ingest({
+      ts: 2,
+      agent_id: "reg",
+      session_id: "s",
+      topic: "system.operator_alert",
+      payload: { level: "warn", source: "x" },
+    } as BusEvent);
+    expect(buf.recent()).toHaveLength(0);
+  });
+
+  it("defaults a non-critical/absent level to warn", () => {
+    const buf = new OperatorAlertBuffer();
+    buf.ingest({
+      ts: 1,
+      agent_id: "reg",
+      session_id: "s",
+      topic: "system.operator_alert",
+      payload: { text: "no level" },
+    } as BusEvent);
+    expect(buf.recent()[0]?.level).toBe("warn");
+  });
+
+  it("evicts oldest-first past the cap", () => {
+    const buf = new OperatorAlertBuffer(3);
+    for (let i = 1; i <= 5; i++) buf.ingest(alert(`a${i}`, "warn", i));
+    const recent = buf.recent();
+    expect(recent.map((r) => r.text)).toEqual(["a3", "a4", "a5"]); // 3 newest
+  });
+
+  it("attaches a single topic subscription and detaches it", () => {
+    let closed = false;
+    let filter: unknown = null;
+    const fakeBus = {
+      subscribe(f: unknown) {
+        filter = f;
+        return { id: "1", close: () => (closed = true), overflowCount: 0, depth: 0 };
+      },
+    };
+    const buf = new OperatorAlertBuffer();
+    // biome-ignore lint/suspicious/noExplicitAny: minimal BusCore seam for the subscribe/close contract.
+    buf.attach(fakeBus as any);
+    expect(filter).toEqual({ topics: ["system.operator_alert"] });
+    // biome-ignore lint/suspicious/noExplicitAny: idempotent re-attach must not double-subscribe.
+    buf.attach(fakeBus as any); // idempotent
+    buf.detach();
+    expect(closed).toBe(true);
+    expect(DEFAULT_MAX_OPERATOR_ALERTS).toBeGreaterThan(0);
+  });
+});

--- a/src/bus/operator-alert-buffer.ts
+++ b/src/bus/operator-alert-buffer.ts
@@ -1,0 +1,70 @@
+/**
+ * Bounded ring of recent `system.operator_alert` events for the web dashboard.
+ *
+ * operator_alerts (stall watchdog false-positive flags, restart failures, …)
+ * are delivered live to the chat adapters (Slack/Discord/Telegram) but the web
+ * UI has no server→client push — only polled `/api/state`. So instead of a
+ * stream, the daemon keeps the last N alerts here and the dashboard reads them
+ * on its normal poll (#325). Subscribe once across ALL agents; the panel reads
+ * `recent()`.
+ *
+ * Volume, not disclosure: the producer already caps each alert's text
+ * (`MAX_ALERT_CHARS`) and the full copy lives in the daemon log — this only
+ * bounds how many alerts the polled surface remembers.
+ */
+import type { BusCore, Subscription } from "./core";
+import type { BusEvent } from "./types";
+import { OPERATOR_ALERT_TOPIC, type OperatorAlertPayload } from "./stall-alert-delivery";
+
+export interface OperatorAlertRecord {
+  /** Event timestamp (ms). */
+  ts: number;
+  agentId: string;
+  level: "warn" | "critical";
+  text: string;
+  /** Producer id (e.g. `stall-watchdog`), best-effort. */
+  source: string;
+}
+
+/** Default retained-alert cap. ~25 × ≤600 chars ≈ 15 kB worst case. */
+export const DEFAULT_MAX_OPERATOR_ALERTS = 25;
+
+export class OperatorAlertBuffer {
+  private readonly ring: OperatorAlertRecord[] = [];
+  private sub: Subscription | null = null;
+
+  constructor(private readonly max: number = DEFAULT_MAX_OPERATOR_ALERTS) {}
+
+  /** Subscribe to operator_alert across every agent. Idempotent. */
+  attach(bus: BusCore): void {
+    if (this.sub) return;
+    this.sub = bus.subscribe({ topics: [OPERATOR_ALERT_TOPIC] }, (e) => this.ingest(e));
+  }
+
+  /** Record one alert. Exposed for deterministic tests. A payload with no
+   *  usable `text` is dropped (nothing to show). */
+  ingest(event: BusEvent): void {
+    const p = event.payload as Partial<OperatorAlertPayload> | undefined;
+    const text = typeof p?.text === "string" ? p.text : "";
+    if (!text) return;
+    this.ring.push({
+      ts: event.ts,
+      agentId: event.agent_id,
+      level: p?.level === "critical" ? "critical" : "warn",
+      text,
+      source: typeof p?.source === "string" ? p.source : "",
+    });
+    // Evict oldest-first past the cap.
+    if (this.ring.length > this.max) this.ring.splice(0, this.ring.length - this.max);
+  }
+
+  /** Retained alerts, oldest-first (newest last). Copy — callers can't mutate. */
+  recent(): OperatorAlertRecord[] {
+    return [...this.ring];
+  }
+
+  detach(): void {
+    this.sub?.close();
+    this.sub = null;
+  }
+}

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -478,6 +478,11 @@ export async function start(args: string[] = []) {
   // turns Task/Agent tool_use → tool_result into board cards. Instantiated in the
   // deferred-spawn block once the bus + agents are up; stopped on teardown.
   let kanbanTracker: import("../bus/kanban-tracker").KanbanTracker | null = null;
+  // #325: recent operator alerts (stall watchdog, …) for the polled /api/state
+  // dashboard panel — a global bus subscriber over `system.operator_alert`.
+  // Mounted with the bus, detached on teardown; the web bridge reads it via
+  // `recentOperatorAlerts`.
+  let operatorAlertBuffer: import("../bus/operator-alert-buffer").OperatorAlertBuffer | null = null;
 
   // Plugin system — initialize before gateway start
   const pluginManager = new PluginManager(process.cwd());
@@ -633,6 +638,15 @@ export async function start(args: string[] = []) {
         console.error("[kanban-tracker] shutdown failed", err);
       }
       kanbanTracker = null;
+    }
+    // #325: detach the operator-alert buffer before the bus stops.
+    if (operatorAlertBuffer) {
+      try {
+        operatorAlertBuffer.detach();
+      } catch (err) {
+        console.error("[operator-alert-buffer] shutdown failed", err);
+      }
+      operatorAlertBuffer = null;
     }
     if (busRuntimeHandle) {
       try {
@@ -967,6 +981,17 @@ export async function start(args: string[] = []) {
       });
       busRuntimeHandle.attachScheduler(schedulerHandle);
 
+      // #325: mount the operator-alert buffer now that the bus is up — a global
+      // subscriber over `system.operator_alert` feeding the web dashboard's
+      // polled alerts panel. Detached in shutdown() below.
+      try {
+        const { OperatorAlertBuffer } = await import("../bus/operator-alert-buffer");
+        operatorAlertBuffer = new OperatorAlertBuffer();
+        operatorAlertBuffer.attach(busRuntimeHandle.bus);
+      } catch (err) {
+        console.error("[operator-alert-buffer] mount failed", err);
+      }
+
       // #294: mount the live Kanban tracker now that the bus + agents are up.
       // A pure global bus subscriber — maps subagent (Task/Agent) tool_use →
       // tool_result onto the Web UI board via the (previously unwired) kanban
@@ -1222,6 +1247,8 @@ export async function start(args: string[] = []) {
                   defaultAgentId: busRuntimeSpawnedAgents[0],
                   activeTurnAgents: () =>
                     (busCoreForWebUi as NonNullable<typeof busCoreForWebUi>).activeTurnAgents(),
+                  // #325: feed the dashboard's polled operator-alerts panel.
+                  recentOperatorAlerts: () => operatorAlertBuffer?.recent() ?? [],
                   sendPromptAndAwait: (agentId, text, sendOpts) =>
                     streamBusPrompt(
                       busCoreForWebUi as NonNullable<typeof busCoreForWebUi>,

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -126,6 +126,36 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     const quickJobsList = $("quick-jobs-list");
     const jobsBubbleEl = $("jobs-bubble");
     const uptimeBubbleEl = $("uptime-bubble");
+    const alertsEl = $("operator-alerts");
+
+    // #325: render the polled operator-alerts panel (newest first). Hidden when
+    // empty. Text is model/interpolated → always esc()'d.
+    function renderOperatorAlerts(alerts) {
+      if (!alertsEl) return;
+      const list = Array.isArray(alerts) ? alerts.slice().reverse() : [];
+      if (list.length === 0) {
+        alertsEl.hidden = true;
+        alertsEl.innerHTML = "";
+        return;
+      }
+      const rows = list.map((a) => {
+        const lvl = a && a.level === "critical" ? "critical" : "warn";
+        const icon = lvl === "critical" ? "🔴" : "⚠️";
+        const when = a && typeof a.ts === "number" ? new Date(a.ts).toLocaleTimeString() : "";
+        const meta = [a && a.agentId, a && a.source, when]
+          .filter(Boolean)
+          .map((s) => esc(String(s)))
+          .join(" · ");
+        return '<div class="op-alert ' + lvl + '">' +
+          '<span class="op-alert-icon">' + icon + "</span>" +
+          '<div class="op-alert-body">' +
+          '<div class="op-alert-text">' + esc(String((a && a.text) || "")) + "</div>" +
+          (meta ? '<div class="op-alert-meta">' + meta + "</div>" : "") +
+          "</div></div>";
+      }).join("");
+      alertsEl.innerHTML = '<div class="op-alert-head">⚠️ Operator alerts</div>' + rows;
+      alertsEl.hidden = false;
+    }
     let hbBusy = false;
     let hbSaveBusy = false;
     let use12Hour = localStorage.getItem("clock.format") === "12";
@@ -509,6 +539,7 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
             '<div class="side-value">' + esc(fmtDur(state.daemon?.uptimeMs ?? 0)) + "</div>" +
             '<div class="side-label">Uptime</div>';
         }
+        renderOperatorAlerts(state.operatorAlerts);
       } catch (err) {
         dockEl.innerHTML = '<div class="pill bad"><div class="pill-label"><span class="pill-icon">⚠️</span>Status</div><div class="pill-value">Offline</div></div>';
         if (jobsBubbleEl) {
@@ -521,6 +552,7 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
         if (uptimeBubbleEl) {
           uptimeBubbleEl.innerHTML = '<div class="side-icon">⏱️</div><div class="side-value">-</div><div class="side-label">Uptime</div>';
         }
+        renderOperatorAlerts([]);
       }
     }
     function smoothScrollTo(top) {

--- a/src/ui/page/styles.ts
+++ b/src/ui/page/styles.ts
@@ -1940,4 +1940,26 @@ export const pageStyles = String.raw`    :root {
   .lr-tiers { grid-template-columns: 1fr; }
   .lr-row { flex-direction: column; align-items: flex-start; }
 }
+
+/* #325: operator-alerts panel (polled via /api/state). Hidden when empty. */
+.operator-alerts {
+  margin: 12px auto 0;
+  max-width: 720px;
+  width: 100%;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.operator-alerts[hidden] { display: none; }
+.op-alert-head { font-size: 12px; font-weight: 600; color: var(--muted); letter-spacing: 0.03em; }
+.op-alert { display: flex; align-items: flex-start; gap: 8px; padding: 6px 8px; border-radius: 8px; border-left: 3px solid var(--warn); background: #ffffff08; }
+.op-alert.critical { border-left-color: var(--bad); }
+.op-alert-icon { flex-shrink: 0; line-height: 1.4; }
+.op-alert-body { min-width: 0; }
+.op-alert-text { font-size: 13px; color: var(--text); white-space: pre-wrap; word-break: break-word; }
+.op-alert-meta { font-size: 11px; color: var(--muted); margin-top: 2px; }
 `;

--- a/src/ui/page/template.ts
+++ b/src/ui/page/template.ts
@@ -368,6 +368,9 @@ ${pageStyles}
     </aside>
   </div>
 
+  <!-- #325: out-of-band operator alerts (stall watchdog, …), polled via /api/state. Hidden when empty. -->
+  <section class="operator-alerts" id="operator-alerts" aria-live="polite" hidden></section>
+
   <script>
 ${pageScript}
   </script>

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -358,7 +358,10 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
       }
 
       if (url.pathname === "/api/state") {
-        return json(await buildState(opts.getSnapshot()));
+        // #325: fold the bus-derived operator alerts into the polled state.
+        // Absent bus (legacy mode) → empty list, no panel.
+        const state = await buildState(opts.getSnapshot());
+        return json({ ...state, operatorAlerts: opts.bus?.recentOperatorAlerts?.() ?? [] });
       }
 
       if (url.pathname === "/api/settings") {

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -87,6 +87,23 @@ export interface BusWebUiBridge {
    * → the health field is simply omitted.
    */
   activeTurnAgents: () => string[];
+  /**
+   * #325: recent out-of-band operator alerts (stall watchdog, restart-failed,
+   * …), newest last, for the polled `/api/state` dashboard panel — the web UI
+   * has no server→client push, so it reads them on its normal poll. Optional /
+   * bus-derived: absent in legacy (non-bus) mode → the dashboard shows no
+   * alerts panel.
+   */
+  recentOperatorAlerts?: () => OperatorAlertView[];
+}
+
+/** One entry of the `/api/state` operator-alerts panel (#325). */
+export interface OperatorAlertView {
+  ts: number;
+  agentId: string;
+  level: "warn" | "critical";
+  text: string;
+  source: string;
 }
 
 export interface BusWebUiPromptResult {


### PR DESCRIPTION
Closes #325 (the web-UI half — the Slack half shipped in #334).

## Problem
`operator_alert`s (stall watchdog false-positive flags, restart-failed, …) are delivered live to the chat adapters, but the web dashboard never saw them. The web UI has **no server→client push** — only polled `/api/state`.

## Approach — polled, not SSE
Alerts aren't sub-second critical, so instead of a new persistent push endpoint (EventSource + reconnect + stream auth), the daemon keeps the last N alerts in a bounded ring and the dashboard reads them on its **existing** `/api/state` poll. Minimal new surface.

## Server (fully tested)
- **`src/bus/operator-alert-buffer.ts`** — `OperatorAlertBuffer`: one topic-only subscription over `system.operator_alert` (all agents), bounded ring (default 25, oldest-first eviction), `recent()`.
- **`start.ts`** — mounted in the bus-runtime block next to the #294 Kanban tracker (same global-subscriber pattern), detached in `shutdown()`.
- **`ui/types.ts`** — `BusWebUiBridge.recentOperatorAlerts?()` + `OperatorAlertView`.
- **`ui/server.ts`** — `/api/state` folds in `operatorAlerts` (absent bus / legacy mode → `[]`, no panel).

## Client
Compact `aria-live` alerts panel below the dock, rendered from the poll: newest-first, hidden when empty, warn/critical styled via existing CSS vars. **All text is `esc()`'d** (model/interpolated input — consistent with the #323/#336 mention hardening).

## Tests
`OperatorAlertBuffer` unit suite (record order, level default, text-drop, cap eviction, single-subscribe/detach). `pageScript` validated to parse as JS. `tsc` delta vs baseline = 0; biome clean.

Note for reviewers: the client panel is additive/defensive but rendered layout wasn't visually diffed in this environment — a quick look at the dashboard is worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
