### PR TITLE
fix(telegram): report the pending resolver's verdict honestly

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.217",
+      "version": "2.2.218",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.218",
+      "version": "2.2.219",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.217",
+  "version": "2.2.218",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.218",
+  "version": "2.2.219",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/commands/__tests__/telegram-pending-ack.test.ts
+++ b/src/commands/__tests__/telegram-pending-ack.test.ts
@@ -4,6 +4,7 @@ import {
   ackForResolution,
   parseResolverVerdict,
   redactResolverDiagnostics,
+  describeResolverFailure,
 } from "../telegram.js";
 
 // #314: a pending-action button tapped after it was already resolved must ack
@@ -119,6 +120,33 @@ describe("redactResolverDiagnostics", () => {
     );
     expect(redactResolverDiagnostics("ConnectionRefusedError: [Errno 111]")).toBe(
       "ConnectionRefusedError: [Errno 111]",
+    );
+  });
+});
+
+describe("describeResolverFailure", () => {
+  // The four shapes execFile actually produces, confirmed against the real API:
+  // a spawn failure reports a STRING code and no signal, a timeout reports
+  // code null with a signal, an ordinary failure reports a numeric code.
+  it("names a spawn failure instead of calling it an exit status", () => {
+    expect(describeResolverFailure({ timedOut: false, signal: null, code: "ENOENT" })).toBe(
+      "spawn error ENOENT",
+    );
+  });
+
+  it("reports an ordinary non-zero exit as an exit status", () => {
+    expect(describeResolverFailure({ timedOut: false, signal: null, code: 3 })).toBe("exit 3");
+  });
+
+  it("prefers the timeout over the code the kill left behind", () => {
+    expect(describeResolverFailure({ timedOut: true, signal: "SIGTERM", code: null })).toBe(
+      "timed out",
+    );
+  });
+
+  it("names the signal when the process was killed but not by the timeout", () => {
+    expect(describeResolverFailure({ timedOut: false, signal: "SIGKILL", code: null })).toBe(
+      "killed by SIGKILL",
     );
   });
 });

--- a/src/commands/__tests__/telegram-pending-ack.test.ts
+++ b/src/commands/__tests__/telegram-pending-ack.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "bun:test";
-import { ackForAlready } from "../telegram.js";
+import {
+  ackForAlready,
+  ackForResolution,
+  parseResolverVerdict,
+  redactResolverDiagnostics,
+} from "../telegram.js";
 
 // #314: a pending-action button tapped after it was already resolved must ack
 // the PRIOR decision + when, not the alarming "not found". ackForAlready parses
