### PR TITLE
fix(mcp-multiplexer): stop orphaning a bucket released mid-request

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.224",
+      "version": "2.2.225",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.225",
+      "version": "2.2.226",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.225",
+  "version": "2.2.226",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.224",
+  "version": "2.2.225",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/mcp-multiplexer-integration.test.ts
+++ b/src/__tests__/mcp-multiplexer-integration.test.ts
@@ -32,6 +32,7 @@ import { McpMultiplexerPlugin, _resetMcpMultiplexer } from "../plugins/mcp-multi
 import { _resetHttpGateway, getHttpGateway } from "../plugins/http-gateway.js";
 import { _resetMcpBridge, getMcpBridge } from "../plugins/mcp-bridge.js";
 import { _resetIdentityStore, revokeIdentity } from "../plugins/mcp-multiplexer/pty-identity.js";
+import type { SessionPersistenceStore } from "../plugins/mcp-multiplexer/session-persistence.js";
 import { makeMuxSettingsView } from "./fixtures/mux-settings-view.js";
 
 const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
@@ -721,9 +722,12 @@ describe("mcp-multiplexer integration — GC tick reclaims orphaned buckets", ()
       settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["beta"],
-        // Stateless → the handler's persistence store is undefined. That used
-        // to mean no GC tick at all, so these were exactly the handlers with
-        // nothing reclaiming their buckets.
+        // `stateless` here only makes the handler's own store undefined —
+        // it is NOT what used to disable the tick. The old early return was
+        // gated on the PLUGIN's store, which this fixture leaves off by
+        // default (`sessionPersistenceEnabled: false`). Two different stores;
+        // keeping them straight matters, because the tick this test asserts
+        // is armed for the whole plugin, not per handler.
         stateless: ["beta"],
       }),
       gcTickMs: 0, // drive it by hand
@@ -757,7 +761,7 @@ describe("mcp-multiplexer integration — GC tick reclaims orphaned buckets", ()
 });
 
 describe("mcp-multiplexer integration — the sweep and the replay path coexist", () => {
-  it("leaves a replay-installed bucket alone", async () => {
+  it("leaves a replay-installed bucket alone while its binding is still live", async () => {
     const cfg = writeProxyConfig(tmpDir, ["alpha"]);
     plugin = new McpMultiplexerPlugin({
       configPath: cfg,
@@ -776,6 +780,116 @@ describe("mcp-multiplexer integration — the sweep and the replay path coexist"
 
     expect(await handler?.sweepOrphanedBuckets()).toBe(0);
     expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual(["pty-resumed"]);
+  });
+
+  it("survives the race when driven through the REAL releaseIdentity", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+    // Persistence wired ON PURPOSE. `releasePty` yields on
+    // `await this.persistence.drop(...)`, and that await is what turns a
+    // revoke-ordering mistake into a real window: with no store the whole
+    // teardown runs in one microtask turn and the ordering cannot be
+    // observed, so a test without persistence passes either way and pins
+    // nothing. In-memory stand-in — this test has no business touching disk.
+    const store = {
+      record: async () => {},
+      touch: async () => {},
+      loadAll: async () => [],
+      garbageCollect: async () => ({ scanned: 0, kept: 0, dropped: 0 }),
+      drop: async () => {},
+    };
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      settingsView: makeMuxSettingsView({
+        webEnabled: true,
+        shared: ["alpha"],
+        sessionPersistenceEnabled: true,
+        sessionPersistencePath: join(tmpDir, "sessions"),
+      }),
+      persistenceFactory: () => store as unknown as SessionPersistenceStore,
+      gcTickMs: 0,
+    });
+    await plugin.start();
+
+    const handler = plugin._getHandler("alpha");
+    const ident = plugin.issueIdentity("agent-job-race");
+
+    // The unit test for this guard hand-simulates teardown as
+    // `revokeIdentity()` then `releasePty()`. That bakes the production
+    // ordering into the FIXTURE, so swapping those two lines in
+    // `releaseIdentity` — which is what actually has to stay true — breaks
+    // nothing. Drive the real method instead: the guard only works because
+    // the identity is revoked BEFORE the teardown it announces, and this is
+    // the test that says so.
+    const inFlight = handler?.handle(
+      new Request("http://127.0.0.1:4632/mcp/alpha", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "X-Claudeclaw-Pty-Id": "agent-job-race",
+          Authorization: ident.headers.Authorization,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "test", version: "1.0" },
+          },
+        }),
+      }),
+    );
+
+    // Mid-window — past the pre-auth turns, before the transport serves.
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+    await plugin.releaseIdentity("agent-job-race");
+
+    const resp = await inFlight;
+    expect(resp).toBeDefined();
+    expect(resp!.status).toBe(401);
+    expect((await resp!.json()).error.code).toBe("pty_released");
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual([]);
+  });
+
+  it("reaps a replay-installed bucket once its grace has run out", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: ["alpha"] }),
+      gcTickMs: 0,
+    });
+    await plugin.start();
+
+    const handler = plugin._getHandler("alpha");
+    await handler?.installResumedBucket(
+      "pty-never-returns",
+      "66666666-7777-8888-9999-aaaaaaaaaaaa",
+    );
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual([
+      "pty-never-returns",
+    ]);
+
+    // The counterpart to the test above, and the one that matters more.
+    // `resumed` is cleared on the authenticated-request path and nowhere
+    // else, so a PTY that never reconnects never clears it. Exempting such a
+    // bucket unconditionally would outlive even the on-disk record it exists
+    // to protect — a permanent orphan produced by the guard against orphans.
+    //
+    // Age the bucket past the grace rather than waiting an hour: `lastUsed`
+    // is the install time until a request claims the bucket, and the grace is
+    // measured from it.
+    const aged = (handler as unknown as { buckets: Map<string, { lastUsed: number }> }).buckets.get(
+      "pty-never-returns",
+    );
+    expect(aged).toBeDefined();
+    aged!.lastUsed = Date.now() - (60 * 60 * 1000 + 1000);
+
+    expect(await handler?.sweepOrphanedBuckets()).toBe(1);
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual([]);
+    // Idempotent: nothing left to reclaim on a second pass.
+    expect(await handler?.sweepOrphanedBuckets()).toBe(0);
   });
 
   it("reclaims that same bucket once its PTY has come and gone", async () => {

--- a/src/__tests__/mcp-multiplexer-integration.test.ts
+++ b/src/__tests__/mcp-multiplexer-integration.test.ts
@@ -31,7 +31,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { McpMultiplexerPlugin, _resetMcpMultiplexer } from "../plugins/mcp-multiplexer/index.js";
 import { _resetHttpGateway, getHttpGateway } from "../plugins/http-gateway.js";
 import { _resetMcpBridge, getMcpBridge } from "../plugins/mcp-bridge.js";
-import { _resetIdentityStore } from "../plugins/mcp-multiplexer/pty-identity.js";
+import { _resetIdentityStore, revokeIdentity } from "../plugins/mcp-multiplexer/pty-identity.js";
 import { makeMuxSettingsView } from "./fixtures/mux-settings-view.js";
 
 const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
@@ -707,6 +707,49 @@ describe("mcp-multiplexer integration — stateless server serves concurrent cli
     // Restoring `releasePty`'s old `if (this.stateless) return` early exit
     // passes every other test in this repo; this is the one that catches it.
     await plugin.releaseIdentity("pty-x");
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual([]);
+
+    await conn.close();
+  });
+});
+
+describe("mcp-multiplexer integration — GC tick reclaims orphaned buckets", () => {
+  it("sweeps a bucket whose identity is gone, on a handler with no persistence", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["beta"]);
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      settingsView: makeMuxSettingsView({
+        webEnabled: true,
+        shared: ["beta"],
+        // Stateless → the handler's persistence store is undefined. That used
+        // to mean no GC tick at all, so these were exactly the handlers with
+        // nothing reclaiming their buckets.
+        stateless: ["beta"],
+      }),
+      gcTickMs: 0, // drive it by hand
+    });
+    await plugin.start();
+    gateway = startTestGateway();
+
+    const ident = plugin.issueIdentity("job-9");
+    const conn = await connectClient({
+      origin: gateway.origin,
+      server: "beta",
+      ptyId: "job-9",
+      bearer: ident.headers.Authorization,
+    });
+    await conn.client.listTools();
+
+    const handler = plugin._getHandler("beta");
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual(["job-9"]);
+
+    // The orphan state: identity revoked, bucket still in the map. This is
+    // what the mid-request release race leaves behind, and a dispatched
+    // job's ptyId never recurs, so nothing would ever pick it up again.
+    revokeIdentity("job-9");
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual(["job-9"]);
+
+    await plugin._runGCTickForTests();
     expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual([]);
 
     await conn.close();

