### PR TITLE
fix(bus): give dispatched agent jobs the shared MCP servers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.220",
+      "version": "2.2.221",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.220",
+  "version": "2.2.221",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ node_modules
 .codemachine
 AGENTS.md
 agents/*/session.json
+# Synthesized per-run `--mcp-config` for dispatched agent jobs. Holds a live
+# bearer token at rest (0600) and is deleted when the job ends — but a job
+# running during a `git add -A` must never stage one.
+agents/*/.claudeclaw/
 MEMORY.md
 # Daemon-generated runtime architecture description for the spawned agent.
 # Regenerated on every startup — must not be committed.

--- a/src/bus/__tests__/agent-job-mcp-config.test.ts
+++ b/src/bus/__tests__/agent-job-mcp-config.test.ts
@@ -13,10 +13,11 @@
  *      throws.
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PtyIdentity } from "../../runner/pty-mcp-config-writer";
+import { buildAgentJobArgs } from "../../runner";
 import { withAgentJobMcpConfig } from "../runtime-mount";
 import {
   type BusMcpConfigSynthesizer,
@@ -104,8 +105,10 @@ describe("synthesizeAgentJobMcpConfig", () => {
   it("revokes the identity and rethrows when the write fails (never a silent no-MCP run)", () => {
     const { synth, revoked } = makeSynth();
     // A path under a regular file: mkdir of `.claudeclaw` fails with ENOTDIR.
+    // Written synchronously on purpose — an unawaited async write would let
+    // mkdir(recursive) create the path as a DIRECTORY and invert this test.
     const notADir = join(cwd, "regular-file");
-    Bun.write(notADir, "x");
+    writeFileSync(notADir, "x");
 
     expect(() => synthesizeAgentJobMcpConfig("agent-job-boom", synth, notADir)).toThrow();
     expect(revoked).toEqual(["agent-job-boom"]);
@@ -118,7 +121,7 @@ describe("releaseAgentJobMcpConfig", () => {
     const path = synthesizeAgentJobMcpConfig("agent-job-rel", synth, cwd) as string;
     expect(existsSync(path)).toBe(true);
 
-    await releaseAgentJobMcpConfig("agent-job-rel", synth, cwd);
+    releaseAgentJobMcpConfig("agent-job-rel", synth, cwd);
 
     expect(revoked).toEqual(["agent-job-rel"]);
     expect(existsSync(path)).toBe(false);
@@ -126,9 +129,9 @@ describe("releaseAgentJobMcpConfig", () => {
 
   it("is idempotent and a no-op when the multiplexer is dormant", async () => {
     const { synth } = makeSynth();
-    await releaseAgentJobMcpConfig("agent-job-never-issued", synth, cwd);
-    await releaseAgentJobMcpConfig("agent-job-never-issued", synth, cwd);
-    await releaseAgentJobMcpConfig("agent-job-never-issued", null, cwd);
+    releaseAgentJobMcpConfig("agent-job-never-issued", synth, cwd);
+    releaseAgentJobMcpConfig("agent-job-never-issued", synth, cwd);
+    releaseAgentJobMcpConfig("agent-job-never-issued", null, cwd);
   });
 });
 
@@ -174,5 +177,70 @@ describe("withAgentJobMcpConfig", () => {
 
     expect(revoked).toEqual(issued);
     expect(existsSync(join(cwd, ".claudeclaw", `mcp-pty-${issued[0]}.json`))).toBe(false);
+  });
+});
+
+describe("release under a real (async) revoke", () => {
+  it("does not wait on multiplexer teardown — the job's slot is freed immediately", async () => {
+    // The real `revoke` is `plugin.releaseIdentity`, which closes transports
+    // and writes the multiplexer's persistence file. Awaiting it would hold
+    // the job's concurrency slot for the whole teardown — and forever if a
+    // close ever hangs.
+    let settle: (() => void) | undefined;
+    const { synth } = makeSynth({
+      revoke: () =>
+        new Promise<void>((resolve) => {
+          settle = resolve;
+        }),
+    });
+
+    const started = Date.now();
+    await withAgentJobMcpConfig(cwd, synth, async () => "done");
+    // Returned while the teardown promise is still pending.
+    expect(settle).toBeDefined();
+    expect(Date.now() - started).toBeLessThan(1000);
+    settle?.();
+  });
+
+  it("logs instead of swallowing when the revoke rejects (a live token would stay issued)", async () => {
+    const warnings: unknown[][] = [];
+    const { synth } = makeSynth({
+      revoke: () => Promise.reject(new Error("multiplexer down")),
+    });
+
+    await withAgentJobMcpConfig(cwd, synth, async () => "done", {
+      warn: (...args: unknown[]) => {
+        warnings.push(args);
+      },
+    });
+    // The rejection is handled on a microtask — let it land.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(String(warnings[0][0])).toContain("revoke failed");
+  });
+});
+
+describe("buildAgentJobArgs", () => {
+  const base = { prompt: "do the thing", securityArgs: ["--sec"], persona: "SOUL" };
+
+  it("passes --mcp-config through to the spawned claude", () => {
+    const args = buildAgentJobArgs({ ...base, mcpConfigPath: "/tmp/x/mcp-pty-agent-job-1.json" });
+    const at = args.indexOf("--mcp-config");
+    expect(at).toBeGreaterThan(-1);
+    expect(args[at + 1]).toBe("/tmp/x/mcp-pty-agent-job-1.json");
+  });
+
+  it("omits the flag entirely when the multiplexer is dormant", () => {
+    expect(buildAgentJobArgs(base)).not.toContain("--mcp-config");
+    // Dormant argv is byte-identical to the pre-fix shape.
+    expect(buildAgentJobArgs(base).slice(1)).toEqual([
+      "-p",
+      "do the thing",
+      "--sec",
+      "--append-system-prompt",
+      "SOUL",
+    ]);
   });
 });

--- a/src/bus/__tests__/agent-job-mcp-config.test.ts
+++ b/src/bus/__tests__/agent-job-mcp-config.test.ts
@@ -11,6 +11,9 @@
  *   3. `withAgentJobMcpConfig` — the mint → run → release wrapper actually
  *      hands the path to the run and releases it, including when the run
  *      throws.
+ *   4. `staticAgentMcpConfig` — the precedence rule: an operator-supplied
+ *      static `agent.mcp_config` wins over synthesis on the job path, exactly
+ *      as it does on the agent path (`synthesizeBusMcpConfig`).
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
@@ -18,7 +21,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PtyIdentity } from "../../runner/pty-mcp-config-writer";
 import { buildAgentJobArgs } from "../../runner";
-import { withAgentJobMcpConfig } from "../runtime-mount";
+import { staticAgentMcpConfig, withAgentJobMcpConfig } from "../runtime-mount";
 import {
   type BusMcpConfigSynthesizer,
   releaseAgentJobMcpConfig,
@@ -219,6 +222,39 @@ describe("release under a real (async) revoke", () => {
 
     expect(warnings.length).toBeGreaterThan(0);
     expect(String(warnings[0][0])).toContain("revoke failed");
+  });
+});
+
+describe("staticAgentMcpConfig", () => {
+  const agents = [{ id: "plain" }, { id: "narrowed", mcp_config: "/etc/claudeclaw/servers.json" }];
+
+  it("returns the operator's static config so the job path can skip synthesis", () => {
+    // Without this, a job dispatched to `narrowed` would get the FULL
+    // `mcp.shared` set the operator deliberately opted that agent out of,
+    // and would never see the operator's own servers.
+    expect(staticAgentMcpConfig("narrowed", agents)).toBe("/etc/claudeclaw/servers.json");
+  });
+
+  it("returns undefined for an agent with no static config (synthesis applies)", () => {
+    expect(staticAgentMcpConfig("plain", agents)).toBeUndefined();
+  });
+
+  it("returns undefined for an agent absent from settings (dir-only agent)", () => {
+    // `dispatch_job` validates against `agents/<name>/`, which can exist
+    // without a matching `settings.agents` entry.
+    expect(staticAgentMcpConfig("not-in-settings", agents)).toBeUndefined();
+    expect(staticAgentMcpConfig("plain", [])).toBeUndefined();
+  });
+
+  it("keeps exactly one --mcp-config in the argv when a static config wins", () => {
+    const args = buildAgentJobArgs({
+      prompt: "p",
+      securityArgs: [],
+      persona: "",
+      mcpConfigPath: staticAgentMcpConfig("narrowed", agents),
+    });
+    expect(args.filter((a) => a === "--mcp-config")).toHaveLength(1);
+    expect(args[args.indexOf("--mcp-config") + 1]).toBe("/etc/claudeclaw/servers.json");
   });
 });
 

--- a/src/bus/__tests__/agent-job-mcp-config.test.ts
+++ b/src/bus/__tests__/agent-job-mcp-config.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Issue #165 follow-up — the agent-job spawn path (`dispatch_job` →
+ * `runAgentJobHeadless`) must synthesize a `--mcp-config` for `mcp.shared`
+ * servers, the same way the legacy PTY supervisor and the bus agent spawn
+ * already do. Before this, a dispatched job ran with no MCP servers at all
+ * while the agent that dispatched it had every shared server.
+ *
+ * Coverage:
+ *   1. `synthesizeAgentJobMcpConfig` — dormancy, JSON shape, per-job keys.
+ *   2. `releaseAgentJobMcpConfig` — revoke + unlink, idempotent, dormant no-op.
+ *   3. `withAgentJobMcpConfig` — the mint → run → release wrapper actually
+ *      hands the path to the run and releases it, including when the run
+ *      throws.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PtyIdentity } from "../../runner/pty-mcp-config-writer";
+import { withAgentJobMcpConfig } from "../runtime-mount";
+import {
+  type BusMcpConfigSynthesizer,
+  releaseAgentJobMcpConfig,
+  synthesizeAgentJobMcpConfig,
+} from "../session-manager";
+
+function makeSynth(overrides: Partial<BusMcpConfigSynthesizer> = {}): {
+  synth: BusMcpConfigSynthesizer;
+  issued: string[];
+  revoked: string[];
+} {
+  const issued: string[] = [];
+  const revoked: string[] = [];
+  const synth: BusMcpConfigSynthesizer = {
+    sharedServers: ["alpha", "beta"],
+    bridgeBaseUrl: () => "http://127.0.0.1:4632",
+    issue: (ptyId): PtyIdentity => {
+      issued.push(ptyId);
+      return {
+        ptyId,
+        issuedAt: 1234,
+        headers: {
+          Authorization: `Bearer secret-${ptyId}`,
+          "X-Claudeclaw-Pty-Id": ptyId,
+          "X-Claudeclaw-Ts": "1234",
+        },
+      };
+    },
+    revoke: (ptyId) => {
+      revoked.push(ptyId);
+    },
+    ...overrides,
+  };
+  return { synth, issued, revoked };
+}
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), "ccaw-job-mcp-"));
+});
+
+afterEach(() => {
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+describe("synthesizeAgentJobMcpConfig", () => {
+  it("returns undefined and writes nothing when the multiplexer is dormant", () => {
+    expect(synthesizeAgentJobMcpConfig("agent-job-1", null, cwd)).toBeUndefined();
+
+    const { synth } = makeSynth({ sharedServers: [] });
+    expect(synthesizeAgentJobMcpConfig("agent-job-1", synth, cwd)).toBeUndefined();
+    expect(existsSync(join(cwd, ".claudeclaw"))).toBe(false);
+  });
+
+  it("writes a 0600 config carrying the shared servers and the job's own identity", () => {
+    const { synth, issued } = makeSynth();
+
+    const path = synthesizeAgentJobMcpConfig("agent-job-abc", synth, cwd);
+    expect(path).toBeDefined();
+    expect(issued).toEqual(["agent-job-abc"]);
+
+    // 0600 — the file holds a bearer token at rest.
+    expect(statSync(path as string).mode & 0o777).toBe(0o600);
+
+    const parsed = JSON.parse(readFileSync(path as string, "utf8"));
+    expect(Object.keys(parsed.mcpServers).sort()).toEqual(["alpha", "beta"]);
+    expect(parsed.mcpServers.alpha.url).toBe("http://127.0.0.1:4632/mcp/alpha");
+    expect(parsed.mcpServers.alpha.headers.Authorization).toBe("Bearer secret-agent-job-abc");
+  });
+
+  it("keys on the job, so two concurrent jobs never share a file or an identity", () => {
+    const { synth, issued } = makeSynth();
+
+    const first = synthesizeAgentJobMcpConfig("agent-job-one", synth, cwd);
+    const second = synthesizeAgentJobMcpConfig("agent-job-two", synth, cwd);
+
+    expect(first).not.toBe(second);
+    expect(existsSync(first as string)).toBe(true);
+    expect(existsSync(second as string)).toBe(true);
+    expect(issued).toEqual(["agent-job-one", "agent-job-two"]);
+  });
+
+  it("revokes the identity and rethrows when the write fails (never a silent no-MCP run)", () => {
+    const { synth, revoked } = makeSynth();
+    // A path under a regular file: mkdir of `.claudeclaw` fails with ENOTDIR.
+    const notADir = join(cwd, "regular-file");
+    Bun.write(notADir, "x");
+
+    expect(() => synthesizeAgentJobMcpConfig("agent-job-boom", synth, notADir)).toThrow();
+    expect(revoked).toEqual(["agent-job-boom"]);
+  });
+});
+
+describe("releaseAgentJobMcpConfig", () => {
+  it("revokes the identity and deletes the config", async () => {
+    const { synth, revoked } = makeSynth();
+    const path = synthesizeAgentJobMcpConfig("agent-job-rel", synth, cwd) as string;
+    expect(existsSync(path)).toBe(true);
+
+    await releaseAgentJobMcpConfig("agent-job-rel", synth, cwd);
+
+    expect(revoked).toEqual(["agent-job-rel"]);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("is idempotent and a no-op when the multiplexer is dormant", async () => {
+    const { synth } = makeSynth();
+    await releaseAgentJobMcpConfig("agent-job-never-issued", synth, cwd);
+    await releaseAgentJobMcpConfig("agent-job-never-issued", synth, cwd);
+    await releaseAgentJobMcpConfig("agent-job-never-issued", null, cwd);
+  });
+});
+
+describe("withAgentJobMcpConfig", () => {
+  it("hands the synthesized path to the run and releases it afterwards", async () => {
+    const { synth, issued, revoked } = makeSynth();
+    let seen: string | undefined;
+    let existedDuringRun = false;
+
+    const result = await withAgentJobMcpConfig(cwd, synth, async (mcpConfigPath) => {
+      seen = mcpConfigPath;
+      existedDuringRun = existsSync(mcpConfigPath as string);
+      return "done";
+    });
+
+    expect(result).toBe("done");
+    expect(seen).toBeDefined();
+    expect(existedDuringRun).toBe(true);
+    // Job-scoped key, generated per run — not the agent's id.
+    expect(issued).toHaveLength(1);
+    expect(issued[0]).toMatch(/^agent-job-/);
+    expect(revoked).toEqual(issued);
+    expect(existsSync(seen as string)).toBe(false);
+  });
+
+  it("passes undefined through when the multiplexer is dormant", async () => {
+    let seen: string | undefined = "sentinel";
+    await withAgentJobMcpConfig(cwd, null, async (mcpConfigPath) => {
+      seen = mcpConfigPath;
+      return 0;
+    });
+    expect(seen).toBeUndefined();
+  });
+
+  it("releases the identity even when the run throws", async () => {
+    const { synth, issued, revoked } = makeSynth();
+
+    await expect(
+      withAgentJobMcpConfig(cwd, synth, async () => {
+        throw new Error("job blew up");
+      }),
+    ).rejects.toThrow("job blew up");
+
+    expect(revoked).toEqual(issued);
+    expect(existsSync(join(cwd, ".claudeclaw", `mcp-pty-${issued[0]}.json`))).toBe(false);
+  });
+});

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -41,8 +41,13 @@ import {
   type JobView,
 } from "./agent-jobs";
 import { runAgentJobHeadless } from "../runner";
-import { agentExists } from "../agents";
-import { SessionManager } from "./session-manager";
+import { agentExists, loadAgent } from "../agents";
+import {
+  type BusMcpConfigSynthesizer,
+  releaseAgentJobMcpConfig,
+  SessionManager,
+  synthesizeAgentJobMcpConfig,
+} from "./session-manager";
 import { wireSlashCommands } from "./wiring";
 import { createMcpReconciler } from "./mcp-reconciler";
 import type { MountedAdapter } from "./adapter-wiring";
@@ -377,6 +382,40 @@ export function deliverAgentJobResult(
  * half-mounted daemon. This mirrors Sprint 4's `SlackAdapter.start()`
  * rollback pattern (Codex PR #117 P2 fix).
  */
+/**
+ * Mint a job-scoped MCP identity, run one agent job with the synthesized
+ * `--mcp-config`, and release the identity when the run ends.
+ *
+ * Issue #165 wired `mcp.shared` into the legacy PTY supervisor and then into
+ * the bus agent spawn. The agent-job spawn (`dispatch_job`) is the third
+ * spawn path and was never wired: it builds its argv by hand, so a dispatched
+ * job started with no MCP servers at all while the agent that dispatched it —
+ * spawned by the same daemon, from the same settings — had every shared
+ * server. This closes that gap.
+ *
+ * A job's identity is per-run, unlike an agent's (one agent = one long-lived
+ * PTY = one identity), so it is released in a `finally`: without that, every
+ * dispatched job would leak an identity in the multiplexer's registry and a
+ * 0600 config file in the agent's directory.
+ *
+ * Exported for tests — the production caller is the `runAgentJob` dep below.
+ */
+export async function withAgentJobMcpConfig<T>(
+  cwd: string,
+  synth: BusMcpConfigSynthesizer | null,
+  run: (mcpConfigPath: string | undefined) => Promise<T>,
+): Promise<T> {
+  // Generated, never caller- or model-supplied: the key lands in the
+  // synthesized file's name.
+  const jobKey = `agent-job-${randomUUID()}`;
+  const mcpConfigPath = synthesizeAgentJobMcpConfig(jobKey, synth, cwd);
+  try {
+    return await run(mcpConfigPath);
+  } finally {
+    await releaseAgentJobMcpConfig(jobKey, synth, cwd);
+  }
+}
+
 export async function mountBusRuntime(
   opts: MountBusRuntimeOptions = {},
 ): Promise<BusRuntimeHandle> {
@@ -440,7 +479,20 @@ export async function mountBusRuntime(
       agentJobConfig = DEFAULT_AGENT_JOB_CONFIG; // settings not loaded (early boot / tests)
     }
     const jobRunner = new AgentJobRunner(agentJobConfig, {
-      runAgentJob: (input) => runAgentJobHeadless(input),
+      // Issue #165 wired `mcp.shared` into the supervisor and then into the
+      // bus agent spawn; the agent-job spawn is the third path and was never
+      // wired, so a dispatched job ran with no MCP servers while its
+      // dispatcher had them all. Mint a job-scoped identity here (the bus
+      // owns the synthesizer), hand the path to the runner, and release it
+      // when the run ends — a job's identity is per-run, unlike an agent's.
+      runAgentJob: async (input) => {
+        const cwd = (await loadAgent(input.agent)).dir;
+        return withAgentJobMcpConfig(
+          cwd,
+          sessionManager.getMcpConfigSynthesizer(),
+          (mcpConfigPath) => runAgentJobHeadless({ ...input, mcpConfigPath }),
+        );
+      },
       isKnownAgent: agentExists,
       deliverResult: (job) => deliverAgentJobResult(bus, job, logger),
       now: Date.now,

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -382,40 +382,6 @@ export function deliverAgentJobResult(
  * half-mounted daemon. This mirrors Sprint 4's `SlackAdapter.start()`
  * rollback pattern (Codex PR #117 P2 fix).
  */
-/**
- * Mint a job-scoped MCP identity, run one agent job with the synthesized
- * `--mcp-config`, and release the identity when the run ends.
- *
- * Issue #165 wired `mcp.shared` into the legacy PTY supervisor and then into
- * the bus agent spawn. The agent-job spawn (`dispatch_job`) is the third
- * spawn path and was never wired: it builds its argv by hand, so a dispatched
- * job started with no MCP servers at all while the agent that dispatched it —
- * spawned by the same daemon, from the same settings — had every shared
- * server. This closes that gap.
- *
- * A job's identity is per-run, unlike an agent's (one agent = one long-lived
- * PTY = one identity), so it is released in a `finally`: without that, every
- * dispatched job would leak an identity in the multiplexer's registry and a
- * 0600 config file in the agent's directory.
- *
- * Exported for tests — the production caller is the `runAgentJob` dep below.
- */
-export async function withAgentJobMcpConfig<T>(
-  cwd: string,
-  synth: BusMcpConfigSynthesizer | null,
-  run: (mcpConfigPath: string | undefined) => Promise<T>,
-): Promise<T> {
-  // Generated, never caller- or model-supplied: the key lands in the
-  // synthesized file's name.
-  const jobKey = `agent-job-${randomUUID()}`;
-  const mcpConfigPath = synthesizeAgentJobMcpConfig(jobKey, synth, cwd);
-  try {
-    return await run(mcpConfigPath);
-  } finally {
-    await releaseAgentJobMcpConfig(jobKey, synth, cwd);
-  }
-}
-
 export async function mountBusRuntime(
   opts: MountBusRuntimeOptions = {},
 ): Promise<BusRuntimeHandle> {
@@ -491,6 +457,7 @@ export async function mountBusRuntime(
           cwd,
           sessionManager.getMcpConfigSynthesizer(),
           (mcpConfigPath) => runAgentJobHeadless({ ...input, mcpConfigPath }),
+          logger,
         );
       },
       isKnownAgent: agentExists,
@@ -808,5 +775,42 @@ export async function mountBusRuntime(
       }
     }
     throw err;
+  }
+}
+
+/**
+ * Mint a job-scoped MCP identity, run one agent job with the synthesized
+ * `--mcp-config`, and release the identity when the run ends.
+ *
+ * Issue #165 wired `mcp.shared` into the legacy PTY supervisor and then into
+ * the bus agent spawn. The agent-job spawn (`dispatch_job`) is the third
+ * spawn path and was never wired: it builds its argv by hand, so a dispatched
+ * job started with no MCP servers at all while the agent that dispatched it —
+ * spawned by the same daemon, from the same settings — had every shared
+ * server. This closes that gap.
+ *
+ * A job's identity is per-run, unlike an agent's (one agent = one long-lived
+ * PTY = one identity), so it is released in a `finally`: without that, every
+ * dispatched job would leak an identity in the multiplexer's registry and a
+ * 0600 config file in the agent's directory.
+ *
+ * Exported for tests — the production caller is the `runAgentJob` dep below.
+ */
+export async function withAgentJobMcpConfig<T>(
+  cwd: string,
+  synth: BusMcpConfigSynthesizer | null,
+  run: (mcpConfigPath: string | undefined) => Promise<T>,
+  logger: Pick<Console, "warn"> = console,
+): Promise<T> {
+  // Generated, never caller- or model-supplied: the key lands in the
+  // synthesized file's name.
+  const jobKey = `agent-job-${randomUUID()}`;
+  const mcpConfigPath = synthesizeAgentJobMcpConfig(jobKey, synth, cwd);
+  try {
+    return await run(mcpConfigPath);
+  } finally {
+    // Not awaited by design — see `releaseAgentJobMcpConfig`. The job's
+    // concurrency slot must not be held open by multiplexer teardown.
+    releaseAgentJobMcpConfig(jobKey, synth, cwd, logger);
   }
 }

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -56,7 +56,7 @@ import { detectOrphanAgents, formatOrphanWarnings } from "./orphan-agent-detect"
 import { createPromptStreamHandler } from "./receipt-wiring";
 import { peekSession } from "../sessions";
 import { generateSummary } from "../rotation";
-import { getSettings } from "../config";
+import { getSettings, type BusAgentSettings } from "../config";
 import { StallWatchdog, DEFAULT_STALL_CONFIG, type StallWatchdogConfig } from "./stall-watchdog";
 import { createStallAlertNotifier } from "./stall-alert-delivery";
 import { probeProcessTreeCpu, classifyKill, appendStallKillAudit } from "./stall-forensics";
@@ -452,6 +452,14 @@ export async function mountBusRuntime(
       // owns the synthesizer), hand the path to the runner, and release it
       // when the run ends — a job's identity is per-run, unlike an agent's.
       runAgentJob: async (input) => {
+        // Precedence, mirroring `synthesizeBusMcpConfig`: an operator-supplied
+        // static `agent.mcp_config` ALWAYS wins. Forward it unchanged and skip
+        // synthesis entirely, so the job's MCP surface matches the long-lived
+        // agent it runs as and exactly one `--mcp-config` is ever emitted.
+        const staticPath = staticAgentMcpConfig(input.agent, readSettingsAgents());
+        if (staticPath) {
+          return runAgentJobHeadless({ ...input, mcpConfigPath: staticPath });
+        }
         const cwd = (await loadAgent(input.agent)).dir;
         return withAgentJobMcpConfig(
           cwd,
@@ -779,8 +787,43 @@ export async function mountBusRuntime(
 }
 
 /**
+ * The operator's static `agent.mcp_config` for the agent a job was dispatched
+ * to, or `undefined` when that agent has none.
+ *
+ * `settings.agents[].id` and the `agents/<name>` directory `dispatch_job`
+ * validates against are the SAME namespace (`id` "becomes … the
+ * `agents/<id>/session.json` directory" — see `BusAgentSettings.id`), so an
+ * entry carrying `mcp_config` is reachable by name from a dispatch and must
+ * be honoured on the job path exactly as `buildClaudeArgs` honours it on the
+ * agent path.
+ *
+ * Pure + exported so the precedence rule is directly assertable without
+ * standing up a daemon.
+ */
+export function staticAgentMcpConfig(
+  agentId: string,
+  agents: readonly BusAgentSettings[],
+): string | undefined {
+  return agents.find((a) => a.id === agentId)?.mcp_config;
+}
+
+/** `settings.agents`, or `[]` when settings aren't loaded (early boot / tests). */
+function readSettingsAgents(): readonly BusAgentSettings[] {
+  try {
+    return getSettings().agents;
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Mint a job-scoped MCP identity, run one agent job with the synthesized
  * `--mcp-config`, and release the identity when the run ends.
+ *
+ * Scope: `mcp.shared` (multiplexer) servers only. An agent carrying a static
+ * `agent.mcp_config` never reaches this function — the caller forwards that
+ * path directly (see the `runAgentJob` dep above), matching
+ * `synthesizeBusMcpConfig`'s "static ALWAYS wins" rule.
  *
  * Issue #165 wired `mcp.shared` into the legacy PTY supervisor and then into
  * the bus agent spawn. The agent-job spawn (`dispatch_job`) is the third

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -226,9 +226,12 @@ export function synthesizeBusMcpConfig(
  * concurrent jobs for the same agent never share an identity or clobber
  * each other's config file.
  *
- * The key lands in the synthesized file name (`mcp-pty-<key>.json`), so
- * callers MUST pass a value they generate themselves — never operator or
- * model-supplied text.
+ * The key lands in the synthesized file name (`mcp-pty-<key>.json`), so it
+ * must be safe as a path segment. Both current callers satisfy that
+ * differently: the agent path passes `agent.id`, which is operator-supplied
+ * but validated upstream, and the job path passes a freshly-minted job key.
+ * What the contract actually forbids is an unvalidated value — model-supplied
+ * text in particular must never reach this parameter.
  */
 function synthesizeMcpConfigForKey(
   key: string,

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -216,10 +216,29 @@ export function synthesizeBusMcpConfig(
   cwd: string,
 ): string | undefined {
   if (agent.mcp_config) return undefined;
+  return synthesizeMcpConfigForKey(agent.id, synth, cwd);
+}
+
+/**
+ * Shared core of the bus-side synthesis, keyed on an arbitrary spawn key
+ * rather than on an `AgentConfig`. Long-lived bus agents key on the stable
+ * `agent.id`; headless agent jobs key on a freshly-minted job key so two
+ * concurrent jobs for the same agent never share an identity or clobber
+ * each other's config file.
+ *
+ * The key lands in the synthesized file name (`mcp-pty-<key>.json`), so
+ * callers MUST pass a value they generate themselves — never operator or
+ * model-supplied text.
+ */
+function synthesizeMcpConfigForKey(
+  key: string,
+  synth: BusMcpConfigSynthesizer | null,
+  cwd: string,
+): string | undefined {
   if (!synth) return undefined;
   if (synth.sharedServers.length === 0) return undefined;
 
-  const identity = synth.issue(agent.id);
+  const identity = synth.issue(key);
   // Roll back the just-minted identity if the on-disk write fails
   // (EACCES, ENOSPC, EROFS, mkdir failure). Without this, the throw
   // escapes the spawn-dispatch try/catch in `spawnAgentInternal`
@@ -230,7 +249,7 @@ export function synthesizeBusMcpConfig(
   let path: string;
   try {
     ({ path } = writeConfigForPty({
-      ptyId: agent.id,
+      ptyId: key,
       cwd,
       sharedServers: synth.sharedServers.map((name) => ({ name })),
       perPtyServers: [],
@@ -238,12 +257,63 @@ export function synthesizeBusMcpConfig(
       identity,
     }));
   } catch (err) {
-    Promise.resolve(synth.revoke(agent.id)).catch(() => {
+    Promise.resolve(synth.revoke(key)).catch(() => {
       // Fire-and-forget; the throw below is the operator-visible signal.
     });
     throw err;
   }
   return path.length > 0 ? path : undefined;
+}
+
+/**
+ * Synthesize a per-JOB `--mcp-config` for the headless agent-job spawn path
+ * (`dispatch_job` → `runAgentJobHeadless`).
+ *
+ * Issue #165 wired `mcp.shared` into the legacy PTY supervisor and then into
+ * the bus agent spawn. The agent-job spawn is the THIRD spawn path and was
+ * never wired: `runAgentJobHeadless` builds its argv by hand, so a dispatched
+ * job started with no `--mcp-config` at all and could not reach a single
+ * shared server — while the dispatching agent, spawned from the same daemon,
+ * could.
+ *
+ * Unlike a long-lived agent (one agent = one identity for the process's whole
+ * life), a job's identity is minted per run and MUST be released when the run
+ * ends — see `releaseAgentJobMcpConfig`. Callers pass a generated `jobKey`.
+ *
+ * Throws when synthesis is active but the write fails, matching the
+ * supervisor's contract (SPEC §4.5: fail the spawn, never fall through to a
+ * silent no-MCP run). The job is then marked failed with that error.
+ */
+export function synthesizeAgentJobMcpConfig(
+  jobKey: string,
+  synth: BusMcpConfigSynthesizer | null,
+  cwd: string,
+): string | undefined {
+  return synthesizeMcpConfigForKey(jobKey, synth, cwd);
+}
+
+/**
+ * Drop a job's multiplexer identity and delete its synthesized config file.
+ * Best-effort and idempotent: a job that never got a config (dormant
+ * multiplexer) releases nothing, and a failure to unlink never fails the job
+ * — the run is already over by the time this is called.
+ */
+export async function releaseAgentJobMcpConfig(
+  jobKey: string,
+  synth: BusMcpConfigSynthesizer | null,
+  cwd: string,
+): Promise<void> {
+  if (!synth) return;
+  try {
+    await synth.revoke(jobKey);
+  } catch {
+    // best-effort — the multiplexer's revoke is documented as idempotent.
+  }
+  try {
+    deleteConfigForPty(cwd, jobKey);
+  } catch {
+    // best-effort — operator may have removed the directory.
+  }
 }
 
 /* ───────────────────────────────────────────────────────────────────── */
@@ -573,6 +643,16 @@ export class SessionManager {
    */
   setMcpConfigSynthesizer(synth: BusMcpConfigSynthesizer | null): void {
     this.mcpSynth = synth;
+  }
+
+  /**
+   * The wired synthesizer, or `null` when the multiplexer is dormant. Read by
+   * the agent-job spawn path, which lives outside this class but needs the
+   * same issuer so a dispatched job reaches the same shared servers as the
+   * agent that dispatched it.
+   */
+  getMcpConfigSynthesizer(): BusMcpConfigSynthesizer | null {
+    return this.mcpSynth;
   }
 
   async spawnAgent(agent: AgentConfig, origin: BusOrigin): Promise<AgentProcess> {

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -280,6 +280,12 @@ function synthesizeMcpConfigForKey(
  * life), a job's identity is minted per run and MUST be released when the run
  * ends — see `releaseAgentJobMcpConfig`. Callers pass a generated `jobKey`.
  *
+ * Scope is `mcp.shared` only, and there is deliberately no `AgentConfig`
+ * parameter: the "static `agent.mcp_config` ALWAYS wins" precedence that
+ * `synthesizeBusMcpConfig` enforces is applied by the CALLER on this path
+ * (`staticAgentMcpConfig` in `runtime-mount.ts`), which forwards the
+ * operator's path instead of calling this function at all.
+ *
  * Throws when synthesis is active but the write fails, matching the
  * supervisor's contract (SPEC §4.5: fail the spawn, never fall through to a
  * silent no-MCP run). The job is then marked failed with that error.
@@ -658,8 +664,13 @@ export class SessionManager {
   /**
    * The wired synthesizer, or `null` when the multiplexer is dormant. Read by
    * the agent-job spawn path, which lives outside this class but needs the
-   * same issuer so a dispatched job reaches the same shared servers as the
-   * agent that dispatched it.
+   * same issuer so a dispatched job reaches the same `mcp.shared` servers as
+   * the agent that dispatched it.
+   *
+   * Only relevant for agents WITHOUT a static `agent.mcp_config`: as on the
+   * agent path (`synthesizeBusMcpConfig`), a static config wins and synthesis
+   * is skipped, so the job runs with the operator's file and no shared
+   * servers — the same surface the long-lived agent gets.
    */
   getMcpConfigSynthesizer(): BusMcpConfigSynthesizer | null {
     return this.mcpSynth;

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -295,25 +295,35 @@ export function synthesizeAgentJobMcpConfig(
 /**
  * Drop a job's multiplexer identity and delete its synthesized config file.
  * Best-effort and idempotent: a job that never got a config (dormant
- * multiplexer) releases nothing, and a failure to unlink never fails the job
- * — the run is already over by the time this is called.
+ * multiplexer) releases nothing, and a failure never fails the job — the run
+ * is already over by the time this is called.
+ *
+ * Deliberately NOT async, mirroring `cleanupAgentMcpConfig`: `revoke` closes
+ * transports and writes the multiplexer's persistence file, so awaiting it
+ * would sit between the job settling and `AgentJobRunner.finish()` — holding
+ * a concurrency slot for the whole teardown, and holding it FOREVER if a
+ * close ever hangs. The unlink stays synchronous so the 0600 bearer file is
+ * gone the moment the run ends.
+ *
+ * Failures are logged rather than swallowed: a directory that has become
+ * unwritable would otherwise leave a live bearer token on disk after every
+ * dispatch with no operator signal at all.
  */
-export async function releaseAgentJobMcpConfig(
+export function releaseAgentJobMcpConfig(
   jobKey: string,
   synth: BusMcpConfigSynthesizer | null,
   cwd: string,
-): Promise<void> {
+  logger: Pick<Console, "warn"> = console,
+): void {
   if (!synth) return;
   try {
-    await synth.revoke(jobKey);
-  } catch {
-    // best-effort — the multiplexer's revoke is documented as idempotent.
-  }
-  try {
     deleteConfigForPty(cwd, jobKey);
-  } catch {
-    // best-effort — operator may have removed the directory.
+  } catch (err) {
+    logger.warn(`[bus-session] job=${jobKey} mcp-config cleanup failed`, err);
   }
+  Promise.resolve(synth.revoke(jobKey)).catch((err) =>
+    logger.warn(`[bus-session] job=${jobKey} mcp identity revoke failed`, err),
+  );
 }
 
 /* ───────────────────────────────────────────────────────────────────── */

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -820,6 +820,25 @@ export async function runClaudeOnce(
 }
 
 /**
+ * Build the argv for one headless agent job.
+ *
+ * Extracted so the `--mcp-config` wiring is directly assertable: without the
+ * flag a dispatched job cannot reach any of the operator's `mcp.shared`
+ * servers, while the agent that dispatched it reaches all of them.
+ */
+export function buildAgentJobArgs(input: {
+  prompt: string;
+  securityArgs: string[];
+  persona: string;
+  mcpConfigPath?: string;
+}): string[] {
+  const args = [CLAUDE_EXECUTABLE, "-p", input.prompt, ...input.securityArgs];
+  if (input.persona) args.push("--append-system-prompt", input.persona);
+  if (input.mcpConfigPath) args.push("--mcp-config", input.mcpConfigPath);
+  return args;
+}
+
+/**
  * Run a named agent as a one-shot headless job (for the bus AgentJobRunner). Loads
  * the agent's persona (IDENTITY/SOUL/CLAUDE.md), runs `claude -p <prompt>` in the
  * agent's dir with plain-text output, and returns the final text. Honours the
@@ -847,13 +866,12 @@ export async function runAgentJobHeadless(input: {
   validateModelString(input.model, "agent job");
   const ctx = await loadAgent(input.agent);
   const persona = await loadAgentPrompts(input.agent);
-  const args = [CLAUDE_EXECUTABLE, "-p", input.prompt, ...buildSecurityArgs(settings.security)];
-  if (persona) args.push("--append-system-prompt", persona);
-  // Without this the job spawns with no MCP servers at all — the gap that
-  // made a dispatched job strictly less capable than the agent that
-  // dispatched it (no shared servers, however the operator configured
-  // `mcp.shared`).
-  if (input.mcpConfigPath) args.push("--mcp-config", input.mcpConfigPath);
+  const args = buildAgentJobArgs({
+    prompt: input.prompt,
+    securityArgs: buildSecurityArgs(settings.security),
+    persona,
+    mcpConfigPath: input.mcpConfigPath,
+  });
   const model = input.model?.trim() || settings.model;
   const { rawStdout, stderr, exitCode } = await runClaudeOnce(
     args,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -832,6 +832,13 @@ export async function runAgentJobHeadless(input: {
   model?: string;
   timeoutMs: number;
   signal: AbortSignal;
+  /**
+   * Absolute path to a synthesized `--mcp-config` for this job, or omitted
+   * when the MCP multiplexer is dormant. Minted and released by the caller
+   * (the bus wires the job runner and owns the multiplexer identity); this
+   * function only forwards the flag to the spawned `claude`.
+   */
+  mcpConfigPath?: string;
 }): Promise<{ exitCode: number; resultText?: string; error?: string; timedOut?: boolean }> {
   const settings = getSettings();
   // Security review (#296 PR 3): validate the caller-supplied model against the
@@ -842,6 +849,11 @@ export async function runAgentJobHeadless(input: {
   const persona = await loadAgentPrompts(input.agent);
   const args = [CLAUDE_EXECUTABLE, "-p", input.prompt, ...buildSecurityArgs(settings.security)];
   if (persona) args.push("--append-system-prompt", persona);
+  // Without this the job spawns with no MCP servers at all — the gap that
+  // made a dispatched job strictly less capable than the agent that
+  // dispatched it (no shared servers, however the operator configured
+  // `mcp.shared`).
+  if (input.mcpConfigPath) args.push("--mcp-config", input.mcpConfigPath);
   const model = input.model?.trim() || settings.model;
   const { rawStdout, stderr, exitCode } = await runClaudeOnce(
     args,


### PR DESCRIPTION
## Problem

A dispatched agent job cannot reach a single one of the operator's shared MCP
servers.

`dispatch_job` is advertised as the supported way to hand work to another agent
("use this instead of shelling out to `claude -p` yourself"), but the agent that
picks the job up is strictly less capable than the agent that dispatched it: the
dispatcher reaches every server in `mcp.shared`, the job reaches none of them.

Observed on a daemon with three shared servers configured and the multiplexer
active (`plugin.isActive()`, all three claimed). Dispatching a job whose whole
purpose needed one of those servers, then asking the job what it could see:

> none of the shared servers are in my loaded tool list

The dispatching agent, in the same daemon and from the same settings, had all
three. Note the multiplexer *claims* those servers, so they are removed from
plain per-process discovery — for a job they were simply unreachable.

## Root cause

Issue #165 wired `mcp.shared` into the legacy PTY supervisor
(`synthesizeMcpConfigIfActive`), then into the bus agent spawn
(`synthesizeBusMcpConfig`). The agent-job spawn is the **third** spawn path and
was never wired.

`runAgentJobHeadless` (`src/runner.ts`) builds its argv by hand:

```ts
const args = [CLAUDE_EXECUTABLE, "-p", input.prompt, ...buildSecurityArgs(settings.security)];
if (persona) args.push("--append-system-prompt", persona);
```

No `--mcp-config`, and no synthesis seam anywhere on that path — so the flag was
not merely absent from the argv, there was nothing to put in it.

## Fix

Mint a **job-scoped** multiplexer identity around each run, and pass the
synthesized config to the spawned `claude`.

- `src/bus/session-manager.ts` — extract the keyed core of
  `synthesizeBusMcpConfig` into `synthesizeMcpConfigForKey`, and add
  `synthesizeAgentJobMcpConfig` / `releaseAgentJobMcpConfig`.
  A long-lived agent's identity lives as long as its PTY; a job's identity is
  per run and **must** be released, or every dispatch leaks an identity in the
  multiplexer registry and a 0600 file in the agent's directory.
- `SessionManager.getMcpConfigSynthesizer()` — the job spawn path lives outside
  the class but needs the same issuer.
- `src/bus/runtime-mount.ts` — `withAgentJobMcpConfig()` mints, runs, and
  releases in a `finally`; it wraps the `runAgentJob` dep of `AgentJobRunner`.
- `src/runner.ts` — `buildAgentJobArgs()` (extracted, so the wiring is
  assertable) forwards an optional `mcpConfigPath`. The runner stays
  policy-free: the bus owns the multiplexer, the runner only forwards the flag.
- `.gitignore` — `agents/*/.claudeclaw/`. This is the first code to write a
  bearer-token file under `agents/`, and a `git add -A` while a job is running
  must not be able to stage one.

### Notes for review

- **The job key is generated, never caller-supplied** (`agent-job-<uuid>`). It
  lands in the synthesized file name (`mcp-pty-<key>.json`), so nothing a model
  or an operator can influence reaches a path component. It is deliberately
  *not* the agent id: two concurrent jobs for one agent would otherwise share an
  identity and clobber each other's file — and a job would overwrite the config
  belonging to that same agent's long-lived PTY, rotating its bearer mid-run.
- **The release is not awaited**, mirroring `cleanupAgentMcpConfig`. `revoke` →
  `releaseIdentity` closes transports and writes the multiplexer's persistence
  file; awaiting it would sit between the job settling and
  `AgentJobRunner.finish()`, holding a concurrency slot for the whole teardown
  and holding it forever if a close ever hung. The *unlink* stays synchronous,
  so the 0600 file is gone the moment the run ends.
- **Failures are logged, not swallowed.** A directory that has become unwritable
  would otherwise leave a live bearer on disk after every dispatch with no
  operator signal — again matching what the agent path already does.
- **Dormant is byte-identical.** No synthesizer wired, or `mcp.shared` empty →
  `undefined` → no flag. A test pins the exact dormant argv.
- **Write failure fails the job** rather than silently running without the
  shared servers, matching the supervisor's contract (SPEC §4.5). The identity
  is rolled back before the throw.
- **Timeout / cancel**: `runClaudeOnce` returns as soon as it has SIGTERM'd a
  hung child (SIGKILL follows 5s later), so the release can run while that child
  is still dying. Intended — the job is being terminated and its credential
  should die with it; `claude` reads `--mcp-config` at startup, so unlinking
  cannot break a process that already started.
- **One behaviour change worth naming**: the multiplexer's per-bearer rate-limit
  window is keyed on the identity and dropped on release
  (`http-handler.ts` `releasePty`). A long-lived agent keeps one identity for
  its whole life, so the window genuinely bounds it; a job now gets a fresh
  window per run. `maxConcurrent`/`maxQueued` still bound simultaneity, and each
  dispatch already costs a full `claude` process, but if you'd rather the window
  survive across a given agent's jobs I'm happy to key it differently — that is
  a design call on your side.
- **Token exposure is otherwise unchanged.** The 0600 file lands in the agent's
  own directory, where long-lived bus agents already write theirs; a job's token
  is in fact shorter-lived, since it is revoked when the run ends.

## Test plan

New: `src/bus/__tests__/agent-job-mcp-config.test.ts` (13 tests) — in a
CI-covered suite:

- dormant (no synthesizer / empty `sharedServers`) → `undefined`, nothing written
- synthesized JSON carries the shared servers, the bridge URLs and the job's own
  identity headers; file mode is 0600
- two job keys → two distinct files and two distinct identities
- write failure → identity revoked, error rethrown
- release → unlink + revoke; idempotent; no-op when dormant
- `withAgentJobMcpConfig` hands the path to the run, the file exists *during* the
  run and is gone after, and the identity is released **even when the run throws**
- a slow (still-pending) `revoke` does not delay the run's return; a *rejecting*
  `revoke` is logged rather than swallowed
- `buildAgentJobArgs` emits `--mcp-config <path>`, and the dormant argv is
  byte-identical to the pre-fix shape

Mechanical gate on this branch:

| Check | Result |
|---|---|
| Base freshness | 0 commits behind `upstream/main` (c77ee84) |
| `bun run lint` (exact CI command) | clean |
| `bun test src/bus` (env scrubbed) | 538 pass |
| Typecheck ratchet | 153 errors = baseline 153, none introduced |
| Version guards | plugin + marketplace 2.2.219 → 2.2.221 (rebased onto `8745b2d` after #348 merged; the earlier 2.2.218 plan is obsolete) |

Refs #165