@@ -33,6 +38,87 @@ describe("ackForAlready (#314)", () => {
     // Unknown decision string → treated as the approve default (informative, not alarming).
     expect(ackForAlready("already:done:2026-07-16T11:51:00")).toBe(
       "✅ Déjà approuvé (16/07 11:51)",
+    );
+  });
+});
+
+// A resolver that prints no verdict is not the same fact as `not_found`: the
+// resolver commits its decision before we read its exit status, so "no verdict"
+// says nothing about whether the tap applied. And the verdict is the LAST line,
+// because an operator's resolver may log its own diagnostics first.
+describe("parseResolverVerdict", () => {
+  it("recognises the three verdicts a resolver can print", () => {
+    expect(parseResolverVerdict("ok").verdict).toBe("ok");
+    expect(parseResolverVerdict("not_found").verdict).toBe("not_found");
+    const already = parseResolverVerdict("already:approve:2026-07-16T11:51:00");
+    expect(already.verdict).toBe("already");
+    expect(already.line).toBe("already:approve:2026-07-16T11:51:00");
+  });
+
+  it("reads the verdict off the last non-empty line, past the resolver's own logs", () => {
+    // The shape that misreported an applied decision: the resolver logged a
+    // failed notification edit on stdout, then printed its verdict.
+    expect(parseResolverVerdict("[pending] Telegram edit error: HTTP 429\nok").verdict).toBe("ok");
+    expect(parseResolverVerdict("warning: deprecated\nnot_found\n\n").verdict).toBe("not_found");
+    expect(parseResolverVerdict("noise\nalready:skip:2026-07-16T09:05:12").line).toBe(
+      "already:skip:2026-07-16T09:05:12",
+    );
+  });
+
+  it("reports no verdict when the resolver printed none", () => {
+    expect(parseResolverVerdict("").verdict).toBe("no_answer");
+    expect(parseResolverVerdict("   \n  ").verdict).toBe("no_answer");
+    expect(parseResolverVerdict("Traceback (most recent call last):").verdict).toBe("no_answer");
+  });
+});
+
+describe("ackForResolution", () => {
+  it("names the decision that was taken", () => {
+    expect(ackForResolution("ok", "approve")).toBe("✅ Approuvé");
+    expect(ackForResolution("ok", "skip")).toBe("⏸ Plus tard");
+    expect(ackForResolution("ok", "reject")).toBe("❌ Rejeté");
+    expect(ackForResolution("ok", "cancel")).toBe("❌ Rejeté");
+  });
+
+  it("delegates an already-resolved tap to ackForAlready", () => {
+    expect(ackForResolution("already:reject:2026-07-16T09:05:12", "approve")).toBe(
+      "❌ Déjà rejeté (16/07 09:05)",
+    );
+  });
+
+  it("keeps 'not found' for a genuinely unknown action id", () => {
+    expect(ackForResolution("not_found", "approve")).toBe("⚠️ Action introuvable");
+  });
+
+  it("acks a missing verdict as retryable instead of claiming the id is unknown", () => {
+    expect(ackForResolution("", "approve")).toBe("⚠️ Erreur — réessaie");
+    expect(ackForResolution("Traceback (most recent call last):", "approve")).toBe(
+      "⚠️ Erreur — réessaie",
+    );
+  });
+
+  it("acks the decision when the verdict trails the resolver's own output", () => {
+    expect(ackForResolution("[pending] Telegram edit error: HTTP 429\nok", "approve")).toBe(
+      "✅ Approuvé",
+    );
+  });
+});
+
+describe("redactResolverDiagnostics", () => {
+  it("strips a bot token out of a resolver traceback", () => {
+    const raw =
+      "urllib.error.HTTPError: https://api.telegram.org/bot123456789:AAH1x_fakeTokenValue0000000/editMessageText";
+    const out = redactResolverDiagnostics(raw);
+    expect(out).toContain("bot<redacted>");
+    expect(out).not.toContain("AAH1x_fakeTokenValue0000000");
+  });
+
+  it("strips bearer credentials and leaves ordinary text alone", () => {
+    expect(redactResolverDiagnostics("Authorization: Bearer abcdefghijklmnopqrst")).toBe(
+      "Authorization: Bearer <redacted>",
+    );
+    expect(redactResolverDiagnostics("ConnectionRefusedError: [Errno 111]")).toBe(
+      "ConnectionRefusedError: [Errno 111]",
     );
   });
 });

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1902,6 +1902,25 @@ export function ackForResolution(stdout: string, decision: string): string {
  * lives in the request URL — into its stderr. Mirrors the redaction the PTY
  * tail applies for the same reason.
  */
+/**
+ * Describe how the pending resolver failed, in the shape an operator can act on.
+ *
+ * `code` is not always an exit status: a spawn failure (ENOENT, EACCES…) reports
+ * a string there, so labelling it `exit ENOENT` would misreport the very failure
+ * this diagnostic exists to explain. A signal kill reports `code: null`, which is
+ * why the signal and timeout cases are tested first.
+ */
+export function describeResolverFailure(result: {
+  timedOut: boolean;
+  signal: string | null;
+  code: number | string | null;
+}): string {
+  if (result.timedOut) return "timed out";
+  if (result.signal) return `killed by ${result.signal}`;
+  if (typeof result.code === "string") return `spawn error ${result.code}`;
+  return `exit ${result.code}`;
+}
+
 export function redactResolverDiagnostics(text: string): string {
   return text
     .replace(/\bbot\d+:[A-Za-z0-9_-]{20,}/g, "bot<redacted>")
@@ -2015,11 +2034,7 @@ async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> 
         if (verdict === "no_answer") {
           // No verdict: the ack cannot say whether the decision was applied, so
           // the operator needs the reason it failed.
-          const how = result.timedOut
-            ? "timed out"
-            : result.signal
-              ? `killed by ${result.signal}`
-              : `exit ${result.code}`;
+          const how = describeResolverFailure(result);
           const why = redactResolverDiagnostics(result.stderr).trim().slice(0, 200) || "no stderr";
           console.warn(
             `[Telegram] pending resolver reported no verdict for action ${actionId} (${how}): ${why}`,

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -21,7 +21,7 @@ import { resetSession, resetFallbackSession, peekSession } from "../sessions";
 import { peekThreadSession, removeThreadSession } from "../sessionManager";
 import { readFile, mkdir } from "node:fs/promises";
 import { existsSync, realpathSync, statSync, mkdirSync } from "node:fs";
-import { execFile } from "node:child_process";
+import { execFile, type ExecFileException } from "node:child_process";
 import { homedir } from "node:os";
 import { resolve, sep } from "node:path";
 import { resolveSkillPrompt, listSkills } from "../skills";
@@ -1848,6 +1848,66 @@ export function ackForAlready(resolution: string): string {
   return `✅ Déjà approuvé${when}`;
 }
 
+/** The four outcomes a pending resolver can report. `no_answer` is not a
+ *  statement about the action — it means we never got a verdict. */
+export type ResolverVerdict = "ok" | "already" | "not_found" | "no_answer";
+
+/**
+ * Read the resolver's verdict off its stdout.
+ *
+ * The verdict is the LAST non-empty line, not the whole buffer: the resolver is
+ * operator-supplied, and a resolver that logs its own diagnostics (a failed
+ * notification edit, a deprecation notice) prints them before the verdict it
+ * was asked for. Comparing the whole buffer classifies "diagnostic\nok" as
+ * garbage and misreports a decision that was in fact applied.
+ */
+export function parseResolverVerdict(stdout: string): { verdict: ResolverVerdict; line: string } {
+  const line =
+    stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .pop() ?? "";
+  if (line === "ok") return { verdict: "ok", line };
+  if (line.startsWith("already:")) return { verdict: "already", line };
+  if (line === "not_found") return { verdict: "not_found", line };
+  return { verdict: "no_answer", line };
+}
+
+/**
+ * Ack for a pending-action resolution.
+ *
+ * `not_found` is a statement about the action: the id is unknown, the button is
+ * stale. `no_answer` is a statement about the resolver: it never printed a
+ * verdict, so the action's fate is unknown — the resolver commits its decision
+ * before we read its exit status, so the tap may well have applied. Acking both
+ * as "not found" claims the tap was rejected when it may have landed.
+ */
+export function ackForResolution(stdout: string, decision: string): string {
+  const { verdict, line } = parseResolverVerdict(stdout);
+  if (verdict === "ok") {
+    const decLower = decision.toLowerCase();
+    if (decLower === "skip") return "⏸ Plus tard";
+    if (decLower === "reject" || decLower === "cancel") return "❌ Rejeté";
+    return "✅ Approuvé";
+  }
+  if (verdict === "already") return ackForAlready(line);
+  if (verdict === "not_found") return "⚠️ Action introuvable";
+  return "⚠️ Erreur — réessaie";
+}
+
+/**
+ * Strip credentials from resolver diagnostics before they reach the log. A
+ * resolver that fails while calling the Bot API can put the bot token — which
+ * lives in the request URL — into its stderr. Mirrors the redaction the PTY
+ * tail applies for the same reason.
+ */
+export function redactResolverDiagnostics(text: string): string {
+  return text
+    .replace(/\bbot\d+:[A-Za-z0-9_-]{20,}/g, "bot<redacted>")
+    .replace(/\bBearer\s+[A-Za-z0-9_.-]{16,}/g, "Bearer <redacted>");
+}
+
 // --- Callback query handler ---
 
 async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> {
@@ -1914,42 +1974,61 @@ async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> 
       ackText = "⚠️ Pending action handler not configured";
     } else {
       try {
-        const result = await new Promise<{ code: number; stdout: string; stderr: string }>(
-          (resolve) => {
-            execFile(
-              "python3",
-              [
-                "-c",
-                // #314: prefer the richer `resolve_pending_ex`
-                // (ok|not_found|already:<decision>:<at>) when the operator's lib
-                // provides it, so an already-resolved tap is distinguishable from
-                // a genuinely unknown/expired one; fall back to the boolean
-                // `resolve_pending` otherwise (zero regression for older libs).
-                "import sys; sys.path.insert(0, sys.argv[1]); import pending; f = getattr(pending, 'resolve_pending_ex', None); print(f(int(sys.argv[2]), sys.argv[3]) if f else ('ok' if pending.resolve_pending(int(sys.argv[2]), sys.argv[3]) else 'not_found'))",
-                pendingLibPath,
-                actionId,
-                decision,
-              ],
-              { timeout: 5000 },
-              (err: Error | null, stdout: string, stderr: string) => {
-                resolve({ code: err ? 1 : 0, stdout: stdout.trim(), stderr });
-              },
-            );
-          },
-        );
-        if (result.stdout === "ok") {
-          const decLower = decision.toLowerCase();
-          if (decLower === "skip") ackText = "⏸ Plus tard";
-          else if (decLower === "reject" || decLower === "cancel") ackText = "❌ Rejeté";
-          else ackText = "✅ Approuvé";
-        } else if (result.stdout.startsWith("already:")) {
-          // #314: already resolved — ack the prior decision, not "not found".
-          ackText = ackForAlready(result.stdout);
-        } else {
-          ackText = "⚠️ Action introuvable";
+        const result = await new Promise<{
+          code: number | string | null;
+          signal: string | null;
+          timedOut: boolean;
+          stdout: string;
+          stderr: string;
+        }>((resolve) => {
+          execFile(
+            "python3",
+            [
+              "-c",
+              // #314: prefer the richer `resolve_pending_ex`
+              // (ok|not_found|already:<decision>:<at>) when the operator's lib
+              // provides it, so an already-resolved tap is distinguishable from
+              // a genuinely unknown/expired one; fall back to the boolean
+              // `resolve_pending` otherwise (zero regression for older libs).
+              "import sys; sys.path.insert(0, sys.argv[1]); import pending; f = getattr(pending, 'resolve_pending_ex', None); print(f(int(sys.argv[2]), sys.argv[3]) if f else ('ok' if pending.resolve_pending(int(sys.argv[2]), sys.argv[3]) else 'not_found'))",
+              pendingLibPath,
+              actionId,
+              decision,
+            ],
+            { timeout: 5000 },
+            (err: ExecFileException | null, stdout: string, stderr: string) => {
+              // `err` carries the real exit code, or a signal when the 5s
+              // timeout killed the process — the three failure shapes this
+              // branch has to tell apart.
+              resolve({
+                code: err?.code ?? (err ? 1 : 0),
+                signal: err?.signal ?? null,
+                timedOut: err?.killed === true,
+                stdout: stdout.trim(),
+                stderr,
+              });
+            },
+          );
+        });
+        const { verdict } = parseResolverVerdict(result.stdout);
+        ackText = ackForResolution(result.stdout, decision);
+        if (verdict === "no_answer") {
+          // No verdict: the ack cannot say whether the decision was applied, so
+          // the operator needs the reason it failed.
+          const how = result.timedOut
+            ? "timed out"
+            : result.signal
+              ? `killed by ${result.signal}`
+              : `exit ${result.code}`;
+          const why = redactResolverDiagnostics(result.stderr).trim().slice(0, 200) || "no stderr";
+          console.warn(
+            `[Telegram] pending resolver reported no verdict for action ${actionId} (${how}): ${why}`,
+          );
         }
-        // Edit original message to show decision
-        if (query.message) {
+        // Edit the original message to record the decision — but only once we
+        // know one was taken. Editing strips the keyboard, and an ack that asks
+        // the user to retry must not delete the buttons it is pointing them at.
+        if (query.message && verdict !== "no_answer") {
           const originalText = query.message.text ?? "";
           await callApi(config.token, "editMessageText", {
             chat_id: query.message.chat.id,


### PR DESCRIPTION
## Problem

A pending-action button can ack `⚠️ Action introuvable` for an action that exists and whose decision was applied. The ack is the only feedback the operator gets, so a wrong one either hides a decision that landed or invites a retry that looks rejected.

## Root cause

`handleCallbackQuery` shells out to the operator's `pending.py` and maps its stdout to an ack. Three defects sit in how that result is read (`src/commands/telegram.ts`):

1. **The verdict was compared against the whole stdout buffer.** The resolver is operator-supplied and logs its own diagnostics. One that fails to edit its notification prints the error and *then* prints `ok`, so the buffer reads `…error…\nok` — matching no verdict, acked as "not found", while the decision had been committed.

2. **`not_found` and "the resolver printed nothing" shared one branch.** They are different facts. `not_found` describes the *action*: unknown id, stale button. A missing verdict describes the *resolver*, and says nothing about the action — the resolver commits its decision before we read its exit status.

3. **The message edit ran unconditionally.** So the ack asking the user to retry also stripped the keyboard, deleting the buttons it was pointing at.

Separately, the callback synthesised the exit status as `err ? 1 : 0`, collapsing spawn failure, non-zero exit and the 5s timeout into "exit 1" — the three shapes a diagnostic exists to tell apart.

## Fix

- `parseResolverVerdict` reads the verdict off the last non-empty line and returns one of `ok | already | not_found | no_answer`.
- `ackForResolution` maps that verdict to an ack. `ok`, `already:` and `not_found` keep their existing text; `no_answer` acks `⚠️ Erreur — réessaie`, which is retryable and asserts no outcome. Retrying is safe — the resolver is idempotent, so a second tap on an action that did resolve returns `already:` and acks the prior decision (#314).
- The message edit runs only once a verdict was reported, so the keyboard survives a resolver failure.
- The `no_answer` path logs the real exit code, signal, or timeout, with credentials redacted from the resolver's stderr first — a resolver failing against the Bot API can carry the bot token in the request URL.

Extracted as pure functions in the shape of `ackForAlready` (#314), so the mapping is testable without a Telegram round-trip.

## Test plan

- `bun run lint` — clean.
- `bun test src/commands` — 14 pass (4 existing from #314, 10 new).
- **Verified against a real resolver**, not just synthetic strings: the four stdout shapes were driven through the actual `execFile` call with a live `pending.py` — unknown id → `not_found` → "Action introuvable"; already-resolved id → `already:add:…` → "Déjà approuvé (20/08 20:21)"; resolver logging a diagnostic before its verdict → `ok` → "Approuvé" (the case that misreported before this change); resolver raising on import → no verdict → "Erreur — réessaie" plus the warn line carrying the real exit code.
- Token redaction checked against a Bot API URL in a traceback.
- Version bumped for the plugin and marketplace guards.

## Notes

- These tests run under the scoped form (`bun test src/commands`). In a whole-repo `bun test` this file's module load resolves through a mocked `telegram.ts` and the suite reports it as an error — that behaviour predates this change and affects the existing #314 tests in the same file identically. Happy to file it separately if you'd like it looked at; it seemed out of scope here.
- `src/commands` is not in the test job's scoped path list, so these tests don't run in CI.
- The Bus adapter is untouched: it documents `pending:` as out of scope (`src/adapters/telegram/index.ts`), so this is the only path in the repo that resolves these buttons.

Refs #314