--- a/src/__tests__/mcp-multiplexer-integration.test.ts
+++ b/src/__tests__/mcp-multiplexer-integration.test.ts
@@ -756,6 +756,79 @@ describe("mcp-multiplexer integration — GC tick reclaims orphaned buckets", ()
   });
 });
 
+describe("mcp-multiplexer integration — the sweep and the replay path coexist", () => {
+  it("leaves a replay-installed bucket alone", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: ["alpha"] }),
+      gcTickMs: 0,
+    });
+    await plugin.start();
+
+    // Restart replay installs a bucket for a ptyId that has NO identity — the
+    // identity store is in-memory and the restart is what wiped it. That is
+    // indistinguishable from "this PTY was released" unless the bucket says
+    // so, and reaping it would destroy the binding replay exists to preserve.
+    const handler = plugin._getHandler("alpha");
+    await handler?.installResumedBucket("pty-resumed", "11111111-2222-3333-4444-555555555555");
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual(["pty-resumed"]);
+
+    expect(await handler?.sweepOrphanedBuckets()).toBe(0);
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual(["pty-resumed"]);
+  });
+
+  it("reclaims that same bucket once its PTY has come and gone", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: ["alpha"] }),
+      gcTickMs: 0,
+    });
+    await plugin.start();
+    gateway = startTestGateway();
+
+    const handler = plugin._getHandler("alpha");
+    await handler?.installResumedBucket("pty-back", "11111111-2222-3333-4444-666666666666");
+
+    // The PTY reconnects: the supervisor issues an identity and a request
+    // authenticates. The bucket is claimed — no longer replayed state waiting
+    // for an owner — so ordinary orphan rules apply to it again.
+    const ident = plugin.issueIdentity("pty-back");
+    const conn = await connectClient({
+      origin: gateway.origin,
+      server: "alpha",
+      ptyId: "pty-back",
+      bearer: ident.headers.Authorization,
+    });
+    await conn.client.listTools();
+    await conn.close();
+
+    revokeIdentity("pty-back");
+    expect(await handler?.sweepOrphanedBuckets()).toBe(1);
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual([]);
+  });
+
+  it("arms the GC tick even with session persistence turned off", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      // Persistence off — the documented kill switch. The bucket sweep has
+      // nothing to do with on-disk session records, so it must still run.
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: ["alpha"] }),
+      gcTickMs: 60_000,
+    });
+    await plugin.start();
+
+    // Reaching the private timer is the only way to assert the tick was ARMED
+    // rather than merely runnable by hand: every other test drives
+    // `_runGCTickForTests`, which bypasses `_startGCTick` entirely — which is
+    // how a gate that skipped arming it went unnoticed.
+    const timer = (plugin as unknown as { gcTimer: unknown }).gcTimer;
+    expect(timer).not.toBeNull();
+  });
+});
+
 // ── 5) Bridge callback integration ──────────────────────────────────────────
 
 describe("mcp-multiplexer integration — bridge callback path", () => {

--- a/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
@@ -10,7 +10,7 @@ import {
   PTY_ID_HEADER,
   PTY_TS_HEADER,
 } from "../pty-identity.js";
-import { _resetMcpBridge, _setMcpBridge } from "../../mcp-bridge.js";
+import { _resetMcpBridge, _setMcpBridge, getMcpBridge } from "../../mcp-bridge.js";
 
 const MOCK_SERVER = fileURLToPath(
   new URL("../../../__tests__/fixtures/mock-mcp-server.ts", import.meta.url),
@@ -918,11 +918,77 @@ describe("McpHttpHandler — a bucket orphaned by a mid-request release", () => 
 
     // The request loses — correctly. Its PTY is gone.
     expect(resp.status).toBe(401);
+    // Assert the REASON, not just the status. 401 is reachable three ways on
+    // this path, and the pre-auth one (`invalid_bearer`, turns 0-1) satisfies
+    // both of the other assertions here while proving nothing: no bucket was
+    // ever built, so of course none was stranded. Pin `pty_released` and the
+    // test can no longer drift into that window silently — add an `await`
+    // upstream of the auth check and this fails loudly with the wrong code,
+    // which is the signal to retune the turn count above.
+    expect((await resp.json()).error.code).toBe("pty_released");
     // And crucially it did not resurrect the bucket. Before the guard, the
     // `delete` above found nothing (the key was not in the map yet) and
     // this insert landed afterwards, stranding a bucket under a ptyId that
     // — being a one-shot job key — no request would ever look up again.
     expect(handler!.health().bucket_keys as string[]).toEqual([]);
+  });
+
+  it("is not inserted when the key was revoked and RE-ISSUED mid-request", async () => {
+    const dead = issueIdentity("job-3");
+
+    const inFlight = handler!.handle(initialize("job-3", dead.headers[AUTH_HEADER]!));
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+
+    // Teardown, then a NEW identity minted under the same key before the
+    // in-flight request resumes. This is not hypothetical: the bus session
+    // manager revokes fire-and-forget and re-issues under the same agent id
+    // on its collision-retry and respawn paths, so both halves land inside
+    // one request's window.
+    revokeIdentity("job-3");
+    await handler!.releasePty("job-3");
+    issueIdentity("job-3");
+
+    const resp = await inFlight;
+
+    // Asking "does SOME identity exist for this key" answers yes here and
+    // lets the dead PTY's request install a bucket under the live key —
+    // initialized with a session id only the dead client holds. Asking
+    // "does the identity honour THIS bearer" is the question that matters.
+    expect(resp.status).toBe(401);
+    expect((await resp.json()).error.code).toBe("pty_released");
+    expect(handler!.health().bucket_keys as string[]).toEqual([]);
+  });
+
+  it("bounds the swept-bucket audit's ptyId list and counts what it omits", async () => {
+    // 25 orphans, cap is 20. An audit line that names every reclaimed key
+    // grows with the number of PTYs the daemon has ever seen; an unbounded
+    // audit payload was a blocking finding on the sibling PR.
+    const audits: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    const bridge = getMcpBridge();
+    const origAudit = bridge.audit.bind(bridge);
+    bridge.audit = (event, payload) => {
+      audits.push({ event, payload });
+    };
+    try {
+      for (let i = 0; i < 25; i++) {
+        const id = issueIdentity(`job-mass-${i}`);
+        await handler!.handle(initialize(`job-mass-${i}`, id.headers[AUTH_HEADER]!));
+        revokeIdentity(`job-mass-${i}`);
+      }
+
+      expect(await handler!.sweepOrphanedBuckets()).toBe(25);
+
+      const swept = audits.find((a) => a.event === "multiplexer_buckets_swept");
+      expect(swept).toBeDefined();
+      // The COUNT stays exact — that is the number an operator acts on.
+      expect(swept!.payload.reclaimed).toBe(25);
+      // The NAMES are a capped sample, and the shortfall is stated rather
+      // than left for the reader to infer from a short array.
+      expect((swept!.payload.pty_ids as string[]).length).toBe(20);
+      expect(swept!.payload.pty_ids_omitted).toBe(5);
+    } finally {
+      bridge.audit = origAudit;
+    }
   });
 
   it("is reclaimed by the sweep when it slips through anyway", async () => {
@@ -938,10 +1004,24 @@ describe("McpHttpHandler — a bucket orphaned by a mid-request release", () => 
     // reaches `releasePty` without going through `releaseIdentity` leaves.
     revokeIdentity("job-2");
 
+    // Seed the rate-limit windows directly. The test handler runs with the
+    // limiter disabled (`_rlMax <= 0`), so `handle()` never creates an entry
+    // and asserting on an empty map would pass no matter what the sweep did.
+    const windows = (handler as unknown as { _rlWindows: Map<string, number[]> })._rlWindows;
+    windows.set("job-2", [Date.now()]);
+    windows.set("pty-live", [Date.now()]);
+
     expect(await handler!.sweepOrphanedBuckets()).toBe(1);
     // The live PTY is untouched — the sweep keys on identity, not on idle
     // time, so a healthy session that simply went quiet is never reaped.
     expect(handler!.health().bucket_keys as string[]).toEqual(["pty-live"]);
+
+    // The bucket is not the only thing keyed by ptyId. `releasePty` clears
+    // the rate-limit window too, and the sweep has to be symmetric with it:
+    // reclaiming 21 KB of bucket while leaving a window entry per one-shot
+    // `agent-job-<uuid>` moves the unbounded growth instead of stopping it.
+    expect(windows.has("job-2")).toBe(false);
+    expect(windows.has("pty-live")).toBe(true);
 
     // Idempotent: a second pass finds nothing left to do.
     expect(await handler!.sweepOrphanedBuckets()).toBe(0);

--- a/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
@@ -856,3 +856,94 @@ describe("McpHttpHandler — session-less discovery probe", () => {
     expect(body).not.toContain("-32601");
   });
 });
+
+// ── Orphaned buckets (issue #355) ───────────────────────────────────────────
+
+describe("McpHttpHandler — a bucket orphaned by a mid-request release", () => {
+  let proc: McpServerProcess | null = null;
+  let handler: McpHttpHandler | null = null;
+
+  beforeEach(async () => {
+    _resetIdentityStore();
+    _resetMcpBridge();
+    proc = new McpServerProcess("test", makeServerConfig());
+    await proc.start();
+    handler = new McpHttpHandler({ serverName: "test", proc, stateless: true });
+  });
+
+  afterEach(async () => {
+    await handler?.stop();
+    await proc?.stop();
+    _resetIdentityStore();
+    _resetMcpBridge();
+  });
+
+  function initialize(ptyId: string, bearer: string): Request {
+    return rpcRequest(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0" },
+        },
+      },
+      { [PTY_ID_HEADER]: ptyId, [AUTH_HEADER]: bearer },
+    );
+  }
+
+  it("is not inserted after its own teardown", async () => {
+    const ident = issueIdentity("job-1");
+
+    // Start the request but do NOT await it. `handle()` yields on the body
+    // cap read, then authenticates, then yields again on the audit peek and
+    // on the bucket build before `buckets.set` runs.
+    const inFlight = handler!.handle(initialize("job-1", ident.headers[AUTH_HEADER]!));
+
+    // Land the teardown INSIDE that window. Measured against this handler
+    // with the guard removed, the window is microtask turns 2-6: turns 0-1
+    // are still pre-auth (the request just 401s, nothing is built), and
+    // from turn 7 the transport is already serving the request. Four sits
+    // in the middle.
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+
+    // Production order: `releaseIdentity` revokes the identity first, then
+    // tears down the handlers.
+    revokeIdentity("job-1");
+    await handler!.releasePty("job-1");
+
+    const resp = await inFlight;
+
+    // The request loses — correctly. Its PTY is gone.
+    expect(resp.status).toBe(401);
+    // And crucially it did not resurrect the bucket. Before the guard, the
+    // `delete` above found nothing (the key was not in the map yet) and
+    // this insert landed afterwards, stranding a bucket under a ptyId that
+    // — being a one-shot job key — no request would ever look up again.
+    expect(handler!.health().bucket_keys as string[]).toEqual([]);
+  });
+
+  it("is reclaimed by the sweep when it slips through anyway", async () => {
+    const live = issueIdentity("pty-live");
+    const doomed = issueIdentity("job-2");
+
+    await handler!.handle(initialize("pty-live", live.headers[AUTH_HEADER]!));
+    await handler!.handle(initialize("job-2", doomed.headers[AUTH_HEADER]!));
+    expect((handler!.health().bucket_keys as string[]).sort()).toEqual(["job-2", "pty-live"]);
+
+    // Simulate the orphan directly: identity gone, bucket still in the map.
+    // This is the state the race produces, and also what any caller that
+    // reaches `releasePty` without going through `releaseIdentity` leaves.
+    revokeIdentity("job-2");
+
+    expect(await handler!.sweepOrphanedBuckets()).toBe(1);
+    // The live PTY is untouched — the sweep keys on identity, not on idle
+    // time, so a healthy session that simply went quiet is never reaped.
+    expect(handler!.health().bucket_keys as string[]).toEqual(["pty-live"]);
+
+    // Idempotent: a second pass finds nothing left to do.
+    expect(await handler!.sweepOrphanedBuckets()).toBe(0);
+  });
+});

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -122,6 +122,16 @@ const SESSION_ID_HEADER = "mcp-session-id";
  */
 const PEEK_MAX_BYTES = 4096;
 
+/** Fallback grace for a replayed bucket when no persistence store is wired.
+ *  Matches `session-persistence.ts`'s own `DEFAULT_MAX_AGE_MS` so the two
+ *  clocks agree; it is a floor against an unbounded exemption, not a tuning
+ *  knob. */
+const DEFAULT_RESUMED_GRACE_MS = 60 * 60 * 1000; // 1 hour
+
+/** How many reclaimed ptyIds the sweep's audit line names before it starts
+ *  counting instead. The count is always exact; only the sample is capped. */
+const AUDIT_PTY_ID_SAMPLE = 20;
+
 /**
  * Helper: read JSON body for the audit-log peek. The SDK transport
  * reparses the body itself from the original Request — this helper
@@ -476,10 +486,21 @@ export class McpHttpHandler {
       // it, or reap it again.
       //
       // `releaseIdentity` revokes the identity BEFORE it calls
-      // `releasePty`, so a vanished identity is the signal that teardown
-      // started while we were awaiting. Drop the bucket we just built and
-      // answer the way any post-teardown request is answered.
-      if (getIdentity(ptyId) === undefined) {
+      // `releasePty`, so an identity that no longer honours THIS request's
+      // bearer is the signal that teardown started while we were awaiting.
+      //
+      // Re-run `verifyBearer` rather than asking whether SOME identity
+      // exists under this key. Existence is the weaker question and it
+      // answers wrong on the sequence this repo actually performs: the bus
+      // session manager revokes fire-and-forget and re-issues under the SAME
+      // agent id on the collision-retry and respawn paths
+      // (`session-manager.ts`), so `getIdentity(ptyId)` is defined again by
+      // the time we look — while the bearer in our hands belongs to the PTY
+      // that just died. That request would install its bucket under the live
+      // key and initialize it with a session id only the dead client holds.
+      // `verifyBearer` subsumes the existence check (a revoked identity
+      // fails it) and rejects the re-issue case too.
+      if (!verifyBearer(ptyId, bearer)) {
         getMcpBridge().audit("multiplexer_bucket_release_raced", {
           server: this.serverName,
           pty_id: ptyId,
@@ -613,6 +634,16 @@ export class McpHttpHandler {
    * Returns the number of buckets reclaimed. Never throws: a close that
    * fails still leaves the map entry gone, which is the part that matters.
    */
+  /** How long a replayed-but-unclaimed bucket is exempt from the sweep.
+   *  Mirrors the persistence TTL so the exemption cannot outlive the record
+   *  it protects. Falls back to the store's own default when no store is
+   *  wired — a resumed bucket cannot exist without one today
+   *  (`installResumedBucket` refuses stateless handlers), but the fallback
+   *  keeps the bound finite if that ever changes. */
+  private _resumedGraceMs(): number {
+    return this.persistence?.maxAge ?? DEFAULT_RESUMED_GRACE_MS;
+  }
+
   async sweepOrphanedBuckets(): Promise<number> {
     const orphans: ServerBucket[] = [];
     for (const [key, bucket] of this.buckets) {
@@ -620,27 +651,60 @@ export class McpHttpHandler {
       // reconnects — the identity store does not survive the restart that
       // made replay necessary. Reaping it would throw away the session
       // binding the whole replay path exists to keep.
-      if (bucket.resumed) continue;
+      //
+      // But the grace EXPIRES, and it has to. `resumed` is cleared in
+      // exactly one place — the authenticated-request path — so a PTY that
+      // never comes back never clears it. An unconditional `continue` would
+      // hand a replayed `agent-job-<uuid>` bucket permanent immunity: the
+      // persistence layer's own TTL eventually deletes its record from disk,
+      // and the ~21 KB of in-memory bucket would survive every tick after
+      // that. That is the exact permanent orphan this sweep exists to
+      // reclaim, re-created by the guard meant to protect replay.
+      //
+      // So the grace runs on the SAME clock as the record it protects: once
+      // the binding is old enough that `garbageCollect()` would drop it from
+      // disk, there is nothing left to preserve and the bucket is reapable.
+      // `lastUsed` is the install time until a request claims the bucket.
+      if (bucket.resumed && Date.now() - bucket.lastUsed <= this._resumedGraceMs()) continue;
       if (getIdentity(key) === undefined) {
         this.buckets.delete(key);
+        // Same per-PTY state `releasePty` clears. A bucket is not the only
+        // thing keyed by ptyId: the rate-limit window and the metrics tuples
+        // are too, and under one-shot `agent-job-<uuid>` keys they grow
+        // without bound exactly like the bucket did. Reclaiming the bucket
+        // and leaving those behind would move the leak rather than close it.
+        this._rlWindows.delete(key);
+        getMetricsRegistry().releasePty(this.serverName, key);
         orphans.push(bucket);
       }
     }
     if (orphans.length === 0) return 0;
     // Symmetric with `releasePty`: a key whose identity is gone must not have
-    // its binding replayed at the next start either. Without this the daemon
-    // loops — restart, replay, sweep at the next tick, restart — replaying a
-    // record for a PTY that will never come back. Best-effort; the map entry
-    // is already gone, which is the part that bounds memory.
+    // its binding replayed at the next start either. The record's own TTL
+    // would eventually retire it — `loadAll` drops expired entries — but that
+    // leaves a window where a restart replays a binding this sweep has
+    // already decided is dead, reinstalling the bucket it just reclaimed.
+    // Dropping here closes that window instead of waiting for the TTL to
+    // agree. Best-effort; the map entry is already gone, which is the part
+    // that bounds memory.
     if (this.persistence) {
       for (const b of orphans) {
         this.persistence.drop(this.serverName, b.bucketKey).catch(() => {});
       }
     }
+    // `reclaimed` is the count and is always exact; `pty_ids` is a sample.
+    // One sweep can reclaim as many buckets as the daemon has seen PTYs, and
+    // an audit line that grows with that is the unbounded-payload defect this
+    // series already had to fix once. Cap the names, and say how many were
+    // left out so the number is never silently wrong.
+    const sampled = orphans.slice(0, AUDIT_PTY_ID_SAMPLE);
     getMcpBridge().audit("multiplexer_buckets_swept", {
       server: this.serverName,
       reclaimed: orphans.length,
-      pty_ids: orphans.map((b) => b.bucketKey),
+      pty_ids: sampled.map((b) => b.bucketKey),
+      ...(orphans.length > sampled.length
+        ? { pty_ids_omitted: orphans.length - sampled.length }
+        : {}),
     });
     await Promise.allSettled(
       orphans.map(async (b) => {

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -35,7 +35,13 @@ import { getMcpBridge } from "../mcp-bridge.js";
 import { getMetricsRegistry } from "./metrics.js";
 import { getResponseCache } from "./cache.js";
 import type { McpServerProcess } from "../mcp-proxy/server-process.js";
-import { AUTH_HEADER, PTY_ID_HEADER, PTY_TS_HEADER, verifyBearer } from "./pty-identity.js";
+import {
+  AUTH_HEADER,
+  getIdentity,
+  PTY_ID_HEADER,
+  PTY_TS_HEADER,
+  verifyBearer,
+} from "./pty-identity.js";
 import type { SessionPersistenceStore } from "./session-persistence.js";
 
 /** Pair of objects making up a live MCP session against this server. */
@@ -438,9 +444,9 @@ export class McpHttpHandler {
 
     const isNewBucket = !bucket;
     if (!bucket) {
+      let fresh: ServerBucket;
       try {
-        bucket = await this._createBucket(bucketKey);
-        this.buckets.set(bucketKey, bucket);
+        fresh = await this._createBucket(bucketKey);
       } catch (err) {
         return _errResponse(
           500,
@@ -448,6 +454,33 @@ export class McpHttpHandler {
           err instanceof Error ? err.message : String(err),
         );
       }
+      // Everything between the auth check and this line yields — the body
+      // cap read, the audit peek, the bucket build. A `releasePty` landing
+      // in that window deletes by key and finds nothing, because the key
+      // is not in the map yet. Inserting now would resurrect the PTY we
+      // just tore down, and for a dispatched job — whose ptyId is a
+      // one-shot `agent-job-<uuid>` — nothing would ever look it up, hold
+      // it, or reap it again.
+      //
+      // `releaseIdentity` revokes the identity BEFORE it calls
+      // `releasePty`, so a vanished identity is the signal that teardown
+      // started while we were awaiting. Drop the bucket we just built and
+      // answer the way any post-teardown request is answered.
+      if (getIdentity(ptyId) === undefined) {
+        getMcpBridge().audit("multiplexer_bucket_release_raced", {
+          server: this.serverName,
+          pty_id: ptyId,
+        });
+        try {
+          await fresh.transport.close();
+        } catch {}
+        try {
+          await fresh.sdkServer.close();
+        } catch {}
+        return _errResponse(401, "pty_released", `pty ${ptyId} was released mid-request`);
+      }
+      bucket = fresh;
+      this.buckets.set(bucketKey, bucket);
     }
     bucket.lastUsed = Date.now();
     // Touch the persisted record on bucket reuse so the GC sweep keeps
@@ -542,6 +575,53 @@ export class McpHttpHandler {
     try {
       await bucket.sdkServer.close();
     } catch {}
+  }
+
+  /**
+   * Reclaim buckets whose PTY no longer has an issued identity.
+   *
+   * A bucket can survive its `releasePty` — see the race guarded in
+   * `handle()`, and any future caller that reaches `releasePty` without
+   * going through `releaseIdentity`. For a long-lived ptyId that is merely
+   * untidy: the next request under the same key adopts the orphan. For a
+   * dispatched agent job it is permanent, because the ptyId is a one-shot
+   * `agent-job-<uuid>` that never recurs — so the orphan is never looked
+   * up, never released, and (before this sweep) never reaped.
+   *
+   * Keyed on identity rather than on an idle TTL deliberately: a bucket
+   * whose identity is gone is PROVABLY dead — no caller can ever
+   * authenticate to it again — whereas an idle bucket may belong to a
+   * healthy long-lived PTY that simply went quiet, and reaping it would
+   * force a pointless re-handshake.
+   *
+   * Returns the number of buckets reclaimed. Never throws: a close that
+   * fails still leaves the map entry gone, which is the part that matters.
+   */
+  async sweepOrphanedBuckets(): Promise<number> {
+    const orphans: ServerBucket[] = [];
+    for (const [key, bucket] of this.buckets) {
+      if (getIdentity(key) === undefined) {
+        this.buckets.delete(key);
+        orphans.push(bucket);
+      }
+    }
+    if (orphans.length === 0) return 0;
+    getMcpBridge().audit("multiplexer_buckets_swept", {
+      server: this.serverName,
+      reclaimed: orphans.length,
+      pty_ids: orphans.map((b) => b.bucketKey),
+    });
+    await Promise.allSettled(
+      orphans.map(async (b) => {
+        try {
+          await b.transport.close();
+        } catch {}
+        try {
+          await b.sdkServer.close();
+        } catch {}
+      }),
+    );
+    return orphans.length;
   }
 
   /** Tear down every bucket and refuse further requests.

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -52,6 +52,17 @@ interface ServerBucket {
   transport: WebStandardStreamableHTTPServerTransport;
   /** Last-touched timestamp, for diagnostics. */
   lastUsed: number;
+  /**
+   * Installed by restart replay and not yet claimed by a request.
+   *
+   * The identity store is in-memory, so a restart wipes it: a replayed bucket
+   * has NO identity until its PTY reconnects and the supervisor issues one.
+   * That is indistinguishable, to `sweepOrphanedBuckets`, from a bucket whose
+   * PTY was released — so without this flag the sweep destroys exactly the
+   * session bindings replay exists to preserve. Cleared on the first
+   * authenticated request for the key.
+   */
+  resumed?: boolean;
 }
 
 export interface McpHttpHandlerOpts {
@@ -454,10 +465,12 @@ export class McpHttpHandler {
           err instanceof Error ? err.message : String(err),
         );
       }
-      // Everything between the auth check and this line yields — the body
-      // cap read, the audit peek, the bucket build. A `releasePty` landing
-      // in that window deletes by key and finds nothing, because the key
-      // is not in the map yet. Inserting now would resurrect the PTY we
+      // Between the auth check and this line the request yields twice — the
+      // audit peek (and its re-read for a session-less body) and the bucket
+      // build itself. (The body-cap read yields too, but BEFORE auth, which
+      // is why a release landing that early simply 401s.) A `releasePty`
+      // landing in the post-auth window deletes by key and finds nothing,
+      // because the key is not in the map yet. Inserting now would resurrect the PTY we
       // just tore down, and for a dispatched job — whose ptyId is a
       // one-shot `agent-job-<uuid>` — nothing would ever look it up, hold
       // it, or reap it again.
@@ -483,6 +496,9 @@ export class McpHttpHandler {
       this.buckets.set(bucketKey, bucket);
     }
     bucket.lastUsed = Date.now();
+    // Claimed: this request authenticated, so the PTY is back and the bucket
+    // is no longer merely replayed state waiting for its owner.
+    bucket.resumed = false;
     // Touch the persisted record on bucket reuse so the GC sweep keeps
     // it. Best-effort, never blocks request dispatch. Skipped on
     // first-create — the `onsessioninitialized` callback handles the
@@ -600,12 +616,27 @@ export class McpHttpHandler {
   async sweepOrphanedBuckets(): Promise<number> {
     const orphans: ServerBucket[] = [];
     for (const [key, bucket] of this.buckets) {
+      // A replayed bucket has no identity BY CONSTRUCTION until its PTY
+      // reconnects — the identity store does not survive the restart that
+      // made replay necessary. Reaping it would throw away the session
+      // binding the whole replay path exists to keep.
+      if (bucket.resumed) continue;
       if (getIdentity(key) === undefined) {
         this.buckets.delete(key);
         orphans.push(bucket);
       }
     }
     if (orphans.length === 0) return 0;
+    // Symmetric with `releasePty`: a key whose identity is gone must not have
+    // its binding replayed at the next start either. Without this the daemon
+    // loops — restart, replay, sweep at the next tick, restart — replaying a
+    // record for a PTY that will never come back. Best-effort; the map entry
+    // is already gone, which is the part that bounds memory.
+    if (this.persistence) {
+      for (const b of orphans) {
+        this.persistence.drop(this.serverName, b.bucketKey).catch(() => {});
+      }
+    }
     getMcpBridge().audit("multiplexer_buckets_swept", {
       server: this.serverName,
       reclaimed: orphans.length,
@@ -701,6 +732,7 @@ export class McpHttpHandler {
       return existing.transport.sessionId ?? sessionId;
     }
     const bucket = await this._createBucket(ptyId, sessionId);
+    bucket.resumed = true;
     this.buckets.set(ptyId, bucket);
     return bucket.transport.sessionId ?? sessionId;
   }

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -258,7 +258,12 @@ export class McpMultiplexerPlugin {
    *   - no `persistenceFactory` was supplied (W1 not yet merged), OR
    *   - the factory returned null (degraded — disk/permission errors). */
   private persistence: SessionPersistenceStore | null = null;
-  /** Periodic GC sweep. Null when persistence is dormant. */
+  /** Periodic GC tick: the persisted-record GC AND the orphaned-bucket
+   *  sweep. Armed whenever the plugin is running — NOT gated on persistence.
+   *  The sweep bounds in-memory buckets, which a handler accumulates whether
+   *  or not anything is written to disk, so gating the tick on a store would
+   *  leave exactly the handlers with no persistence unswept. Null only while
+   *  the plugin is stopped or dormant. */
   private gcTimer: ReturnType<typeof setInterval> | null = null;
   /** #72 item 7: file to check for shared-name collisions at startup.
    *  Defaults to `~/.claude/mcp.json`; tests can override. */

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -695,7 +695,11 @@ export class McpMultiplexerPlugin {
 
   private _startGCTick(intervalMs: number): void {
     if (intervalMs <= 0) return;
-    if (!this.persistence) return;
+    // Deliberately NOT gated on `this.persistence` any more. The tick now
+    // also reclaims orphaned in-memory buckets, and a handler with no
+    // persistence store is exactly the case that most needs it: `stateless`
+    // servers have `persistence` set to undefined, so gating here left them
+    // with no sweep at all.
     this.gcTimer = setInterval(() => {
       void this._runGCTick();
     }, intervalMs);
@@ -711,18 +715,34 @@ export class McpMultiplexerPlugin {
     }
   }
 
-  /** One GC pass. Delegates the TTL sweep to the persistence layer;
-   *  the store emits `mcp_session_gc` per dropped entry internally. */
+  /** One GC pass. Two independent sweeps, each isolated so a failure in
+   *  one still runs the other:
+   *    - on-disk session records, TTL-based, delegated to the persistence
+   *      layer (it emits `mcp_session_gc` per dropped entry internally);
+   *    - in-memory buckets whose PTY identity is gone, which is how a
+   *      bucket orphaned by a mid-request `releasePty` gets reclaimed. */
   private async _runGCTick(): Promise<void> {
-    if (!this.persistence) return;
-    try {
-      await this.persistence.garbageCollect();
-    } catch (err) {
-      console.warn(
-        `[mcp-multiplexer] persistence GC failed (continuing): ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
+    if (this.persistence) {
+      try {
+        await this.persistence.garbageCollect();
+      } catch (err) {
+        console.warn(
+          `[mcp-multiplexer] persistence GC failed (continuing): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+    for (const handler of this.handlers.values()) {
+      try {
+        await handler.sweepOrphanedBuckets();
+      } catch (err) {
+        console.warn(
+          `[mcp-multiplexer] bucket sweep failed (continuing): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
     }
   }
 

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -496,11 +496,16 @@ export class McpMultiplexerPlugin {
     // method returns, so this ordering is safe.
     if (this.persistence) {
       await this._replayPersistedSessions();
-      // Start the GC sweep. Default cadence 1h; tests pin to 0 to drive
-      // synchronously via `_runGCTickForTests`.
-      const gcTickMs = this.gcTickMsOverride ?? 3_600_000;
-      this._startGCTick(gcTickMs);
     }
+    // The tick runs whether or not a persistence store exists — it also
+    // reclaims orphaned in-memory buckets, which is a hazard the store has no
+    // bearing on. Gating the whole thing on `this.persistence` meant an
+    // operator who turned session persistence off got no bucket sweep either,
+    // and those two knobs have nothing to do with each other.
+    // Default cadence 1h; tests pin to 0 to drive synchronously via
+    // `_runGCTickForTests`.
+    const gcTickMs = this.gcTickMsOverride ?? 3_600_000;
+    this._startGCTick(gcTickMs);
   }
 
   async stop(): Promise<void> {
@@ -695,11 +700,6 @@ export class McpMultiplexerPlugin {
 
   private _startGCTick(intervalMs: number): void {
     if (intervalMs <= 0) return;
-    // Deliberately NOT gated on `this.persistence` any more. The tick now
-    // also reclaims orphaned in-memory buckets, and a handler with no
-    // persistence store is exactly the case that most needs it: `stateless`
-    // servers have `persistence` set to undefined, so gating here left them
-    // with no sweep at all.
     this.gcTimer = setInterval(() => {
       void this._runGCTick();
     }, intervalMs);

--- a/src/plugins/mcp-multiplexer/session-persistence.ts
+++ b/src/plugins/mcp-multiplexer/session-persistence.ts
@@ -164,6 +164,13 @@ export class SessionPersistenceStore {
     this.maxAgeMs = opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
   }
 
+  /** The record TTL, in ms. Read by the multiplexer's orphan sweep so the
+   *  grace it grants a replayed-but-unclaimed bucket expires on the same
+   *  clock as the on-disk record that bucket exists to preserve. */
+  get maxAge(): number {
+    return this.maxAgeMs;
+  }
+
   // ── Public API ─────────────────────────────────────────────────────────
 
   /**


### PR DESCRIPTION
Closes #355.

> ⚠️ **Depends on #354 — do not merge before it.** This branch is built on top of it (GitHub won't let a cross-fork PR target a fork branch, so it shows #354's commits too; **the reviewable diff is the last commit**, `1b2f290`).
>
> The dependency is real, not cosmetic: the sweep asks whether a bucket's key still has an issued identity. On `main` a stateless server's bucket is keyed `__stateless__`, which is not a ptyId and never has an identity — so the sweep would reap the shared bucket on every tick. #354 is what makes every bucket key a real ptyId and the question meaningful. I'll rebase onto `main` once #354 lands.

## The race

`handle()` yields at least twice between authenticating and putting the bucket in the map — `_enforceBodyCap()` → `arrayBuffer()`, `_readBody()` → `clone().json()`, then `_createBucket()` itself. `releasePty()` deletes by key, so one landing in that window finds nothing to delete, and the in-flight request then inserts its bucket **after its own teardown**.

Measured against the handler, injecting the release N microtask turns in:

```
turns 0-1   pre-auth — the request just 401s, nothing is built
turns 2-6   LEAK — request 200s, bucket outlives its own release
turns 7+    transport already serving; the request hangs (see the bottom)
```

## Why it matters for jobs specifically

For a long-lived ptyId an orphan is only untidy: the next request under that key adopts it. A dispatched agent job keys on a one-shot `agent-job-<uuid>`, so nothing ever looks it up, releases it, or reaps it — **one permanent ~21 KB orphan per race hit, per shared server**.

And it is not an exotic interleaving: the job config's `finally` revokes the identity the instant a run settles, including the abort path that kills `claude` with requests still in flight.

Nothing reclaimed these. `lastUsed` is written on every dispatch and never read; the GC tick only swept on-disk records; and `_startGCTick` returned early when there was no persistence store — which is exactly what a `stateless` handler has, so those handlers had no tick at all.

## The fix

Two layers, because the first is precise and the second is a backstop.

**1. Close the window.** `releaseIdentity` revokes the identity *before* calling `releasePty`, so a vanished identity is a reliable signal that teardown began while we were awaiting. Check it immediately before `buckets.set`; tear the fresh bucket down instead of inserting it, audit `multiplexer_bucket_release_raced`, and answer `401` — the same thing any post-teardown request gets.

**2. Sweep what slips through.** `sweepOrphanedBuckets()` reclaims any bucket whose ptyId no longer has an issued identity, on the existing GC tick.

Keyed on identity rather than on an idle TTL **deliberately**: a bucket with no identity is *provably* dead — nothing can ever authenticate to it again — whereas an idle bucket may belong to a healthy long-lived PTY that simply went quiet, and reaping that would force a pointless re-handshake. It also covers any future caller that reaches `releasePty` without going through `releaseIdentity`.

The tick no longer returns early without a persistence store, since that gate excluded precisely the handlers that most needed a sweep. The two sweeps are isolated so a failure in one still runs the other.

## Verification

Three tests, each failing on **exactly one** mutation and nothing else:

| test | dies when you remove |
|---|---|
| `is not inserted after its own teardown` | the identity re-check before `buckets.set` |
| `is reclaimed by the sweep when it slips through anyway` | the sweep's identity test |
| `sweeps a bucket whose identity is gone, on a handler with no persistence` | the sweep call in the GC tick |

The first pins the release at microtask turn 4 — the middle of the measured 2-6 window — with the boundaries recorded in a comment so a future reader knows why that number and not another.

The sweep test also asserts a live PTY's bucket is **left alone**, which is the property that makes identity-keying safe, and that a second pass is a no-op.

Typecheck ratchet unchanged at baseline (153). Touched suites: 50 pass / 1 fail, the one being the pre-existing flake below.

### Two intermittent failures, both pre-existing

- `session-persistence-integration` → *"GC tick drops on-disk expired entries while leaving live in-memory buckets intact"*. Its name makes it the obvious suspect for this PR, so I measured it on the parent branch **without** this change: 4 failures in 5 runs. With the change: 2 in 3. Same rate, unrelated cause — it uses the stateful `alpha` server and the identity for its live PTY is still issued, so the sweep never touches it.
- `buildHostTelemetryProvider — omitting extraProducers is a no-op`. Also fails on `main`.

No new deterministic failures.

## Not fixed here

From turn 7 onward the release closes the transport while `handleRequest()` is still pending and the promise **never settles** — a hang rather than a throw, so `handle()`'s catch never runs and the gateway holds the connection. Fixing it needs in-flight tracking on the bucket so teardown can defer the close, which is a different change; it stays described on #355.
