### PR TITLE
fix(mcp-multiplexer): give every PTY its own bucket, stateless servers included

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.223",
+      "version": "2.2.224",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.223",
+  "version": "2.2.224",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.planning/mcp-multiplexer/SECURITY-AUDIT.md
+++ b/.planning/mcp-multiplexer/SECURITY-AUDIT.md
@@ -257,7 +257,9 @@ async releaseIdentity(ptyId: string): Promise<void> {
 
 `releasePty(ptyId)` (`http-handler.ts:186-199`) deletes the bucket from the map and closes both the SDK server and the transport. Idempotent — safe to call for a never-issued ptyId.
 
-For stateless servers (`http-handler.ts:189`), `releasePty` is a no-op because the bucket is keyed on `STATELESS_BUCKET` not `ptyId`. That's correct (the bucket is shared and survives PTY lifecycle), but means PTY teardown does NOT clean up the upstream session for stateless servers. **This is by design** (per `http-handler.ts:33-36` comment) but worth confirming with the operator: if a stateless server holds per-PTY state inside its own process (e.g. graphiti's group_id), that state will outlive the PTY. The same was already true before this milestone, so it's not a regression — just worth knowing.
+~~For stateless servers, `releasePty` is a no-op because the bucket is keyed on `STATELESS_BUCKET` not `ptyId`.~~ **Superseded.** The bucket collapse this described was removed: a bucket is the client-facing MCP session, and an MCP session cannot be shared by two clients, so a collapsed bucket made a stateless server single-client (the second client's `initialize` drew `400 -32600 "Server already initialized"` and it dropped the server). Buckets are now keyed on `ptyId` for every server, `stateless` included, and `releasePty` tears them down uniformly.
+
+The residual worth knowing is unchanged and unrelated to keying: the upstream child is a single shared process for every bucket either way, so if a shared server holds per-PTY state inside its own process (e.g. graphiti's `group_id`), that state outlives any one PTY.
 
 `stop()` (`index.ts:287-307`) tears down everything in order: stop probe → unregister plugin from bridge → unregister gateway routes → stop handlers → stop server processes → clear caches. **PASS.**
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Net effect: you get the per-PTY process explosion the multiplexer was designed t
 ```
 
 - `shared` — server names (must also exist in `mcp-proxy.json`) the multiplexer hosts. Empty list = dormant; PTY claudes fall back to per-PTY stdio spawns (no protection from the explosion).
-- `stateless` — subset of `shared` for servers with no per-session state; one upstream session shared across all PTYs.
+- `stateless` — subset of `shared` for servers with no per-session state; the multiplexer keeps no session binding on disk for them and replays none at restart. It does **not** change client demultiplexing: every PTY still gets its own MCP session against the multiplexer (a session cannot be shared by two clients), and the upstream child is a single shared process for every server either way.
 - `rateLimit` — per-bearer (= per-PTY) sliding-window cap on `/mcp/<server>` requests. Defense-in-depth for a leaked bearer.
 
 #### Surface coverage: tools only (no resources / prompts / completions)

--- a/src/__tests__/mcp-multiplexer-integration.test.ts
+++ b/src/__tests__/mcp-multiplexer-integration.test.ts
@@ -99,7 +99,14 @@ async function connectClient(opts: {
   ptyId: string;
   bearer: string;
   clientName?: string;
-}): Promise<{ client: Client; close: () => Promise<void> }> {
+}): Promise<{
+  client: Client;
+  /** Exposed so a test can assert two clients got DISTINCT MCP session ids —
+   *  `bucket_keys` only proves the map was keyed apart, not that the SDK
+   *  minted separate sessions. */
+  transport: StreamableHTTPClientTransport;
+  close: () => Promise<void>;
+}> {
   const transport = new StreamableHTTPClientTransport(
     new URL(`${opts.origin}/mcp/${opts.server}`),
     {
@@ -118,6 +125,7 @@ async function connectClient(opts: {
   await client.connect(transport);
   return {
     client,
+    transport,
     close: async () => {
       try {
         await client.close();
@@ -458,10 +466,134 @@ describe("mcp-multiplexer integration — stateful vs stateless demux", () => {
 });
 
 describe("mcp-multiplexer integration — stateless server serves concurrent clients", () => {
-  // No explicit timeout override: this test is sub-second, and the
-  // `it(name, {timeout}, fn)` overload is what the typecheck ratchet
-  // already counts as an error 7 times over in this file.
-  it("two PTYs each complete their own initialize against a stateless server and both can call tools", async () => {
+  // No explicit timeout override anywhere in this describe: these are
+  // sub-second, and the `it(name, {timeout}, fn)` overload is what the
+  // typecheck ratchet already counts as an error 7 times over in this file.
+  it("four PTYs each complete their own initialize against a stateless server", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["beta"]);
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      settingsView: makeMuxSettingsView({
+        webEnabled: true,
+        shared: ["beta"],
+        stateless: ["beta"],
+      }),
+    });
+    await plugin.start();
+    gateway = startTestGateway();
+
+    // FOUR, not two. Two proves the keys are not ALL collapsed; it does not
+    // prove the keying is unbounded — a mutation that keys the first two
+    // apart and collapses the third onward survives a 2-client test.
+    const ids = ["pty-a", "pty-b", "pty-c", "pty-d"];
+    const conns = [];
+    for (const ptyId of ids) {
+      const ident = plugin.issueIdentity(ptyId);
+      conns.push(
+        await connectClient({
+          origin: gateway.origin,
+          server: "beta",
+          ptyId,
+          bearer: ident.headers.Authorization,
+        }),
+      );
+    }
+
+    try {
+      for (const c of conns) {
+        expect((await c.client.listTools()).tools.map((t) => t.name)).toEqual(["echo"]);
+      }
+
+      // Concurrent IN-FLIGHT dispatch. Awaiting each call in turn never puts
+      // two requests on the wire at once, so it cannot catch a regression
+      // where two clients share one session and collide on JSON-RPC ids —
+      // the very hazard this test is named for.
+      const results = await Promise.all(
+        conns.map((c, i) =>
+          c.client.callTool({ name: "echo", arguments: { message: `from-${ids[i]}` } }),
+        ),
+      );
+      results.forEach((r, i) => {
+        expect(JSON.stringify(r)).toContain(`from-${ids[i]}`);
+      });
+
+      // Distinct MCP session ids — the property that actually prevents the
+      // id collision. `bucket_keys` only shows the map was keyed apart.
+      const sids = conns.map((c) => c.transport.sessionId);
+      for (const sid of sids) expect(sid).toBeDefined();
+      expect(new Set(sids).size).toBe(ids.length);
+
+      const betaH = plugin._getHandler("beta")?.health() as {
+        stateless: boolean;
+        bucket_keys: string[];
+        active_buckets: number;
+      };
+      expect(betaH.stateless).toBe(true);
+      expect(betaH.bucket_keys.sort()).toEqual([...ids].sort());
+      expect(betaH.active_buckets).toBe(ids.length);
+    } finally {
+      for (const c of conns) await c.close();
+    }
+  });
+
+  it("a fresh client on the SAME ptyId is not bricked by its predecessor", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["beta"]);
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      settingsView: makeMuxSettingsView({
+        webEnabled: true,
+        shared: ["beta"],
+        stateless: ["beta"],
+      }),
+    });
+    await plugin.start();
+    gateway = startTestGateway();
+
+    const ident = plugin.issueIdentity("pty-r");
+
+    // First client opens and goes away WITHOUT the supervisor revoking the
+    // identity — that is exactly what a crash-respawn looks like
+    // ("a respawn, not a permanent dispose"), so no `releasePty` runs.
+    const first = await connectClient({
+      origin: gateway.origin,
+      server: "beta",
+      ptyId: "pty-r",
+      bearer: ident.headers.Authorization,
+    });
+    await first.client.listTools();
+    const firstSid = first.transport.sessionId;
+    await first.close();
+
+    // The replacement must be able to handshake. Without bucket recycling it
+    // lands on the predecessor's initialized transport and the SDK answers
+    // `400 -32600 "Server already initialized"`, which the client reads as an
+    // unreachable server — the same failure mode as the collapsed bucket,
+    // one ptyId at a time.
+    const second = await connectClient({
+      origin: gateway.origin,
+      server: "beta",
+      ptyId: "pty-r",
+      bearer: ident.headers.Authorization,
+    });
+    try {
+      expect((await second.client.listTools()).tools.map((t) => t.name)).toEqual(["echo"]);
+      expect(second.transport.sessionId).toBeDefined();
+      expect(second.transport.sessionId).not.toBe(firstSid);
+
+      // One live bucket for the ptyId, not two: the predecessor was retired,
+      // not merely shadowed.
+      const betaH = plugin._getHandler("beta")?.health() as {
+        bucket_keys: string[];
+        active_buckets: number;
+      };
+      expect(betaH.bucket_keys).toEqual(["pty-r"]);
+      expect(betaH.active_buckets).toBe(1);
+    } finally {
+      await second.close();
+    }
+  });
+
+  it("routes an authenticated raw POST with no session id into that PTY's own bucket", async () => {
     const cfg = writeProxyConfig(tmpDir, ["beta"]);
     plugin = new McpMultiplexerPlugin({
       configPath: cfg,
@@ -477,50 +609,107 @@ describe("mcp-multiplexer integration — stateless server serves concurrent cli
     const a = plugin.issueIdentity("pty-1");
     const b = plugin.issueIdentity("pty-2");
 
-    // Both PTYs are REAL MCP clients: each drives its own `initialize`,
-    // exactly like two `claude` processes handed the same synthesized
-    // `--mcp-config`. This is the scenario the old bucket-collapse made
-    // impossible — the second `initialize` landed on the first client's
-    // transport and the SDK answered
-    // `400 -32600 "Server already initialized"`, which the client reads
-    // as an unreachable server and drops.
     const b1 = await connectClient({
       origin: gateway.origin,
       server: "beta",
       ptyId: "pty-1",
       bearer: a.headers.Authorization,
     });
-    const b2 = await connectClient({
-      origin: gateway.origin,
-      server: "beta",
-      ptyId: "pty-2",
-      bearer: b.headers.Authorization,
-    });
+    await b1.client.listTools();
 
     try {
-      // Both clients see the upstream tool surface...
-      expect((await b1.client.listTools()).tools.map((t) => t.name)).toEqual(["echo"]);
-      expect((await b2.client.listTools()).tools.map((t) => t.name)).toEqual(["echo"]);
+      // A bare POST: valid bearer, no `mcp-session-id`, not an initialize.
+      // This is the shape the `server/discover` guard re-reads the body for,
+      // and the only stateless path not driven through an SDK Client.
+      const resp = await fetch(`${gateway.origin}/mcp/beta`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: b.headers.Authorization,
+          "X-Claudeclaw-Pty-Id": "pty-2",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 99, method: "tools/list", params: {} }),
+      });
+      // Past auth. The SDK rejects it as a session-less non-initialize (400)
+      // — what matters is where it landed.
+      expect(resp.status).not.toBe(401);
+      expect(resp.status).not.toBe(404);
 
-      // ...and both can actually dispatch through to the single shared
-      // upstream child.
-      const r1 = await b1.client.callTool({ name: "echo", arguments: { message: "from-pty-1" } });
-      const r2 = await b2.client.callTool({ name: "echo", arguments: { message: "from-pty-2" } });
-      expect(JSON.stringify(r1)).toContain("from-pty-1");
-      expect(JSON.stringify(r2)).toContain("from-pty-2");
-
-      // Each client got its OWN MCP session: sharing one session id
-      // across two clients is what collides on JSON-RPC message ids.
-      const betaH = plugin._getHandler("beta")?.health() as {
-        stateless: boolean;
-        bucket_keys: string[];
-      };
-      expect(betaH.stateless).toBe(true);
+      // It got its OWN bucket rather than being routed onto pty-1's session.
+      const betaH = plugin._getHandler("beta")?.health() as { bucket_keys: string[] };
       expect(betaH.bucket_keys.sort()).toEqual(["pty-1", "pty-2"]);
     } finally {
       await b1.close();
-      await b2.close();
     }
+  });
+
+  it("a client that ends its session releases the bucket immediately", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["beta"]);
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      settingsView: makeMuxSettingsView({
+        webEnabled: true,
+        shared: ["beta"],
+        stateless: ["beta"],
+      }),
+    });
+    await plugin.start();
+    gateway = startTestGateway();
+
+    const ident = plugin.issueIdentity("pty-d");
+    const conn = await connectClient({
+      origin: gateway.origin,
+      server: "beta",
+      ptyId: "pty-d",
+      bearer: ident.headers.Authorization,
+    });
+    await conn.client.listTools();
+    const handler = plugin._getHandler("beta");
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual(["pty-d"]);
+
+    // The SDK client's terminateSession() sends the transport DELETE. A
+    // bucket IS the session it belongs to, so it must go with it rather than
+    // sit on a transport the SDK still considers initialized until the
+    // supervisor happens to revoke the identity.
+    await conn.transport.terminateSession();
+    await new Promise((r) => setTimeout(r, 50));
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual([]);
+
+    await conn.close();
+  });
+
+  it("releaseIdentity tears down a stateless bucket", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["beta"]);
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      settingsView: makeMuxSettingsView({
+        webEnabled: true,
+        shared: ["beta"],
+        stateless: ["beta"],
+      }),
+    });
+    await plugin.start();
+    gateway = startTestGateway();
+
+    const ident = plugin.issueIdentity("pty-x");
+    const conn = await connectClient({
+      origin: gateway.origin,
+      server: "beta",
+      ptyId: "pty-x",
+      bearer: ident.headers.Authorization,
+    });
+    await conn.client.listTools();
+
+    const handler = plugin._getHandler("beta");
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual(["pty-x"]);
+
+    // Restoring `releasePty`'s old `if (this.stateless) return` early exit
+    // passes every other test in this repo; this is the one that catches it.
+    await plugin.releaseIdentity("pty-x");
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual([]);
+
+    await conn.close();
   });
 });
 

--- a/src/__tests__/mcp-multiplexer-integration.test.ts
+++ b/src/__tests__/mcp-multiplexer-integration.test.ts
@@ -379,7 +379,7 @@ describe("mcp-multiplexer integration — auth rejection", () => {
 // ── 4) Stateful vs stateless session demux ──────────────────────────────────
 
 describe("mcp-multiplexer integration — stateful vs stateless demux", () => {
-  it("stateful server creates per-PTY buckets; stateless server collapses to a single __stateless__ bucket", {
+  it("both stateful and stateless servers key their buckets per PTY", {
     timeout: 10000,
   }, async () => {
     const cfg = writeProxyConfig(tmpDir, ["alpha", "beta"]);
@@ -397,8 +397,8 @@ describe("mcp-multiplexer integration — stateful vs stateless demux", () => {
     const a = plugin.issueIdentity("pty-1");
     const b = plugin.issueIdentity("pty-2");
 
-    // STATEFUL server (`alpha`): use full SDK clients — each PTY's
-    // initialize() goes to its own SDK Server in its own bucket.
+    // STATEFUL server (`alpha`): each PTY's initialize() goes to its own
+    // SDK Server in its own bucket.
     const a1 = await connectClient({
       origin: gateway.origin,
       server: "alpha",
@@ -414,47 +414,24 @@ describe("mcp-multiplexer integration — stateful vs stateless demux", () => {
     await a1.client.listTools();
     await a2.client.listTools();
 
-    // STATELESS server (`beta`): both PTYs share a single SDK Server.
-    // The first PTY drives initialize() via the SDK Client; the second
-    // PTY hits the same bucket via a raw tools/list — re-initialising
-    // a shared SDK Server would (correctly) be rejected, which is the
-    // whole point of the stateless mode. We assert the bucket-collapse
-    // property on the handler health snapshot.
+    // STATELESS server (`beta`): same keying. The marker changes what is
+    // persisted, not how clients are demultiplexed — an MCP session is
+    // per-client either way. See the concurrent-clients test below for
+    // the behaviour this protects.
     const b1 = await connectClient({
       origin: gateway.origin,
       server: "beta",
       ptyId: "pty-1",
       bearer: a.headers.Authorization,
     });
-    await b1.client.listTools();
-
-    // PTY-2 reuses the existing __stateless__ bucket — send a raw
-    // tools/list bypassing client-side initialization. Auth still
-    // gates the request, so PTY-2 must use its own bearer. The SDK
-    // transport will reject this with 400 (no session ID) — that's
-    // fine; what matters is the request flowed past auth into the
-    // shared bucket without creating a new one, which is the
-    // collapse property we assert below on handler.health().
-    const resp = await fetch(`${gateway.origin}/mcp/beta`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json, text/event-stream",
-        Authorization: b.headers.Authorization,
-        "X-Claudeclaw-Pty-Id": "pty-2",
-      },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 99,
-        method: "tools/list",
-        params: {},
-      }),
+    const b2 = await connectClient({
+      origin: gateway.origin,
+      server: "beta",
+      ptyId: "pty-2",
+      bearer: b.headers.Authorization,
     });
-    // Past auth (status !== 401, !== 404). The SDK transport may
-    // accept (200/202) or reject as malformed session (400) — either
-    // proves the request reached the bucket, not the auth wall.
-    expect(resp.status).not.toBe(401);
-    expect(resp.status).not.toBe(404);
+    await b1.client.listTools();
+    await b2.client.listTools();
 
     try {
       const alphaH = plugin._getHandler("alpha")?.health() as {
@@ -470,12 +447,79 @@ describe("mcp-multiplexer integration — stateful vs stateless demux", () => {
       expect(alphaH.bucket_keys.sort()).toEqual(["pty-1", "pty-2"]);
 
       expect(betaH.stateless).toBe(true);
-      // STATELESS_BUCKET sentinel — one bucket regardless of PTY count.
-      expect(betaH.bucket_keys).toEqual(["__stateless__"]);
+      expect(betaH.bucket_keys.sort()).toEqual(["pty-1", "pty-2"]);
     } finally {
       await a1.close();
       await a2.close();
       await b1.close();
+      await b2.close();
+    }
+  });
+});
+
+describe("mcp-multiplexer integration — stateless server serves concurrent clients", () => {
+  // No explicit timeout override: this test is sub-second, and the
+  // `it(name, {timeout}, fn)` overload is what the typecheck ratchet
+  // already counts as an error 7 times over in this file.
+  it("two PTYs each complete their own initialize against a stateless server and both can call tools", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["beta"]);
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      settingsView: makeMuxSettingsView({
+        webEnabled: true,
+        shared: ["beta"],
+        stateless: ["beta"],
+      }),
+    });
+    await plugin.start();
+    gateway = startTestGateway();
+
+    const a = plugin.issueIdentity("pty-1");
+    const b = plugin.issueIdentity("pty-2");
+
+    // Both PTYs are REAL MCP clients: each drives its own `initialize`,
+    // exactly like two `claude` processes handed the same synthesized
+    // `--mcp-config`. This is the scenario the old bucket-collapse made
+    // impossible — the second `initialize` landed on the first client's
+    // transport and the SDK answered
+    // `400 -32600 "Server already initialized"`, which the client reads
+    // as an unreachable server and drops.
+    const b1 = await connectClient({
+      origin: gateway.origin,
+      server: "beta",
+      ptyId: "pty-1",
+      bearer: a.headers.Authorization,
+    });
+    const b2 = await connectClient({
+      origin: gateway.origin,
+      server: "beta",
+      ptyId: "pty-2",
+      bearer: b.headers.Authorization,
+    });
+
+    try {
+      // Both clients see the upstream tool surface...
+      expect((await b1.client.listTools()).tools.map((t) => t.name)).toEqual(["echo"]);
+      expect((await b2.client.listTools()).tools.map((t) => t.name)).toEqual(["echo"]);
+
+      // ...and both can actually dispatch through to the single shared
+      // upstream child.
+      const r1 = await b1.client.callTool({ name: "echo", arguments: { message: "from-pty-1" } });
+      const r2 = await b2.client.callTool({ name: "echo", arguments: { message: "from-pty-2" } });
+      expect(JSON.stringify(r1)).toContain("from-pty-1");
+      expect(JSON.stringify(r2)).toContain("from-pty-2");
+
+      // Each client got its OWN MCP session: sharing one session id
+      // across two clients is what collides on JSON-RPC message ids.
+      const betaH = plugin._getHandler("beta")?.health() as {
+        stateless: boolean;
+        bucket_keys: string[];
+      };
+      expect(betaH.stateless).toBe(true);
+      expect(betaH.bucket_keys.sort()).toEqual(["pty-1", "pty-2"]);
+    } finally {
+      await b1.close();
+      await b2.close();
     }
   });
 });

--- a/src/__tests__/session-persistence-integration.test.ts
+++ b/src/__tests__/session-persistence-integration.test.ts
@@ -733,7 +733,7 @@ describe("session-persistence integration — kill-switch", () => {
 // ── 7) Stateless server is not persisted ────────────────────────────────────
 
 describe("session-persistence integration — stateless server skips persistence", () => {
-  it("stateless server creates a collapsed bucket but never writes to disk", {
+  it("stateless server gets a normal per-PTY bucket but never writes to disk", {
     timeout: 10000,
   }, async () => {
     const cfg = writeProxyConfig(tmpDir, ["alpha", "beta"]);
@@ -769,13 +769,16 @@ describe("session-persistence integration — stateless server skips persistence
       // Window for any fire-and-forget.
       await new Promise((r) => setTimeout(r, 100));
 
-      // Beta bucket collapsed to the sentinel.
+      // The `stateless` marker scopes DOWNSTREAM state only: the bucket
+      // is the client-facing MCP session and is keyed per-PTY like any
+      // other server's. What the marker buys is everything below — no
+      // file, no audit, nothing to replay.
       const betaH = plugin._getHandler("beta")?.health() as {
         bucket_keys: string[];
         stateless: boolean;
       };
       expect(betaH.stateless).toBe(true);
-      expect(betaH.bucket_keys).toEqual(["__stateless__"]);
+      expect(betaH.bucket_keys).toEqual(["pty-s"]);
 
       // No persistence file for beta.
       expect(existsSync(join(persistRoot, "beta.json"))).toBe(false);

--- a/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
@@ -194,13 +194,40 @@ describe("McpHttpHandler — successful auth + RPC dispatch", () => {
     expect(remaining).not.toContain("suzy");
   });
 
-  it("stateless handler does not have per-PTY buckets", async () => {
+  it("stateless handler keys buckets per PTY and releasePty tears them down", async () => {
     await handler!.stop();
     handler = new McpHttpHandler({ serverName: "test", proc: proc!, stateless: true });
-    // releasePty is a no-op for stateless
+    const a = issueIdentity("suzy");
+
+    await handler.handle(
+      rpcRequest(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "test", version: "1.0" },
+          },
+        },
+        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: a.headers[AUTH_HEADER] },
+      ),
+    );
+
+    const before = handler.health();
+    expect(before.stateless).toBe(true);
+    // The marker does not collapse the key space: a stateless server owns a
+    // bucket per PTY like any other.
+    expect(before.bucket_keys as string[]).toEqual(["suzy"]);
+
+    // And that bucket is genuinely reclaimed on identity teardown. This is
+    // the half of the per-PTY fix that an earlier `if (this.stateless)
+    // return` in `releasePty` would silently skip — leaking the transport
+    // and leaving the next identity for this ptyId to collide with a stale
+    // initialized session.
     await handler.releasePty("suzy");
-    const h = handler.health();
-    expect(h.stateless).toBe(true);
+    expect(handler.health().bucket_keys as string[]).toEqual([]);
   });
 });
 

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -9,10 +9,18 @@
  *
  * Per-PTY isolation:
  *   - Each (server, ptyId) pair gets its own ephemeral SDK `Server` +
