### PR TITLE
fix(mcp-multiplexer): answer a session-less server/discover probe instead of 400ing it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.219",
+      "version": "2.2.220",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.219",
+      "version": "2.2.218",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.218",
+      "version": "2.2.219",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.219",
+  "version": "2.2.220",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.219",
+  "version": "2.2.218",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.218",
+  "version": "2.2.219",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
@@ -711,3 +711,76 @@ describe("McpHttpHandler — body-peek threshold for audit (#72 item 11)", () =>
     revokeIdentity("suzy");
   });
 });
+
+describe("McpHttpHandler — session-less discovery probe", () => {
+  let proc: McpServerProcess | null = null;
+  let handler: McpHttpHandler | null = null;
+
+  beforeEach(async () => {
+    _resetIdentityStore();
+    proc = new McpServerProcess("test", makeServerConfig());
+    await proc.start();
+    handler = new McpHttpHandler({ serverName: "test", proc });
+  });
+
+  afterEach(async () => {
+    if (handler) await handler.stop();
+    if (proc) await proc.stop();
+    proc = null;
+    handler = null;
+    _resetIdentityStore();
+  });
+
+  function authed(body: unknown): Request {
+    const id = issueIdentity("suzy");
+    return rpcRequest(body, {
+      [PTY_ID_HEADER]: "suzy",
+      [PTY_TS_HEADER]: String(Date.now()),
+      ...id.headers,
+    });
+  }
+
+  // A client on MCP revision 2026-07-28 probes with `server/discover` before
+  // it holds a session id. The session-ful SDK transport answers that with a
+  // transport-level 400, which the client reads as "server unreachable" and
+  // drops the server. A JSON-RPC "method not found" keeps the connection
+  // usable and lets the client fall back to `initialize`.
+  it("answers server/discover with a JSON-RPC error, not a transport 400", async () => {
+    const resp = await handler!.handle(
+      authed({ jsonrpc: "2.0", id: "server-discover-probe-1", method: "server/discover" }),
+    );
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as {
+      jsonrpc: string;
+      id: unknown;
+      error: { code: number; message: string };
+    };
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.error.code).toBe(-32601);
+    expect(body.id).toBe("server-discover-probe-1");
+  });
+
+  it("echoes a null id back when the probe carries none", async () => {
+    const resp = await handler!.handle(authed({ jsonrpc: "2.0", method: "server/discover" }));
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { id: unknown; error?: { code: number } };
+    // Assert the error too: without it this passes on the unpatched
+    // transport as well, which would make the test prove nothing.
+    expect(body.error?.code).toBe(-32601);
+    expect(body.id).toBeNull();
+  });
+
+  it("still authenticates the probe — no bearer, no answer", async () => {
+    const resp = await handler!.handle(
+      rpcRequest({ jsonrpc: "2.0", id: 1, method: "server/discover" }),
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  it("leaves every other method on the transport path", async () => {
+    const resp = await handler!.handle(authed({ jsonrpc: "2.0", id: 1, method: "initialize" }));
+    expect(resp.status).not.toBe(401);
+    const body = (await resp.text()) as string;
+    expect(body).not.toContain("-32601");
+  });
+});

--- a/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
@@ -770,6 +770,51 @@ describe("McpHttpHandler — session-less discovery probe", () => {
     expect(body.id).toBeNull();
   });
 
+  /** Same as `authed`, but with an explicit `content-length` header and a
+   *  body padded past PEEK_MAX_BYTES. `new Request(url, { body })` sets no
+   *  content-length of its own, so without this the peek's declared-size
+   *  branch — the one production actually takes over a socket — is never
+   *  exercised. Mirrors `bigRpcRequest` in the #72 item 11 block. */
+  function authedBig(method: string, targetBodyBytes: number): Request {
+    const id = issueIdentity("suzy");
+    const padding = "x".repeat(Math.max(0, targetBodyBytes - 80));
+    const body = JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: { padding } });
+    return new Request("http://127.0.0.1:4632/mcp/test", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        "content-length": String(body.length),
+        [PTY_ID_HEADER]: "suzy",
+        [PTY_TS_HEADER]: String(Date.now()),
+        ...id.headers,
+      },
+      body,
+    });
+  }
+
+  // Regression: the audit peek skips bodies over PEEK_MAX_BYTES, so gating
+  // the probe answer on that peek alone let a >4 KiB probe fall through to
+  // the transport and 400 — the exact failure this guard exists to prevent.
+  // Reproduced over a real socket before the fix; in-process it needs the
+  // declared content-length that `authedBig` supplies.
+  it("answers a probe larger than the audit peek threshold", async () => {
+    const req = authedBig("server/discover", 8192);
+    expect(req.headers.get("content-length")).not.toBeNull();
+    expect(Number(req.headers.get("content-length"))).toBeGreaterThan(4096);
+
+    const resp = await handler!.handle(req);
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { error: { code: number } };
+    expect(body.error.code).toBe(-32601);
+  });
+
+  it("does not divert other large methods onto the probe path", async () => {
+    const resp = await handler!.handle(authedBig("tools/list", 8192));
+    expect(resp.status).not.toBe(401);
+    expect(await resp.text()).not.toContain("-32601");
+  });
+
   it("still authenticates the probe — no bearer, no answer", async () => {
     const resp = await handler!.handle(
       rpcRequest({ jsonrpc: "2.0", id: 1, method: "server/discover" }),

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -316,6 +316,34 @@ export class McpHttpHandler {
       );
     }
 
+    // ── Session-less discovery probe ──────────────────────────────────
+    // A client on MCP revision 2026-07-28 opens with `server/discover`
+    // BEFORE it has a session id. Our transport is session-ful
+    // (`sessionIdGenerator` is always set), so the SDK rejects that probe
+    // at the transport layer with `400 Mcp-Session-Id header is required`
+    // — a transport-level failure the client reads as "this server is
+    // unreachable", so it drops the server entirely instead of falling
+    // back to `initialize`.
+    //
+    // `server/discover` is an optional capability we do not implement.
+    // Answer it the way JSON-RPC says an unimplemented method must be
+    // answered: a well-formed error, not a broken transport. Clients then
+    // fall back to the classic `initialize` handshake and connect.
+    // Verified against claude-code 2.1.239: with the 400 the servers are
+    // dropped; with this response the same client connects and lists tools.
+    const peek = await _readBody(safeReq);
+    if (_peekRpcMethod(peek) === "server/discover") {
+      const probeId = (peek as { id?: unknown } | undefined)?.id ?? null;
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: probeId,
+          error: { code: -32601, message: "Method not found: server/discover" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
     // ── Upstream readiness ────────────────────────────────────────────
     // If the upstream child is mid-restart we return 503 immediately so
     // the MCP client retries instead of hanging on a dead session.
@@ -352,9 +380,9 @@ export class McpHttpHandler {
       this.persistence.touch(this.serverName, bucketKey).catch(() => {});
     }
 
-    // Peek at the body for audit observability without consuming the
-    // request stream (the transport needs to re-read it).
-    const peek = await _readBody(safeReq);
+    // `peek` was already parsed above for the discovery-probe check; it
+    // clones rather than consuming, so the transport can still read the
+    // body. Reused here for audit observability instead of parsing twice.
 
     // #72 item 5: include the client-asserted identity-issuance
     // timestamp (`X-Claudeclaw-Ts`) in the invoke audit so the audit

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -78,6 +78,11 @@ export interface McpHttpHandlerOpts {
  *  would OOM the daemon. */
 const MAX_BODY_BYTES = 1_048_576; // 1 MiB
 
+/** Session header minted by the SDK's Streamable HTTP transport. A request
+ *  that carries it already completed the handshake, so it can never be the
+ *  pre-session discovery probe. */
+const SESSION_ID_HEADER = "mcp-session-id";
+
 /**
  * Maximum body size we'll clone + JSON.parse for the audit-log peek
  * (#72 item 11). Above this threshold we skip the peek entirely — the
@@ -110,8 +115,13 @@ const PEEK_MAX_BYTES = 4096;
  * server name, ptyId, timestamp, etc. The bulk of multiplexer traffic
  * (tool listings, small dispatches) is well under 4KB and continues
  * to get the peek.
+ *
+ * `maxBytes` overrides that ceiling for callers that need the method
+ * for a *correctness* decision rather than for the audit row — the
+ * skip above is a memory optimisation and must never silently change
+ * how a request is routed. See the discovery-probe guard in `handle`.
  */
-async function _readBody(req: Request): Promise<unknown> {
+async function _readBody(req: Request, maxBytes: number = PEEK_MAX_BYTES): Promise<unknown> {
   const ct = req.headers.get("content-type") ?? "";
   if (!ct.toLowerCase().includes("json")) return undefined;
   // Skip the clone+parse when the body is big enough to materially
@@ -121,7 +131,7 @@ async function _readBody(req: Request): Promise<unknown> {
   const declared = req.headers.get("content-length");
   if (declared !== null) {
     const n = Number(declared);
-    if (Number.isFinite(n) && n > PEEK_MAX_BYTES) {
+    if (Number.isFinite(n) && n > maxBytes) {
       return undefined;
     }
   }
@@ -331,9 +341,26 @@ export class McpHttpHandler {
     // fall back to the classic `initialize` handshake and connect.
     // Verified against claude-code 2.1.239: with the 400 the servers are
     // dropped; with this response the same client connects and lists tools.
+    //
+    // The audit peek below skips any body whose declared Content-Length is
+    // over `PEEK_MAX_BYTES` (#72 item 11). That skip is a memory
+    // optimisation for large tool calls, and it must not decide whether
+    // this probe is answered: a probe over 4 KiB would fall through to the
+    // transport and reproduce the exact 400 this guard exists to prevent.
+    // So when the cheap peek came back empty and the request carries no
+    // session id — the only requests that can be a pre-session probe, and
+    // never the large tool-call bodies the skip was written for — re-read
+    // with the ceiling lifted to the 1 MiB body cap `_enforceBodyCap`
+    // already enforces. The audit row keeps the cheap peek's semantics.
     const peek = await _readBody(safeReq);
-    if (_peekRpcMethod(peek) === "server/discover") {
-      const probeId = (peek as { id?: unknown } | undefined)?.id ?? null;
+    const probePeek =
+      peek !== undefined
+        ? peek
+        : safeReq.headers.get(SESSION_ID_HEADER) === null
+          ? await _readBody(safeReq, MAX_BODY_BYTES)
+          : undefined;
+    if (_peekRpcMethod(probePeek) === "server/discover") {
+      const probeId = (probePeek as { id?: unknown } | undefined)?.id ?? null;
       return new Response(
         JSON.stringify({
           jsonrpc: "2.0",


### PR DESCRIPTION
## Problem

A client on MCP revision `2026-07-28` opens a connection with a `server/discover` probe **before** it holds a session id. The multiplexer's transport is session-ful (`sessionIdGenerator` is always set in `_createBucket`), so the SDK rejects that probe at the transport layer:

```
HTTP 400
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: Mcp-Session-Id header is required"},"id":null}
```

A transport-level 400 is not a "method unsupported" signal — the client reads it as *this server is unreachable* and drops the server outright instead of falling back to the classic `initialize` handshake. Every server behind the multiplexer disappears for that client, with no error surfaced beyond "no MCP servers available".

Captured with a logging proxy in front of the multiplexer, from `claude-code/2.1.239 (sdk-cli)`:

```
POST /mcp/<server>
  mcp-protocol-version: 2026-07-28
  mcp-method: server/discover
  (no Mcp-Session-Id)
  {"jsonrpc":"2.0","id":"server-discover-probe-1","method":"server/discover", ...}
→ HTTP 400  Mcp-Session-Id header is required
```

Three configured servers, three 400s, zero connected.

## Root cause

`server/discover` is an optional capability this server does not implement. There is no handler registered for it, so the request falls through to the session-ful transport, which requires a session id for anything that is not `initialize`. The unimplemented-method case is being reported as a broken transport.

## Fix

Intercept the probe and answer it the way JSON-RPC says an unimplemented method must be answered — a well-formed `-32601` over HTTP 200. The connection stays usable and the client falls back to `initialize`.

Placement matters and is deliberate:

- **After authentication**, so the probe is not a new unauthenticated surface. A probe without a valid bearer still gets 401, and there is a test pinning that.
- **Before bucket creation**, so a discovery probe no longer spins up a session bucket, an SDK `Server`, and a persistence record it will never use.
- The body peek that already existed for the audit line is **reused** rather than parsed a second time.

No SDK upgrade, no change to any other method's path.

One subtlety worth calling out, because it defeated the first version of this fix. The audit peek (`_readBody`) skips parsing when a declared `Content-Length` exceeds 4 KiB — that ceiling exists for audit observability, where losing `rpc_method` is acceptable. Reusing it as a *correctness* gate meant a probe larger than 4 KiB fell straight through to the transport and reproduced the original 400. The audit peek keeps its ceiling and its exact semantics; the probe check falls back to a full parse only when the body is over the ceiling **and** carries no `mcp-session-id`, which in practice is only the probe. Large tool-call bodies always carry a session id, so the optimisation those tests were written for is untouched.

## Test plan

Six tests in `src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts`. Three assert the fix: the probe gets `-32601` rather than a transport 400; a probe with no `id` echoes `null` and still carries the error; a probe larger than the audit-peek ceiling is answered rather than falling through. Three are negative controls: an unauthenticated probe still gets 401, every other method still goes down the transport path, and a large non-probe is not diverted onto the probe path.

Verified over a real socket rather than in-process, because that distinction matters here: `new Request(url, {body})` sets no `Content-Length`, so an in-process test never exercises the branch production takes. Behind `Bun.serve`:

| body | before the large-probe fix | after |
|---|---|---|
| 51 B probe | 200 `-32601` | 200 `-32601` |
| 5 075 B probe | **400 transport** | 200 `-32601` |
| 900 075 B probe | — | 200 `-32601` |
| 5 070 B `tools/list` | 400 transport | 400 transport (untouched) |

Mutation-checked twice. Making the interception unreachable fails 3 of the 6 — the three that assert the fix. The three negative controls pass with the fix fully disabled and are not evidence it works; they exist to catch the guard being moved before authentication or made too greedy. Reverting only the large-probe remediation fails exactly one test, the regression test written for it.

| Command | Result |
|---|---|
| `bun test src/plugins/mcp-multiplexer` | 148 pass, 0 fail |
| `bun test src/plugins` | 197 pass / 18 fail — base is 191 pass / **the same 18**, failing names diffed |
| `bun run typecheck` | `153 error(s), baseline 153` — flat on base, on HEAD, and after |
| `bun run lint` | exit 0 |

On the pre-existing failures: 11 are in `SessionPersistenceStore` and 7 are `McpHttpHandler` audit tests that pass in isolation and fail only in the full `src/plugins` run through cross-file mock interference. Both sets fail identically on a pristine `upstream/main` worktree.

End-to-end, outside this repo: an HTTP MCP server answering the probe with a transport 400 is dropped by `claude-code 2.1.239`, which then reports no servers at all; the same server answering `-32601` connects and lists its tools.

## Notes

- Manifests bumped 2.2.219 → **2.2.220**. This branch was rebased onto `8745b2d` after #348 merged (which shipped 2.2.219), so the earlier 2.2.218 plan is obsolete. The sibling PRs were rebased in the same pass and take 2.2.221 (#349), 2.2.222 (#350) and 2.2.223 (#352); if the merge order changes, whichever lands later needs a re-bump.
- This is independent of #349, which wires `--mcp-config` into dispatched agent jobs. That wiring is correct; the jobs were reaching this 400 once connected, so #349 cannot demonstrate its own fix until this one lands.

