### PR TITLE
fix(tuner): surface an external subject's own error instead of discarding stdout

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.221",
+      "version": "2.2.222",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.221",
+  "version": "2.2.222",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/skills-tuner/subjects/__tests__/external_process.test.ts
+++ b/src/skills-tuner/subjects/__tests__/external_process.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ExternalProcessSubject } from "../external_process.js";
+
+/**
+ * These tests drive the real subprocess path: every fixture is a script on disk
+ * spawned by ExternalProcessSubject itself, so the assertions cover what an
+ * operator actually sees when an external subject fails.
+ */
+
+let dir: string;
+
+/**
+ * Write a fixture script whose body runs once stdin is drained (the subject
+ * always writes a request), and return a subject wired to it.
+ */
+function subjectRunning(fileName: string, body: string): ExternalProcessSubject {
+  const scriptPath = join(dir, fileName);
+  writeFileSync(
+    scriptPath,
+    `const chunks = [];
+process.stdin.on("data", (c) => chunks.push(c));
+process.stdin.on("end", () => {
+${body}
+});
+`,
+  );
+  return new ExternalProcessSubject({
+    name: "fixture-subject",
+    command: [process.execPath, scriptPath],
+    allowedRoots: [dir],
+    timeoutMs: 15_000,
+  });
+}
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "external-process-test-"));
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("ExternalProcessSubject non-zero exit", () => {
+  it('surfaces the documented {"error": ...} stdout envelope (regression)', async () => {
+    const subject = subjectRunning(
+      "stdout-error.js",
+      `  process.stdout.write(JSON.stringify({ error: "config file is missing a 'threshold' key" }));
+  process.exit(1);`,
+    );
+
+    const promise = subject.collectObservations(new Date(0));
+    await expect(promise).rejects.toThrow("config file is missing a 'threshold' key");
+    await expect(promise).rejects.toThrow("exited 1");
+  });
+
+  it("still surfaces stderr when the subject logs there", async () => {
+    const subject = subjectRunning(
+      "stderr-only.js",
+      `  process.stderr.write("Traceback: interpreter blew up");
+  process.exit(3);`,
+    );
+
+    const promise = subject.collectObservations(new Date(0));
+    await expect(promise).rejects.toThrow("stderr: Traceback: interpreter blew up");
+    await expect(promise).rejects.toThrow("exited 3");
+  });
+
+  it("reports both streams when the subject writes to each", async () => {
+    const subject = subjectRunning(
+      "both-streams.js",
+      `  process.stderr.write("warning: cache unreadable");
+  process.stdout.write(JSON.stringify({ error: "scan aborted" }));
+  process.exit(1);`,
+    );
+
+    let message = "";
+    try {
+      await subject.collectObservations(new Date(0));
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("error: scan aborted");
+    expect(message).toContain("stderr: warning: cache unreadable");
+  });
+
+  it("falls back to raw stdout when it is not the documented envelope", async () => {
+    const subject = subjectRunning(
+      "stdout-not-json.js",
+      `  process.stdout.write("segfault while loading model");
+  process.exit(2);`,
+    );
+
+    await expect(subject.collectObservations(new Date(0))).rejects.toThrow(
+      "stdout: segfault while loading model",
+    );
+  });
+
+  it("says so explicitly when both streams are empty", async () => {
+    const subject = subjectRunning("silent.js", `  process.exit(9);`);
+
+    let message = "";
+    try {
+      await subject.collectObservations(new Date(0));
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toBe("ExternalProcess fixture-subject exited 9. no output on stdout or stderr");
+  });
+
+  it("truncates an oversized stream instead of inlining all of it", async () => {
+    const subject = subjectRunning(
+      "huge-stderr.js",
+      `  process.stderr.write("x".repeat(5000));
+  process.exit(1);`,
+    );
+
+    let message = "";
+    try {
+      await subject.collectObservations(new Date(0));
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain(`stderr: ${"x".repeat(500)}`);
+    expect(message).not.toContain("x".repeat(501));
+  });
+});
+
+describe("ExternalProcessSubject zero exit (unchanged)", () => {
+  it("returns the result payload on the happy path", async () => {
+    const subject = subjectRunning(
+      "ok-result.js",
+      `  process.stdout.write(JSON.stringify({ result: [] }));
+  process.exit(0);`,
+    );
+
+    await expect(subject.collectObservations(new Date(0))).resolves.toEqual([]);
+  });
+
+  it("still throws the RPC error branch on exit 0 with an error envelope", async () => {
+    const subject = subjectRunning(
+      "ok-error.js",
+      `  process.stdout.write(JSON.stringify({ error: "unknown method: collect_observations" }));
+  process.exit(0);`,
+    );
+
+    await expect(subject.collectObservations(new Date(0))).rejects.toThrow(
+      "method collect_observations error: unknown method: collect_observations",
+    );
+  });
+});
+
+describe("ExternalProcessSubject line-oriented envelope", () => {
+  it("finds the envelope when the subject logged before failing", async () => {
+    const subject = subjectRunning(
+      "logs-then-error.js",
+      `  process.stdout.write("loading configuration " + ".".repeat(600) + "\\n");
+  process.stdout.write(JSON.stringify({ error: "threshold key missing in config" }) + "\\n");
+  process.exit(1);`,
+    );
+
+    // The protocol prints one JSON object per line, so the envelope is the last
+    // line: parsing the whole buffer would drown it in the preceding log noise.
+    await expect(subject.collectObservations(new Date(0))).rejects.toThrow(
+      "threshold key missing in config",
+    );
+  });
+
+  it("keeps a result payload out of the failure message", async () => {
+    const subject = subjectRunning(
+      "result-then-exit.js",
+      `  process.stdout.write(JSON.stringify({ result: ["confidential-record-1", "confidential-record-2"] }));
+  process.exit(3);`,
+    );
+
+    const promise = subject.collectObservations(new Date(0));
+    await expect(promise).rejects.toThrow("stdout: result payload");
+    await expect(promise).rejects.not.toThrow("confidential-record-1");
+  });
+
+  it("clips on a code-point boundary, never mid-surrogate", async () => {
+    const subject = subjectRunning(
+      "wide-chars.js",
+      `  process.stdout.write(JSON.stringify({ error: "x".repeat(499) + "\\u{1F4A5}" + "boom" }));
+  process.exit(1);`,
+    );
+
+    const message = await subject.collectObservations(new Date(0)).then(
+      () => "",
+      (e: Error) => e.message,
+    );
+    expect(message).toContain("\u{1F4A5}");
+    expect(/[\uD800-\uDBFF]$/.test(message)).toBe(false);
+  });
+});
+
+describe("ExternalProcessSubject timeout", () => {
+  it("surfaces what the subject reported before it hung", async () => {
+    const scriptPath = join(dir, "reports-then-hangs.js");
+    writeFileSync(
+      scriptPath,
+      `process.stdin.on("data", () => {});
+process.stdout.write(JSON.stringify({ error: "database handle stuck" }) + "\\n");
+setTimeout(() => {}, 30_000);
+`,
+    );
+    const subject = new ExternalProcessSubject({
+      name: "fixture-subject",
+      command: [process.execPath, scriptPath],
+      allowedRoots: [dir],
+      timeoutMs: 1_500,
+    });
+
+    const promise = subject.collectObservations(new Date(0));
+    await expect(promise).rejects.toThrow("timed out after 1500ms");
+    await expect(promise).rejects.toThrow("database handle stuck");
+  });
+});

--- a/src/skills-tuner/subjects/__tests__/external_process.test.ts
+++ b/src/skills-tuner/subjects/__tests__/external_process.test.ts
@@ -15,6 +15,19 @@ let dir: string;
 /**
  * Write a fixture script whose body runs once stdin is drained (the subject
  * always writes a request), and return a subject wired to it.
+ *
+ * Fixture bodies set `process.exitCode` rather than calling `process.exit()`:
+ * `exit()` tears the process down without waiting for a pending write to the
+ * stdout/stderr pipe to flush. Measured truncation thresholds are ~219 KB on
+ * bun and ~146 KB on node, so no fixture here is anywhere near losing output
+ * today — this removes a size-dependent footgun for whoever writes the first
+ * fixture that dumps more, not an active flake.
+ *
+ * The trade: `exit()` always exits, `exitCode` exits only once nothing holds
+ * the event loop. Nothing does today. A fixture that later leaves a timer or
+ * handle open will hang instead, and surface as the subject's 15s timeout
+ * rather than as "your fixture leaked a handle" — so keep fixture bodies free
+ * of live handles.
  */
 function subjectRunning(fileName: string, body: string): ExternalProcessSubject {
   const scriptPath = join(dir, fileName);
@@ -48,7 +61,7 @@ describe("ExternalProcessSubject non-zero exit", () => {
     const subject = subjectRunning(
       "stdout-error.js",
       `  process.stdout.write(JSON.stringify({ error: "config file is missing a 'threshold' key" }));
-  process.exit(1);`,
+  process.exitCode = 1;`,
     );
 
     const promise = subject.collectObservations(new Date(0));
@@ -60,7 +73,7 @@ describe("ExternalProcessSubject non-zero exit", () => {
     const subject = subjectRunning(
       "stderr-only.js",
       `  process.stderr.write("Traceback: interpreter blew up");
-  process.exit(3);`,
+  process.exitCode = 3;`,
     );
 
     const promise = subject.collectObservations(new Date(0));
@@ -73,7 +86,7 @@ describe("ExternalProcessSubject non-zero exit", () => {
       "both-streams.js",
       `  process.stderr.write("warning: cache unreadable");
   process.stdout.write(JSON.stringify({ error: "scan aborted" }));
-  process.exit(1);`,
+  process.exitCode = 1;`,
     );
 
     let message = "";
@@ -90,7 +103,7 @@ describe("ExternalProcessSubject non-zero exit", () => {
     const subject = subjectRunning(
       "stdout-not-json.js",
       `  process.stdout.write("segfault while loading model");
-  process.exit(2);`,
+  process.exitCode = 2;`,
     );
 
     await expect(subject.collectObservations(new Date(0))).rejects.toThrow(
@@ -99,7 +112,7 @@ describe("ExternalProcessSubject non-zero exit", () => {
   });
 
   it("says so explicitly when both streams are empty", async () => {
-    const subject = subjectRunning("silent.js", `  process.exit(9);`);
+    const subject = subjectRunning("silent.js", `  process.exitCode = 9;`);
 
     let message = "";
     try {
@@ -114,7 +127,7 @@ describe("ExternalProcessSubject non-zero exit", () => {
     const subject = subjectRunning(
       "huge-stderr.js",
       `  process.stderr.write("x".repeat(5000));
-  process.exit(1);`,
+  process.exitCode = 1;`,
     );
 
     let message = "";
@@ -133,7 +146,7 @@ describe("ExternalProcessSubject zero exit (unchanged)", () => {
     const subject = subjectRunning(
       "ok-result.js",
       `  process.stdout.write(JSON.stringify({ result: [] }));
-  process.exit(0);`,
+  process.exitCode = 0;`,
     );
 
     await expect(subject.collectObservations(new Date(0))).resolves.toEqual([]);
@@ -143,7 +156,7 @@ describe("ExternalProcessSubject zero exit (unchanged)", () => {
     const subject = subjectRunning(
       "ok-error.js",
       `  process.stdout.write(JSON.stringify({ error: "unknown method: collect_observations" }));
-  process.exit(0);`,
+  process.exitCode = 0;`,
     );
 
     await expect(subject.collectObservations(new Date(0))).rejects.toThrow(
@@ -158,7 +171,7 @@ describe("ExternalProcessSubject line-oriented envelope", () => {
       "logs-then-error.js",
       `  process.stdout.write("loading configuration " + ".".repeat(600) + "\\n");
   process.stdout.write(JSON.stringify({ error: "threshold key missing in config" }) + "\\n");
-  process.exit(1);`,
+  process.exitCode = 1;`,
     );
 
     // The protocol prints one JSON object per line, so the envelope is the last
@@ -172,7 +185,7 @@ describe("ExternalProcessSubject line-oriented envelope", () => {
     const subject = subjectRunning(
       "result-then-exit.js",
       `  process.stdout.write(JSON.stringify({ result: ["confidential-record-1", "confidential-record-2"] }));
-  process.exit(3);`,
+  process.exitCode = 3;`,
     );
 
     const promise = subject.collectObservations(new Date(0));
@@ -184,7 +197,7 @@ describe("ExternalProcessSubject line-oriented envelope", () => {
     const subject = subjectRunning(
       "wide-chars.js",
       `  process.stdout.write(JSON.stringify({ error: "x".repeat(499) + "\\u{1F4A5}" + "boom" }));
-  process.exit(1);`,
+  process.exitCode = 1;`,
     );
 
     const message = await subject.collectObservations(new Date(0)).then(

--- a/src/skills-tuner/subjects/external_process.ts
+++ b/src/skills-tuner/subjects/external_process.ts
@@ -52,10 +52,22 @@ const MAX_STREAM_CHARS = 500;
 /**
  * Truncate on a code-point boundary so a clipped message never ends on half of
  * a surrogate pair (which would become U+FFFD once the message is encoded).
+ *
+ * The scan is bounded: it stops one code point past the cap, so the cost of
+ * describing a failure never scales with how much the failing subject dumped.
+ * `Array.from(text)` would materialise every code point of a multi-megabyte
+ * stream as its own string before throwing all but 500 of them away — turning
+ * a misbehaving subject into a memory spike on the error path.
  */
 function clip(text: string): string {
-  const points = Array.from(text);
-  return points.length <= MAX_STREAM_CHARS ? text : points.slice(0, MAX_STREAM_CHARS).join("");
+  let clipped = "";
+  let points = 0;
+  for (const point of text) {
+    if (points === MAX_STREAM_CHARS) return clipped;
+    clipped += point;
+    points++;
+  }
+  return text;
 }
 
 /**

--- a/src/skills-tuner/subjects/external_process.ts
+++ b/src/skills-tuner/subjects/external_process.ts
@@ -47,6 +47,63 @@ const RpcResponseSchema = z.union([
   z.object({ error: z.string() }).strict(),
 ]);
 
+const MAX_STREAM_CHARS = 500;
+
+/**
+ * Truncate on a code-point boundary so a clipped message never ends on half of
+ * a surrogate pair (which would become U+FFFD once the message is encoded).
+ */
+function clip(text: string): string {
+  const points = Array.from(text);
+  return points.length <= MAX_STREAM_CHARS ? text : points.slice(0, MAX_STREAM_CHARS).join("");
+}
+
+/**
+ * Decode the RPC envelope a subject wrote to stdout, if there is one.
+ *
+ * The protocol is line-oriented — the template prints one JSON object per line
+ * (see examples/external_subject_python_template.py) — so the envelope is the
+ * LAST non-empty line, and anything a subject logged before it is not JSON.
+ * Parsing the whole buffer would therefore miss the envelope of any subject
+ * that logs before it fails.
+ */
+function stdoutEnvelope(stdout: string): { error: string } | { result: unknown } | undefined {
+  const lines = stdout.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]?.trim();
+    if (!line) continue;
+    try {
+      const envelope = RpcResponseSchema.safeParse(JSON.parse(line));
+      return envelope.success ? envelope.data : undefined;
+    } catch {
+      // The last non-empty line is not JSON — treat stdout as raw output.
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Describe what a failing subject left behind, preferring its own diagnosis.
+ */
+function failureDetails(stdout: string, stderr: string): string {
+  const details: string[] = [];
+  const envelope = stdoutEnvelope(stdout);
+  if (envelope && "error" in envelope) {
+    details.push(`error: ${clip(envelope.error)}`);
+  } else if (envelope) {
+    // A result payload on a failure path is not a diagnosis; naming it keeps
+    // the subject's data out of the exception message.
+    details.push("stdout: result payload");
+  } else if (stdout.trim()) {
+    details.push(`stdout: ${clip(stdout)}`);
+  }
+  if (stderr.trim()) {
+    details.push(`stderr: ${clip(stderr)}`);
+  }
+  return details.length > 0 ? details.join(" | ") : "no output on stdout or stderr";
+}
+
 export class ExternalProcessSubject extends TunableSubject {
   readonly name: string;
   readonly risk_tier: RiskTier;
@@ -87,7 +144,14 @@ export class ExternalProcessSubject extends TunableSubject {
     const exitCode: number = await new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         proc.kill("SIGKILL");
-        reject(new Error(`ExternalProcess ${this.name} timed out after ${timeoutMs}ms`));
+        // A subject can report its own failure and then hang; surface whatever it
+        // wrote so a timeout is not the only thing the operator gets.
+        reject(
+          new Error(
+            `ExternalProcess ${this.name} timed out after ${timeoutMs}ms. ` +
+              failureDetails(stdout, stderr),
+          ),
+        );
       }, timeoutMs);
       proc.on("exit", (code) => {
         clearTimeout(timer);
@@ -100,8 +164,12 @@ export class ExternalProcessSubject extends TunableSubject {
     });
 
     if (exitCode !== 0) {
+      // The documented stdio protocol (see examples/external_subject_python_template.py)
+      // has a failing subject print `{"error": "<message>"}` to STDOUT and then exit
+      // non-zero, so the subject's own diagnosis lives on stdout, not stderr. Report
+      // both streams — a subject may legitimately log to stderr as well.
       throw new Error(
-        `ExternalProcess ${this.name} exited ${exitCode}. stderr: ${stderr.slice(0, 500)}`,
+        `ExternalProcess ${this.name} exited ${exitCode}. ${failureDetails(stdout, stderr)}`,
       );
     }
 
@@ -109,9 +177,7 @@ export class ExternalProcessSubject extends TunableSubject {
     try {
       parsed = JSON.parse(stdout);
     } catch {
-      throw new Error(
-        `ExternalProcess ${this.name} returned invalid JSON: ${stdout.slice(0, 500)}`,
-      );
+      throw new Error(`ExternalProcess ${this.name} returned invalid JSON: ${clip(stdout)}`);
     }
 
     const validated = RpcResponseSchema.parse(parsed);


### PR DESCRIPTION
## Problem

When an external subject exits non-zero, the operator gets an exit code and whatever happened to be on stderr — which, for a subject written against this repo's own template, is nothing. The subject's actual diagnosis (`config file is missing a 'threshold' key`) is discarded before the error is ever thrown. Debugging a failing external subject currently means re-running it by hand outside the tuner to find out what it was trying to say.

## Root cause

`src/skills-tuner/subjects/external_process.ts`, in `callMethod()`, the `exitCode !== 0` branch built its message from `stderr` only:

```ts
throw new Error(
  `ExternalProcess ${this.name} exited ${exitCode}. stderr: ${stderr.slice(0, 500)}`,
);
```

`stdout` was already captured at that point and simply dropped.

The stream it drops is the documented one. The reference template, `examples/external_subject_python_template.py`, declares the protocol in its header — `stdout: {"result": <data>}  OR  {"error": "<message>"}` — and its error path (lines 62-68) implements exactly that: `print(json.dumps({"error": ...}))` to **stdout**, then `sys.exit(1)`.

The `{"error": ...}` handling further down in `callMethod` runs only after the exit-code check passes, so it is reachable only on exit 0. A subject that follows the template — error to stdout, exit 1 — takes the branch that never looks at stdout. The documented failure path was unreachable on failure.

## Fix

Failure paths now report the subject's own message, via one `failureDetails()` helper:

- **The envelope is read from the last non-empty line.** The protocol is line-oriented (the template prints one JSON object per line), so a subject that logs anything before it fails still ends with a parseable envelope. Parsing the whole buffer would miss it and report the log noise instead — which is the same class of bug this PR is fixing.
- **stderr is still appended whenever it is non-empty**, since a subject may legitimately log there as well; when both streams are empty the message says so explicitly rather than trailing an empty `stderr:`.
- **A `{"result": ...}` payload on a failure path is named, not echoed**, so subject data stays out of the exception message.
- **Truncation moved to a code-point boundary**, so a clipped message cannot end on half a surrogate pair and become `U+FFFD` once encoded.
- **The timeout path had the same defect** — a subject that reports its failure and then hangs gave the operator nothing but a duration. It now surfaces the streams through the same helper.

## Test plan

New file `src/skills-tuner/subjects/__tests__/external_process.test.ts` — 12 tests, each spawning a real fixture script from a `mkdtemp` directory so the assertions cover the actual subprocess path, not a mocked one:

- documented stdout envelope on exit 1 (the regression test), stderr-only, both streams, non-JSON stdout, both streams empty, truncation
- envelope preceded by a log line, result payload on a failure path, code-point-boundary clipping, timeout with a reported error
- two success-path tests pinning unchanged behaviour: `{"result": ...}` on exit 0, and the exit-0 `{"error": ...}` RPC branch

| Command | Result |
|---|---|
| `bun test src/skills-tuner/subjects/__tests__/external_process.test.ts` | 12 pass, 0 fail |
| `bun test src/skills-tuner` | 54 pass, 0 fail, 75 `expect()` across 3 files |
| `bun run typecheck` | `153 error(s), baseline 153` — exit 0, no regressions |
| `bun run lint` | `Checked 448 files. Found 1155 warnings, 296 infos.` — exit 0, identical to base |

Regression baseline: the two pre-existing `src/skills-tuner` test files alone give 42 pass / 0 fail; with the new file, 54 pass / 0 fail. 42 + 12 = 54, so the delta is entirely new coverage.

Lint attribution: scoping biome to only the touched files yields one warning, `noNonNullAssertion` on `spawn(this.opts.command[0]!, ...)`. That is pre-existing — it sits at line 67 in `upstream/main` and moved only because the new helpers add lines above it. Left untouched. The new test file lints at 0 diagnostics.

## Notes

- Manifests bumped 2.2.219 → **2.2.222**. This branch was rebased onto `8745b2d` after #348 merged (which shipped 2.2.219), so the earlier 2.2.218 plan is obsolete. The sibling PRs were rebased in the same pass and take 2.2.220 (#353), 2.2.221 (#349), 2.2.222 (#350) and 2.2.223 (#352); if the merge order changes, whichever lands later needs a re-bump.
- The pre-existing `returned invalid JSON` path now uses the same clipping helper, so the file is consistent about not emitting broken UTF-8. That is the only line touched outside the failure paths.
- Success-path behaviour is unchanged: on exit 0 the response is parsed and dispatched exactly as before, including the existing `{"error": ...}` RPC branch, which is covered by two of the new tests.
- Deliberately out of scope: stripping ANSI/control sequences from subject output before it reaches a terminal. That is a policy call for the logging layer rather than this call site — happy to follow up if you want it.
- No changes to the protocol itself, the template, or any caller. One root cause, one fix.