- *     transport pair, lazily created on first request.
- *   - For servers in `settings.mcp.stateless`, the (ptyId) dimension is
- *     collapsed — a single `Server` + transport pair is shared across
- *     all PTYs. Per-PTY HMAC verification still gates access.
+ *     transport pair, lazily created on first request. This holds for
+ *     EVERY server, `settings.mcp.stateless` included: a bucket is the
+ *     client-facing MCP session, and an MCP session cannot be shared by
+ *     two clients. The SDK transport rejects a second `initialize` with
+ *     `400 -32600 "Server already initialized"`, which a client reads as
+ *     an unreachable server and drops — so collapsing the (ptyId)
+ *     dimension made a stateless server single-client in practice.
+ *   - `settings.mcp.stateless` therefore scopes DOWNSTREAM state only:
+ *     no session binding is persisted and none is replayed at restart
+ *     (`installResumedBucket` refuses). The upstream child is a single
+ *     shared process for every bucket regardless of the marker, so
+ *     per-PTY buckets add no upstream cost — only the facing transport.
  *   - Identity teardown (`McpMultiplexerPlugin.releaseIdentity(ptyId)`)
  *     calls `releasePty(ptyId)` here to tear down the per-PTY transport.
  *
@@ -30,14 +38,9 @@ import type { McpServerProcess } from "../mcp-proxy/server-process.js";
 import { AUTH_HEADER, PTY_ID_HEADER, PTY_TS_HEADER, verifyBearer } from "./pty-identity.js";
 import type { SessionPersistenceStore } from "./session-persistence.js";
 
-/** Sentinel used when a server is declared stateless: all PTYs collapse
- *  to a single (server, *) bucket so they share one upstream session.
- *  Per-PTY auth verification still happens before any routing. */
-const STATELESS_BUCKET = "__stateless__";
-
 /** Pair of objects making up a live MCP session against this server. */
 interface ServerBucket {
-  /** Owner ptyId or `STATELESS_BUCKET`. */
+  /** Owner ptyId. One bucket per client, stateless servers included. */
   bucketKey: string;
   sdkServer: Server;
   transport: WebStandardStreamableHTTPServerTransport;
@@ -383,7 +386,10 @@ export class McpHttpHandler {
     }
 
     // ── Dispatch to per-(server, pty) bucket ──────────────────────────
-    const bucketKey = this.stateless ? STATELESS_BUCKET : ptyId;
+    // Keyed on ptyId for every server. A `stateless` server used to
+    // collapse to one shared bucket here; that made its SECOND client
+    // fail its `initialize` and drop the server (see the header note).
+    const bucketKey = ptyId;
     let bucket = this.buckets.get(bucketKey);
     const isNewBucket = !bucket;
     if (!bucket) {
@@ -465,16 +471,17 @@ export class McpHttpHandler {
     // (the normal `releaseIdentity` → `issueIdentity` rotation in
     // index.ts), the fresh bearer would otherwise inherit the prior
     // session's timestamps and immediately hit 429s based on traffic
-    // it didn't originate. Cleared unconditionally — stateless handlers
-    // still keyed the window by ptyId (we use `STATELESS_BUCKET` for
-    // the SDK session, but `_checkRateLimit` keys on the actual ptyId).
+    // it didn't originate.
     this._rlWindows.delete(ptyId);
     // Same hygiene for the cost-tracking metrics (issue #68): drop any
     // tuples scoped to this PTY so stale percentiles from the reaped
     // session don't bleed into the next bucket. 5-agent review on
     // PR #cost-metrics flagged this class from PR #91 P2.
     getMetricsRegistry().releasePty(this.serverName, ptyId);
-    if (this.stateless) return; // no per-PTY bucket exists
+    // Stateless servers own a per-PTY bucket like every other server and
+    // must be torn down here too; only their persistence is skipped
+    // (`this.persistence` is undefined for them, so the drop below is a
+    // no-op rather than a special case).
     // Drop the persisted record FIRST so that even if the bucket's
     // already gone (race with transport_error path) the disk state is
     // still cleaned up.

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -53,14 +53,18 @@ export interface McpHttpHandlerOpts {
   serverName: string;
   /** Upstream child to which `tools/call` is proxied. */
   proc: McpServerProcess;
-  /** When `true`, all PTYs share a single upstream MCP session for this
-   *  server. Defaults to `false` (per-PTY isolation). */
+  /** When `true`, this server keeps no session binding on disk and none is
+   *  replayed at restart. It does NOT change client demultiplexing: buckets
+   *  are keyed per-PTY either way, because a bucket is the client-facing MCP
+   *  session and two clients cannot share one. Defaults to `false`. */
   stateless?: boolean;
   /** Optional persistence layer. When provided, `_createBucket` records a
    *  (serverName, ptyId, sessionId) tuple on the SDK transport's
    *  `onsessioninitialized` callback; `releasePty` drops it; bucket
-   *  reuse touches `lastUsedAt`. Stateless buckets are never persisted
-   *  (no per-PTY identity to bind to). When undefined, no on-disk
+   *  reuse touches `lastUsedAt`. Stateless servers are never persisted —
+   *  the operator has declared the upstream carries nothing worth rebinding
+   *  a session id to, so there is nothing to survive a restart. When
+   *  undefined, no on-disk
    *  session-binding state is written — the dispatch path otherwise
    *  honours the issue #68 metrics hook and issue #69 cache hook
    *  (both default-off, opt-in via `settings.mcp.metricsEnabled` /
@@ -219,9 +223,10 @@ export class McpHttpHandler {
     this.serverName = opts.serverName;
     this.proc = opts.proc;
     this.stateless = opts.stateless === true;
-    // Persistence is only meaningful for per-PTY (stateful) buckets — the
-    // stateless bucket has no per-PTY identity to bind to. Even if the
-    // operator wires a store, we skip it for stateless servers.
+    // `stateless` declares the upstream holds nothing worth rebinding a
+    // session id to, so we persist nothing for it even when the operator
+    // wires a store. This is the marker's whole remaining job — it does not
+    // affect how clients are demultiplexed (see the header note).
     this.persistence = this.stateless ? undefined : opts.persistence;
     this._rlMax = opts.rateLimit?.maxRequestsPerWindow ?? 0;
     this._rlWindowMs = opts.rateLimit?.windowMs ?? 60_000;
@@ -391,6 +396,46 @@ export class McpHttpHandler {
     // fail its `initialize` and drop the server (see the header note).
     const bucketKey = ptyId;
     let bucket = this.buckets.get(bucketKey);
+
+    // A bucket can outlive the client that opened it: the supervisor
+    // deliberately keeps the identity across a crash-respawn (`this is a
+    // respawn, not a permanent dispose` — pty-supervisor.ts), so no
+    // `releasePty` runs and the fresh `claude` arrives at a transport the
+    // SDK already marked initialized. Its `initialize` would draw the same
+    // `400 -32600 "Server already initialized"` this file exists to prevent,
+    // just one ptyId at a time instead of one server at a time.
+    //
+    // A pre-session `initialize` — no session id header — can only come from
+    // a client that has no session here, so an already-initialized bucket
+    // under that key belongs to a predecessor. Retire it and build fresh.
+    if (bucket && _peekRpcMethod(probePeek) === "initialize") {
+      if (
+        safeReq.headers.get(SESSION_ID_HEADER) === null &&
+        bucket.transport.sessionId !== undefined
+      ) {
+        this.buckets.delete(bucketKey);
+        const retired = bucket;
+        bucket = undefined;
+        getMcpBridge().audit("multiplexer_bucket_recycled", {
+          server: this.serverName,
+          pty_id: ptyId,
+          reason: "reinitialize_without_session",
+        });
+        // Teardown is best-effort and must not delay the handshake the new
+        // client is waiting on; the map no longer references it either way.
+        void Promise.resolve()
+          .then(async () => {
+            try {
+              await retired.transport.close();
+            } catch {}
+            try {
+              await retired.sdkServer.close();
+            } catch {}
+          })
+          .catch(() => {});
+      }
+    }
+
     const isNewBucket = !bucket;
     if (!bucket) {
       try {
@@ -692,6 +737,7 @@ export class McpHttpHandler {
     const serverName = this.serverName;
     const persistence = this.persistence;
     const stateless = this.stateless;
+    const this_buckets = this.buckets;
 
     const transport = new WebStandardStreamableHTTPServerTransport({
       // SPEC §4.5: replay overrides the UUID generator with the
@@ -719,6 +765,16 @@ export class McpHttpHandler {
       // this catches a PTY-side claude that DELETEs without supervisor
       // teardown (e.g. claude restarted in-place).
       onsessionclosed: (_sessionId: string) => {
+        // The client ended its session (transport DELETE). A bucket IS that
+        // session, so it must not outlive it: the SDK's close() leaves
+        // `_initialized` and `sessionId` set, so a retained bucket would
+        // answer the next client's `initialize` on this ptyId with
+        // `400 -32600 "Server already initialized"`. Guard on transport
+        // identity so a bucket already replaced by the reinitialize path
+        // above is not evicted out from under its successor.
+        if (this_buckets.get(bucketKey)?.transport === transport) {
+          this_buckets.delete(bucketKey);
+        }
         if (!persistence || stateless) return;
         persistence.drop(serverName, bucketKey).catch(() => {});
       },


### PR DESCRIPTION
## The bug

A server listed in `settings.mcp.stateless` collapsed every PTY onto a single shared bucket — one SDK `Server` + transport pair for all clients.

But a bucket is the **client-facing MCP session**, and an MCP session cannot be shared by two clients. The SDK transport answers a second `initialize` with

```
400 {"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request: Server already initialized"},"id":null}
```

(`webStandardStreamableHttp.js`: `if (this._initialized && this.sessionId !== undefined)`)

A client reads a transport-level 400 as "this server is unreachable" and drops it. So the marker meant as a cheap optimisation quietly made those servers **single-client**: whoever initialized first kept them, everyone after got nothing.

## How it surfaced

Right after #349 landed. A dispatched agent job now receives a synthesized `--mcp-config` listing all three shared servers — and only `claudeclaw-plus` surfaced any tools inside the job.

The two that vanished, `gws-gmail` and `perplexity`, were exactly the two marked `stateless`. Their upstream children were alive the whole time (`[mcp-multiplexer] spawned gws-gmail pid 13766 — 11 tools`), and the job's config file listed all three. The split correlated perfectly with the `stateless` list and with nothing else.

## The fix

Delete the special case: `bucketKey` is always `ptyId`.

The upstream child was already a single shared process for every bucket — `stateless` never changed that. So per-PTY buckets add no upstream cost, only the facing transport, which is what every non-stateless server already allocates. The marker keeps a coherent, narrower meaning: no session binding persisted, none replayed at restart (`installResumedBucket` still refuses).

`releasePty` loses its `if (this.stateless) return` early exit, which would now leak the per-PTY bucket it no longer knew existed. Persistence is already `undefined` for stateless handlers, so the drop below it is a no-op rather than a special case.

## Why no test caught it

The existing demux test asserted the collapse property, and routed the second PTY through a raw `tools/list` instead of a real client — commenting that "re-initialising a shared SDK Server would (correctly) be rejected, which is the whole point of the stateless mode", and accepting a 400 as proof the request "reached the bucket".

It encoded the limitation as the intent. No test ever asked whether a second client could actually *use* a stateless server.

The replacement drives two real MCP clients through their own `initialize`, then `listTools` and `callTool` on both. Against the old code it fails with the exact production error; against this branch it passes.

## Verification

- New test `stateless server serves concurrent clients` — fails on the pre-fix commit with `-32600 Server already initialized`, passes here.
- `mcp-multiplexer-integration.test.ts` + `session-persistence-integration.test.ts`: **15 pass / 0 fail**.
- Full suite: failure set is **byte-identical to `main`** (85 pre-existing failures before and after — no new break, none masked).
- Typecheck ratchet: **153 errors, baseline 153** — unchanged.

One pre-existing order-dependent flake (`runtime GC > GC tick drops on-disk expired entries`) shows up in some file orderings on `main` as well as here; unrelated to this change.

## Docs

The README described `stateless` as "one upstream session shared across all PTYs". The upstream session was always shared, marker or not — corrected to say what the marker actually scopes.

---

## Adversarial pass — what it changed, and what it left open

Four independent reviewers were pointed at this branch with instructions to refute it. The core claim held (two clients genuinely cannot share one MCP session, and the collapse was the only thing routing PTY-2's `initialize` onto PTY-1's transport). Three things did not, and are fixed in the follow-up commit:

**The invariant this PR asserts was not actually true yet.** Per-PTY keying stopped one client from bricking *another* client's server; it did not stop a client from bricking its *own successor*, with the identical 400. A bucket outlived its client on crash-respawn (the supervisor keeps the identity by design, so no `releasePty` runs) and on a clean session end (`onsessionclosed` dropped the persisted record but not the bucket, despite its comment saying it exists for exactly that case). Both predate this branch and neither is a regression — pre-fix, stateless servers failed harder and earlier. But the header this PR adds says "a bucket is the client-facing MCP session", and that was false while a bucket could outlive its session. It is true now.

**Half the fix was defended by nothing.** Restoring `releasePty`'s old `if (this.stateless) return;` early exit passed all 163 multiplexer tests. There is now a test that fails on exactly that mutation.

**The keying was only proven for N=2.** A mutation keying the first two PTYs apart and collapsing the third onward also passed everything. Now four.

Each new test was mutation-checked individually: it fails on its own guard and on nothing else.

### Known, not addressed here

- **A bucket can be orphaned by a race.** `handle()` yields (body read) between the auth check and `buckets.set`. A `releasePty` landing in that window deletes nothing and the in-flight request then inserts a bucket after its own teardown — measured at ~7 microtask turns wide. For a long-lived ptyId the orphan is simply recycled by the next request under the same key. For dispatched agent jobs, which key on a fresh `agent-job-<uuid>` per run, the key never recurs, so it is a permanent orphan (~21 KB) on every race hit. Pre-existing on the stateful path, but this branch makes it reachable for stateless servers too. Nothing sweeps in-memory buckets: `lastUsed` is written on every dispatch and never read, and the GC tick returns early when there is no persistence store — which is precisely the stateless case. Worth its own change (sweep `buckets` by `lastUsed`, and/or re-check the identity is still issued immediately before `buckets.set`); calling it out rather than folding an unrelated lifecycle fix into this one.
- **`releasePty` during an in-flight request wedges that request.** Closing the transport mid-`handleRequest` leaves the promise unsettled — a hang, not a throw, so the `catch` never runs. Pre-existing; same fix area as above.
- **Metrics keying moved.** `record()` now gets a per-PTY key for stateless servers instead of `"__stateless__"`. That *fixes* a pre-existing leak — the old code keyed on the sentinel while `releasePty` pruned by `server::ptyId::`, so a stateless server's tuples were never reclaimable — but it also means tuple count now scales with live PTYs rather than being pinned at one. Default-off (`metricsEnabled`).
- **`stateless` is now a narrow marker.** After this change it does three things: skips persistence, refuses resume, sets an audit field. True SDK stateless mode (`sessionIdGenerator: undefined`) would make the marker mean what the README used to claim and would moot the reconnect handling entirely — at the cost of a fresh `Server` + transport per HTTP request, since the SDK forbids reusing a stateless transport, and of the server→client SSE stream. That looks like the wrong trade here, but it is a real option and worth naming rather than leaving the marker hollow.

### Pre-existing flake, not from this branch

`session-persistence-integration.test.ts` → *"GC tick drops on-disk expired entries while leaving live in-memory buckets intact"* fails in roughly 20-40% of runs depending on file ordering, on `main` as well as here. It uses only the stateful `alpha` server, so it cannot be affected by this change.
