### PR TITLE
fix(tuner): chat adapters can no longer be handed an unrenderable proposal

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.227",
+      "version": "2.2.228",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.227",
+  "version": "2.2.228",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/skills-tuner/adapters-unbounded.test.ts
+++ b/src/__tests__/skills-tuner/adapters-unbounded.test.ts
@@ -1,0 +1,541 @@
+/**
+ * What the chat adapters do with a proposal carrying more alternatives than
+ * the surface can render.
+ *
+ * The proposal store does not bound `alternatives` on the read path — a row
+ * written under an older, tighter bound has to stay readable — so every one of
+ * these limits is reachable from real data. Each of them rejects the WHOLE
+ * message when exceeded, so the failure is not a shortened proposal, it is no
+ * proposal at all.
+ *
+ * The fixtures here are deliberately hostile: realistic label and tradeoff
+ * lengths, ids long enough to blow a callback identifier, and enough
+ * alternatives to cross every cap. An earlier version of this work passed its
+ * tests with one-word labels while the real shape failed in production.
+ *
+ * The load-bearing assertion in this file is `expectButtonsMatchBody`. Caps on
+ * counts are easy to hold and easy to test; the failure that actually reached
+ * an operator was a button whose alternative had been cut out of the body,
+ * with nothing saying so. Every surface asserts that invariant on a fixture
+ * that really does overflow.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { DiscordAdapter } from "../../skills-tuner/adapters/discord";
+import { SlackAdapter } from "../../skills-tuner/adapters/slack";
+import { TelegramAdapter } from "../../skills-tuner/adapters/telegram";
+import {
+  elidePath,
+  pickAddressable,
+  renderProposalBody,
+  stripInlineMarkup,
+} from "../../skills-tuner/adapters/renderable";
+import type { Alternative, Proposal } from "../../skills-tuner/core/types";
+
+/** Alternatives shaped like the ones subjects actually emit. */
+function alts(n: number, opts: { idLen?: number; labelLen?: number } = {}): Alternative[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `a${i + 1}`.padEnd(opts.idLen ?? 2, "x"),
+    // Padded with a non-space character on purpose: the adapters collapse
+    // whitespace runs, so a label padded with spaces would shrink back and
+    // stop overflowing anything.
+    label: "Rewrite the retention window"
+      .padEnd(opts.labelLen ?? 40, "x")
+      .slice(0, opts.labelLen ?? 40),
+    diff_or_content: "x",
+    tradeoff: "Cheaper to run, slower to converge, and harder to explain afterwards",
+  }));
+}
+
+function makeProposal(alternatives: Alternative[]): Proposal {
+  return {
+    id: 42,
+    cluster_id: "cluster-1",
+    subject: "memory",
+    kind: "update",
+    target_path: "/home/user/.claude/memory/retention.md",
+    alternatives,
+    pattern_signature: "sig-1",
+    created_at: new Date("2026-05-17T00:00:00Z"),
+    signature: "test-signature",
+  } as Proposal;
+}
+
+/** A path deep enough to blow a content limit on the header alone. */
+const HUGE_PATH = "/very/deep/" + "segment/".repeat(700) + "retention.md";
+
+type CapturedCall = { url: string; init?: RequestInit };
+let calls: CapturedCall[];
+const origFetch = globalThis.fetch;
+
+beforeEach(() => {
+  calls = [];
+  globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: url.toString(), init });
+    return new Response('{"ok":true,"id":"msg-1"}', { status: 200 });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+});
+
+function body(): Record<string, unknown> {
+  return JSON.parse(calls[0]!.init?.body as string);
+}
+
+// ── Reading a rendered message back, per surface ─────────────────────────────
+
+/** The body text and the alternative ids that got an Apply button. */
+interface Rendered {
+  text: string;
+  applied: string[];
+}
+
+function readDiscord(): Rendered {
+  const b = body();
+  const rows = b.components as Array<{ components: Array<{ custom_id: string }> }>;
+  return {
+    text: b.content as string,
+    applied: rows
+      .flatMap((r) => r.components)
+      .map((c) => c.custom_id)
+      .filter((id) => id.startsWith("apply:"))
+      .map((id) => id.split(":")[2] as string),
+  };
+}
+
+function readSlack(): Rendered {
+  const blocks = body().blocks as Array<{
+    type: string;
+    text?: { text: string };
+    elements?: Array<{ value: string; action_id: string }>;
+  }>;
+  const actions = blocks.find((x) => x.type === "actions");
+  return {
+    text: blocks.find((x) => x.type === "section")?.text?.text ?? "",
+    applied: (actions?.elements ?? [])
+      .map((e) => e.value)
+      .filter((v) => v.startsWith("apply:"))
+      .map((v) => v.split(":")[2] as string),
+  };
+}
+
+function readTelegram(): Rendered {
+  const b = body();
+  const kb = (b.reply_markup as { inline_keyboard: Array<Array<{ callback_data: string }>> })
+    .inline_keyboard;
+  return {
+    text: b.text as string,
+    applied: kb
+      .flat()
+      .map((btn) => btn.callback_data)
+      .filter((d) => d.startsWith("apply:"))
+      .map((d) => d.split(":")[2] as string),
+  };
+}
+
+/**
+ * The invariant the whole module exists for: a button is never offered for an
+ * alternative the reader cannot see, the body really did overflow (otherwise
+ * the assertion proves nothing), and the notice counts what is actually there.
+ */
+function expectButtonsMatchBody(r: Rendered, total: number, cap: number) {
+  expect(r.text.length).toBeLessThanOrEqual(cap);
+  // Guard against a fixture that quietly stopped overflowing: if everything
+  // fits, this test is not testing what it claims to test.
+  expect(r.applied.length).toBeLessThan(total);
+  for (const id of r.applied) {
+    expect(r.text).toContain(id);
+  }
+  expect(r.text).toContain(`${r.applied.length} of ${total} alternatives`);
+}
+
+// ── The shared decision ─────────────────────────────────────────────────────
+
+describe("pickAddressable", () => {
+  it("drops an alternative whose identifier will not survive the round trip", () => {
+    const proposal = makeProposal([
+      ...alts(2),
+      { id: "z".repeat(200), label: "huge id", diff_or_content: "x", tradeoff: "" },
+    ]);
+    const shown = pickAddressable(proposal.alternatives, [
+      { build: (a) => `apply:${proposal.id}:${a.id}`, max: 100 },
+    ]);
+    expect(shown).toHaveLength(2);
+  });
+
+  it("measures the identifier the way the surface counts it", () => {
+    // A four-byte emoji is one UTF-16 unit pair but four bytes. A surface that
+    // counts bytes must not be told the id fits because it is short.
+    const alternatives = [
+      { id: "\u{1F4A5}".repeat(20), label: "emoji id", diff_or_content: "x", tradeoff: "" },
+    ];
+    const byChars = pickAddressable(alternatives, [{ build: (a) => `apply:42:${a.id}`, max: 64 }]);
+    const byBytes = pickAddressable(alternatives, [
+      { build: (a) => `apply:42:${a.id}`, max: 64, measure: (v) => Buffer.byteLength(v, "utf8") },
+    ]);
+    expect(byChars).toHaveLength(1);
+    expect(byBytes).toHaveLength(0);
+  });
+
+  it("keeps an identifier of exactly the limit and drops the next character", () => {
+    // The off-by-one that a fixture sitting far from the cap cannot catch.
+    const atLimit = [{ id: "y".repeat(90), label: "l", diff_or_content: "x", tradeoff: "" }];
+    const overLimit = [{ id: "y".repeat(91), label: "l", diff_or_content: "x", tradeoff: "" }];
+    const build = (a: Alternative) => `apply:42:${a.id}`; // 9-char prefix → 99 and 100
+    expect(pickAddressable(atLimit, [{ build, max: 99 }])).toHaveLength(1);
+    expect(pickAddressable(overLimit, [{ build, max: 99 }])).toHaveLength(0);
+  });
+
+  it("requires EVERY limit to be satisfied, not just the loosest one", () => {
+    // Slack's shape: a generous budget on the value it parses back, a much
+    // tighter one on the action_id that has to stay unique in the block.
+    const alternatives = [{ id: "q".repeat(300), label: "l", diff_or_content: "x", tradeoff: "" }];
+    expect(
+      pickAddressable(alternatives, [{ build: (a) => `apply:42:${a.id}`, max: 2000 }]),
+    ).toHaveLength(1);
+    expect(
+      pickAddressable(alternatives, [
+        { build: (a) => `apply:42:${a.id}`, max: 2000 },
+        { build: (a) => `tuner_apply_42_${a.id}`, max: 255 },
+      ]),
+    ).toHaveLength(0);
+  });
+});
+
+describe("renderProposalBody", () => {
+  const opts = (over: Partial<Parameters<typeof renderProposalBody>[1]> = {}) => ({
+    identifiers: [{ build: (a: Alternative) => a.id, max: 100 }],
+    maxButtons: 20,
+    maxText: 200,
+    header: "HEADER",
+    block: (a: Alternative) => `${a.id}: ${a.label}`,
+    ...over,
+  });
+
+  it("shows an alternative only when its block fits, and counts the rest", () => {
+    const r = renderProposalBody(makeProposal(alts(20)), opts());
+    expect(r.text.length).toBeLessThanOrEqual(200);
+    expect(r.shown.length).toBeGreaterThan(0);
+    expect(r.hidden).toBe(20 - r.shown.length);
+    expect(r.notice).toContain(`${r.shown.length} of 20 alternatives`);
+    for (const alt of r.shown) expect(r.text).toContain(alt.id);
+  });
+
+  it("counts the notice against the budget instead of appending past it", () => {
+    // A body sized to fill the limit exactly without a notice still has to
+    // hold the notice once one is needed.
+    const r = renderProposalBody(makeProposal(alts(20)), opts({ maxText: 300 }));
+    expect(r.text.length).toBeLessThanOrEqual(300);
+    expect(r.notice).not.toBe("");
+    expect(r.text.endsWith(r.notice)).toBe(true);
+  });
+
+  it("says nothing and keeps everything when it all fits", () => {
+    const r = renderProposalBody(makeProposal(alts(3)), opts({ maxText: 4000 }));
+    expect(r.hidden).toBe(0);
+    expect(r.notice).toBe("");
+    expect(r.shown).toHaveLength(3);
+  });
+
+  it("cuts between blocks, never inside one", () => {
+    const r = renderProposalBody(makeProposal(alts(20)), opts());
+    // Every block that made it is present in full; no half of one is.
+    for (const alt of r.shown) expect(r.text).toContain(`${alt.id}: ${alt.label}`);
+    expect(r.text.split("\n\n")).toHaveLength(r.shown.length + 2); // header + blocks + notice
+  });
+
+  it("cuts the header rather than emitting a body over the limit", () => {
+    // `target_path` is unbounded and lands in the header, not in a droppable
+    // block: a deep enough path blows the limit before a single alternative is
+    // considered, and the surface rejects the whole message.
+    const r = renderProposalBody(makeProposal(alts(20)), {
+      identifiers: [{ build: (a: Alternative) => a.id, max: 100 }],
+      maxButtons: 20,
+      maxText: 200,
+      header: "Proposal #42\n\nTarget: `" + "x".repeat(500) + "`",
+      block: (a: Alternative) => `${a.id}: ${a.label}`,
+    });
+    expect(r.text.length).toBeLessThanOrEqual(200);
+    expect(r.text).toContain("Proposal #42");
+  });
+
+  it("keeps the notice free of markup, so it is safe on every surface", () => {
+    const r = renderProposalBody(makeProposal(alts(20)), opts());
+    for (const ch of ["*", "_", "`", "~", "["]) {
+      expect(r.notice).not.toContain(ch);
+    }
+  });
+
+  it("keeps the header even when not one alternative fits", () => {
+    const r = renderProposalBody(makeProposal(alts(20)), opts({ maxText: 100 }));
+    expect(r.shown).toHaveLength(0);
+    expect(r.text).toContain("HEADER");
+    expect(r.text.length).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("elidePath", () => {
+  it("keeps the tail, which is the identifying end of a path", () => {
+    const out = elidePath("/a/very/long/path/to/retention.md", 20);
+    expect(out).toHaveLength(20);
+    expect(out.endsWith("retention.md")).toBe(true);
+    expect(out.startsWith("\u2026")).toBe(true);
+  });
+
+  it("leaves a path that already fits untouched", () => {
+    expect(elidePath("/short/path.md", 200)).toBe("/short/path.md");
+  });
+});
+
+describe("stripInlineMarkup", () => {
+  it("removes the characters that would leave an entity open", () => {
+    expect(stripInlineMarkup("use snake_case for *keys*", "*_`[")).toBe("use snakecase for keys");
+  });
+
+  it("flattens newlines so a block cannot straddle the cut boundary", () => {
+    expect(stripInlineMarkup("first line\nsecond line", "")).toBe("first line second line");
+    expect(stripInlineMarkup("  padded\n\n  out  ", "")).toBe("padded out");
+  });
+
+  it("leaves ordinary prose untouched", () => {
+    expect(stripInlineMarkup("Cheaper to run, slower to converge", "*_`[")).toBe(
+      "Cheaper to run, slower to converge",
+    );
+  });
+});
+
+// ── Discord ─────────────────────────────────────────────────────────────────
+
+describe("DiscordAdapter — a proposal bigger than the surface", () => {
+  const cfg = {
+    botToken: "t",
+    channelId: "c",
+    baseUrl: "https://discord.test",
+    allowedUserIds: ["u"],
+  };
+
+  it("never offers a button for an alternative it cut out of the body", async () => {
+    // 20 alternatives is the valid maximum a subject may emit, and it already
+    // overflows the 2000-character content limit on text alone — while the
+    // 20-button budget never bites. Deciding buttons before text rendered four
+    // buttons whose alternatives were nowhere in the message.
+    await new DiscordAdapter(cfg).renderProposal(makeProposal(alts(20)));
+    expectButtonsMatchBody(readDiscord(), 20, 2000);
+  });
+
+  it("keeps content under the limit when the notice is also needed", async () => {
+    await new DiscordAdapter(cfg).renderProposal(makeProposal(alts(24)));
+    const r = readDiscord();
+    expect(r.text.length).toBeLessThanOrEqual(2000);
+    expectButtonsMatchBody(r, 24, 2000);
+  });
+
+  it("chunks buttons five to a row and keeps Refuse/Edit last", async () => {
+    await new DiscordAdapter(cfg).renderProposal(makeProposal(alts(12)));
+    const rows = body().components as Array<{ components: Array<{ label: string }> }>;
+    for (const row of rows) expect(row.components.length).toBeLessThanOrEqual(5);
+    const last = rows[rows.length - 1]!.components;
+    expect(last.map((c) => c.label)).toEqual(["Refuse", "Edit"]);
+  });
+
+  it("never truncates a custom_id, because it is parsed back out", async () => {
+    const proposal = makeProposal([
+      ...alts(2),
+      { id: "z".repeat(200), label: "unaddressable", diff_or_content: "x", tradeoff: "" },
+    ]);
+    await new DiscordAdapter(cfg).renderProposal(proposal);
+    const r = readDiscord();
+    expect(r.applied).toEqual(["a1", "a2"]);
+    expect(r.text).toContain("2 of 3 alternatives");
+  });
+
+  it("stays under the limit when the target path alone would blow it", async () => {
+    await new DiscordAdapter(cfg).renderProposal(
+      makeProposal(alts(20)) && ({ ...makeProposal(alts(20)), target_path: HUGE_PATH } as Proposal),
+    );
+    const r = readDiscord();
+    expect(r.text.length).toBeLessThanOrEqual(2000);
+    expect(r.text).toContain("retention.md");
+  });
+
+  it("leaves a proposal that fits completely alone", async () => {
+    await new DiscordAdapter(cfg).renderProposal(makeProposal(alts(3)));
+    const r = readDiscord();
+    expect(r.applied).toHaveLength(3);
+    expect(r.text).not.toContain("alternatives have a button here");
+  });
+});
+
+// ── Slack ───────────────────────────────────────────────────────────────────
+
+describe("SlackAdapter — a proposal bigger than the surface", () => {
+  const cfg = {
+    botToken: "t",
+    channelId: "c",
+    baseUrl: "https://slack.test",
+    allowedUserIds: ["u"],
+  };
+
+  it("never offers a button for an alternative it cut out of the body", async () => {
+    await new SlackAdapter(cfg).renderProposal(makeProposal(alts(40)));
+    expectButtonsMatchBody(readSlack(), 40, 3000);
+  });
+
+  it("keeps the actions block within Slack's 25-element cap", async () => {
+    await new SlackAdapter(cfg).renderProposal(makeProposal(alts(40)));
+    const blocks = body().blocks as Array<{ type: string; elements?: unknown[] }>;
+    const actions = blocks.find((b) => b.type === "actions");
+    expect(actions?.elements?.length).toBeLessThanOrEqual(25);
+  });
+
+  it("stays under the limit when the target path alone would blow it", async () => {
+    await new SlackAdapter(cfg).renderProposal({
+      ...makeProposal(alts(20)),
+      target_path: HUGE_PATH,
+    } as Proposal);
+    expect(readSlack().text.length).toBeLessThanOrEqual(3000);
+  });
+
+  it("keeps every action_id unique when ids share a 255-character prefix", async () => {
+    // `action_id` is bounded four times tighter than `value`, and Slack
+    // rejects the whole block if two elements share one. Bounding only the
+    // value let both of these render as the same truncated action_id.
+    const prefix = "p".repeat(300);
+    const proposal = makeProposal([
+      { id: prefix + "one", label: "first", diff_or_content: "x", tradeoff: "" },
+      { id: prefix + "two", label: "second", diff_or_content: "x", tradeoff: "" },
+      ...alts(2),
+    ]);
+    await new SlackAdapter(cfg).renderProposal(proposal);
+    const blocks = body().blocks as Array<{
+      type: string;
+      elements?: Array<{ action_id: string }>;
+    }>;
+    const ids = (blocks.find((b) => b.type === "actions")?.elements ?? []).map((e) => e.action_id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id.length).toBeLessThanOrEqual(255);
+    // And the two that could not be addressed were dropped, not truncated.
+    expect(readSlack().applied).toEqual(["a1", "a2"]);
+  });
+});
+
+// ── Telegram ────────────────────────────────────────────────────────────────
+
+describe("TelegramAdapter — a proposal bigger than the surface", () => {
+  const cfg = {
+    botToken: "t",
+    chatId: "c",
+    baseUrl: "https://telegram.test",
+    allowedUserIds: [1],
+  };
+
+  it("never offers a button for an alternative it cut out of the body", async () => {
+    // Long labels, few alternatives: the text limit is what bites here, not
+    // the button budget.
+    await new TelegramAdapter(cfg).renderProposal(makeProposal(alts(20, { labelLen: 400 })));
+    expectButtonsMatchBody(readTelegram(), 20, 4096);
+  });
+
+  it("emits the exact callback_data for an id that fits", async () => {
+    await new TelegramAdapter(cfg).renderProposal(makeProposal(alts(2)));
+    const kb = (body().reply_markup as { inline_keyboard: Array<Array<{ callback_data: string }>> })
+      .inline_keyboard;
+    expect(kb.flat().map((b) => b.callback_data)).toEqual([
+      "apply:42:a1",
+      "apply:42:a2",
+      "refuse:42",
+      "edit:42",
+    ]);
+  });
+
+  it("counts callback_data in BYTES, not UTF-16 units", async () => {
+    // 20 four-byte emoji are 40 UTF-16 units — comfortably under 64 — but 80
+    // bytes, which Telegram rejects with BUTTON_DATA_INVALID for the whole
+    // message. Counting characters here renders the button anyway.
+    const proposal = makeProposal([
+      { id: "\u{1F4A5}".repeat(20), label: "emoji id", diff_or_content: "x", tradeoff: "" },
+      ...alts(2),
+    ]);
+    await new TelegramAdapter(cfg).renderProposal(proposal);
+    const r = readTelegram();
+    expect(r.applied).toEqual(["a1", "a2"]);
+    for (const d of ["apply:42:a1", "apply:42:a2"]) {
+      expect(Buffer.byteLength(d, "utf8")).toBeLessThanOrEqual(64);
+    }
+    expect(r.text).toContain("2 of 3 alternatives");
+  });
+
+  it("keeps every callback_data within 64 bytes", async () => {
+    await new TelegramAdapter(cfg).renderProposal(makeProposal(alts(6, { idLen: 80 })));
+    const kb = (body().reply_markup as { inline_keyboard: Array<Array<{ callback_data: string }>> })
+      .inline_keyboard;
+    for (const btn of kb.flat()) {
+      expect(Buffer.byteLength(btn.callback_data, "utf8")).toBeLessThanOrEqual(64);
+    }
+    // The over-long ids were dropped, so only the decision row survives — and
+    // the message says so rather than pretending the proposal had no options.
+    expect(readTelegram().applied).toEqual([]);
+    expect(body().text as string).toContain("0 of 6 alternatives");
+  });
+
+  it("leaves the Markdown balanced on text that really was trimmed", async () => {
+    const proposal = makeProposal(alts(20, { labelLen: 400 }));
+    await new TelegramAdapter(cfg).renderProposal(proposal);
+    const text = body().text as string;
+    expect(text.length).toBeLessThanOrEqual(4096);
+    // The fixture must actually overflow, or the parity below is vacuous.
+    expect(text).toContain("alternatives have a button here");
+    for (const delim of ["*", "_", "`"]) {
+      expect(text.split(delim).length % 2).toBe(1);
+    }
+  });
+
+  it("survives a label carrying its own markup and newlines", async () => {
+    // `label` and `tradeoff` are unbounded strings written by a subject. A
+    // lone underscore, or a newline splitting an italic run across the cut
+    // boundary, makes Telegram reject the entire message.
+    const proposal = makeProposal([
+      {
+        id: "a1",
+        label: "use snake_case for keys",
+        diff_or_content: "x",
+        tradeoff: "opens *bold\nand never closes it",
+      },
+      ...alts(2),
+    ]);
+    await new TelegramAdapter(cfg).renderProposal(proposal);
+    const text = body().text as string;
+    for (const delim of ["*", "_", "`"]) {
+      expect(text.split(delim).length % 2).toBe(1);
+    }
+    expect(text).not.toContain("snake_case");
+    expect(text).toContain("snakecase");
+  });
+
+  it("stays under the limit when the target path alone would blow it", async () => {
+    await new TelegramAdapter(cfg).renderProposal({
+      ...makeProposal(alts(20, { labelLen: 400 })),
+      target_path: HUGE_PATH,
+    } as Proposal);
+    const text = body().text as string;
+    expect(text.length).toBeLessThanOrEqual(4096);
+    for (const delim of ["*", "_", "`"]) {
+      expect(text.split(delim).length % 2).toBe(1);
+    }
+  });
+
+  it("bounds the keyboard instead of emitting hundreds of buttons", async () => {
+    await new TelegramAdapter(cfg).renderProposal(makeProposal(alts(60)));
+    const kb = (body().reply_markup as { inline_keyboard: unknown[][] }).inline_keyboard;
+    expect(kb.length).toBeLessThanOrEqual(11);
+    for (const row of kb) expect(row.length).toBeGreaterThan(0);
+  });
+
+  it("puts at most two buttons on a row, because these are read on a phone", async () => {
+    await new TelegramAdapter(cfg).renderProposal(makeProposal(alts(6)));
+    const kb = (body().reply_markup as { inline_keyboard: unknown[][] }).inline_keyboard;
+    for (const row of kb) expect(row.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/skills-tuner/adapters/discord.ts
+++ b/src/skills-tuner/adapters/discord.ts
@@ -1,5 +1,6 @@
 import { Adapter } from "../core/interfaces.js";
-import type { Proposal } from "../core/types.js";
+import type { Alternative, Proposal } from "../core/types.js";
+import { elidePath, renderProposalBody, stripInlineMarkup } from "./renderable.js";
 import type { CallbackHandler } from "./base.js";
 
 export interface DiscordAdapterConfig {
@@ -25,8 +26,23 @@ const BUTTON_STYLE_SECONDARY = 2; // Edit
 const BUTTON_STYLE_DANGER = 4; // Refuse
 
 // Discord limits we enforce defensively
+/** Discord API limits: 5 buttons per action row, 5 rows per message. The last
+ *  row carries Refuse + Edit, so four are left for Apply buttons. Exceeding
+ *  either rejects the whole message with 400 — it does not truncate. */
+const MAX_BUTTONS_PER_ROW = 5;
+const MAX_APPLY_ROWS = 4;
+const MAX_APPLY_BUTTONS = MAX_BUTTONS_PER_ROW * MAX_APPLY_ROWS;
+/** `content` limit. The proposal text carries one label + tradeoff line per
+ *  alternative, both unbounded strings, so this is reached well before the
+ *  button budget is. */
+const MAX_CONTENT = 2000;
+
 const MAX_BUTTON_LABEL = 80;
 const MAX_CUSTOM_ID = 100;
+/** Characters that open a markup entity in a Discord message body. */
+/** Header budget for the one unbounded field it interpolates. */
+const MAX_TARGET_PATH = 200;
+const DISCORD_MARKUP = "*_~`|";
 
 export class DiscordAdapter extends Adapter {
   constructor(private cfg: DiscordAdapterConfig) {
@@ -44,19 +60,31 @@ export class DiscordAdapter extends Adapter {
 
   async renderProposal(proposal: Proposal): Promise<void> {
     const baseUrl = this.cfg.baseUrl ?? "https://discord.com/api/v10";
-    const content = this.formatProposalText(proposal);
+    // `custom_id` is parsed back out in `handleCallback` to recover the
+    // alternative id, so truncating it produces a button that renders, looks
+    // clickable, and resolves to an alternative no subject can find. An
+    // alternative whose id will not fit is left out and counted instead.
+    //
+    // Buttons and body are budgeted together: twenty ordinary alternatives
+    // exceed the content limit on text alone, well before the button budget
+    // bites, so deciding the buttons first would render buttons for
+    // alternatives the body no longer describes.
+    const { shown, content } = this.renderBody(proposal);
 
-    // Action row 1: one Apply button per alternative (Discord allows ≤5 buttons/row;
-    // alternatives are capped at 3 by AlternativeSchema so this always fits).
-    const applyRow = {
-      type: COMPONENT_ACTION_ROW,
-      components: proposal.alternatives.map((alt) => ({
-        type: COMPONENT_BUTTON,
-        style: BUTTON_STYLE_PRIMARY,
-        label: truncate("Apply " + alt.id + ": " + alt.label, MAX_BUTTON_LABEL),
-        custom_id: truncate("apply:" + proposal.id + ":" + alt.id, MAX_CUSTOM_ID),
-      })),
-    };
+    // Apply buttons, chunked across action rows.
+    const applyButtons = shown.map((alt) => ({
+      type: COMPONENT_BUTTON,
+      style: BUTTON_STYLE_PRIMARY,
+      label: truncate("Apply " + alt.id + ": " + alt.label, MAX_BUTTON_LABEL),
+      custom_id: "apply:" + proposal.id + ":" + alt.id,
+    }));
+    const applyRows: Array<{ type: number; components: typeof applyButtons }> = [];
+    for (let i = 0; i < applyButtons.length; i += MAX_BUTTONS_PER_ROW) {
+      applyRows.push({
+        type: COMPONENT_ACTION_ROW,
+        components: applyButtons.slice(i, i + MAX_BUTTONS_PER_ROW),
+      });
+    }
 
     // Action row 2: Refuse + Edit
     const decisionRow = {
@@ -85,7 +113,7 @@ export class DiscordAdapter extends Adapter {
       },
       body: JSON.stringify({
         content,
-        components: [applyRow, decisionRow],
+        components: [...applyRows, decisionRow],
       }),
     });
     if (!res.ok) {
@@ -146,10 +174,19 @@ export class DiscordAdapter extends Adapter {
     }
   }
 
-  formatProposalText(proposal: Proposal): string {
-    const altLines = proposal.alternatives
-      .map((a) => "**" + a.id + ".** " + a.label + "\n   _" + (a.tradeoff || "no tradeoff") + "_")
-      .join("\n\n");
+  /** Header, kept alternative blocks and gap notice, within `MAX_CONTENT`. */
+  private renderBody(proposal: Proposal): { shown: Alternative[]; content: string } {
+    const { shown, text } = renderProposalBody(proposal, {
+      identifiers: [{ build: (alt) => "apply:" + proposal.id + ":" + alt.id, max: MAX_CUSTOM_ID }],
+      maxButtons: MAX_APPLY_BUTTONS,
+      maxText: MAX_CONTENT,
+      header: this.formatHeader(proposal),
+      block: (alt) => this.formatAlternative(alt),
+    });
+    return { shown, content: text };
+  }
+
+  formatHeader(proposal: Proposal): string {
     return (
       "**Proposal #" +
       proposal.id +
@@ -159,10 +196,28 @@ export class DiscordAdapter extends Adapter {
       proposal.kind +
       "\n\n" +
       "Target: `" +
-      proposal.target_path +
-      "`\n\n" +
-      altLines
+      elidePath(stripInlineMarkup(proposal.target_path, DISCORD_MARKUP), MAX_TARGET_PATH) +
+      "`"
     );
+  }
+
+  formatAlternative(a: Alternative): string {
+    return (
+      "**" +
+      a.id +
+      ".** " +
+      stripInlineMarkup(a.label, DISCORD_MARKUP) +
+      "\n   _" +
+      (stripInlineMarkup(a.tradeoff || "", DISCORD_MARKUP) || "no tradeoff") +
+      "_"
+    );
+  }
+
+  formatProposalText(proposal: Proposal, only?: readonly Alternative[]): string {
+    return [
+      this.formatHeader(proposal),
+      ...(only ?? proposal.alternatives).map((a) => this.formatAlternative(a)),
+    ].join("\n\n");
   }
 }
 

--- a/src/skills-tuner/adapters/renderable.ts
+++ b/src/skills-tuner/adapters/renderable.ts
@@ -1,0 +1,226 @@
+/**
+ * Deciding what a chat surface can actually render of a proposal.
+ *
+ * The proposal store deliberately does not bound `alternatives` on the read
+ * path — a row written under an older, tighter bound must stay readable — so
+ * a stored proposal can carry more alternatives than any chat API will
+ * accept. Each surface then has three independent limits:
+ *
+ *   - how many action buttons it will take at all;
+ *   - how long each identifier carried on a button may be, when that
+ *     identifier has to survive the round trip and be parsed back out of the
+ *     callback (a surface can impose more than one such limit on the same
+ *     button, with different budgets);
+ *   - how long the message body may be.
+ *
+ * Truncating the identifier is not an option where it is parsed back: the
+ * button still renders, still looks clickable, and resolves to an alternative
+ * that does not exist. Dropping the button and saying so is worse for one
+ * alternative and better for the operator, who can still act on it from the
+ * CLI.
+ *
+ * The three budgets are resolved TOGETHER, in one pass, because resolving
+ * them separately is what produced the bug this module was written to fix:
+ * picking buttons first and trimming text afterwards renders a button whose
+ * alternative was cut out of the body, with nothing saying so. The invariant
+ * here is that `shown` is exactly the set that got BOTH a block of text and a
+ * button, and `notice` is derived from that final set — never from an
+ * intermediate one.
+ *
+ * This lives in one place because the three adapters had drifted: the same
+ * reasoning was written three times, corrected in one, and left stale in the
+ * other two.
+ */
+
+import type { Alternative, Proposal } from "../core/types.js";
+
+/** Blocks are joined — and therefore cut — on this boundary. */
+const SEPARATOR = "\n\n";
+
+const utf16 = (s: string) => s.length;
+
+/**
+ * One limit a surface puts on a string carried by a button.
+ *
+ * A surface may impose several on the same button — Slack bounds both the
+ * `value` it hands back and the `action_id` that must stay unique within the
+ * block — and an alternative is only addressable if it satisfies every one.
+ */
+export interface IdentifierConstraint {
+  /** Builds the string the surface will carry and later parse back. */
+  build: (alt: Alternative) => string;
+  /** The surface's limit for it. */
+  max: number;
+  /**
+   * How the surface counts. UTF-16 length by default; byte length where the
+   * API counts bytes, which is not the same thing the moment the id is not
+   * pure ASCII.
+   */
+  measure?: (s: string) => number;
+}
+
+export interface RenderedProposal {
+  /**
+   * The alternatives that got a button AND a block of text describing them.
+   * Never one without the other — that is the whole point of this module.
+   */
+  shown: Alternative[];
+  /** How many of the proposal's alternatives were left out, for any reason. */
+  hidden: number;
+  /**
+   * A sentence naming the gap, or `""` when nothing was left out. Plain text —
+   * no markup — so it is safe to append on any surface, and counted against
+   * the body budget before the body is built.
+   */
+  notice: string;
+  /** Header, kept blocks and notice, guaranteed within the surface's limit. */
+  text: string;
+}
+
+/**
+ * Filter to the alternatives every one of a surface's identifier limits can
+ * carry. Order is preserved; nothing is truncated.
+ */
+export function pickAddressable(
+  alternatives: readonly Alternative[],
+  identifiers: readonly IdentifierConstraint[],
+): Alternative[] {
+  return alternatives.filter((alt) =>
+    identifiers.every((c) => (c.measure ?? utf16)(c.build(alt)) <= c.max),
+  );
+}
+
+/**
+ * Flatten a string for inline use inside a markup body.
+ *
+ * `label` and `tradeoff` are unbounded `z.string()`s written by subjects, so
+ * they can carry newlines and markup characters of their own. Either one is
+ * enough to break the body: a newline splits a block across the cut boundary,
+ * and a lone `_` leaves an entity Telegram will not close — it answers
+ * `can't find end of entity` and drops the whole message, which is a worse
+ * outcome than any amount of missing text.
+ *
+ * The markup characters are removed rather than backslash-escaped because
+ * Telegram's legacy `Markdown` parse mode does not accept escapes everywhere
+ * they would be needed. These are descriptive prose fields; losing an
+ * asterisk from them costs nothing.
+ */
+export function stripInlineMarkup(s: string, markupChars: string): string {
+  const flattened = s.replace(/\s+/g, " ").trim();
+  return markupChars
+    ? flattened.replace(new RegExp(`[${escapeForClass(markupChars)}]`, "g"), "")
+    : flattened;
+}
+
+function escapeForClass(chars: string): string {
+  return chars.replace(/[\\\]^-]/g, (c) => "\\" + c);
+}
+
+/**
+ * Bound the one unbounded field the header interpolates.
+ *
+ * `target_path` is a `z.string()` with no length cap, and it is rendered
+ * inside the header rather than in a droppable block — so an over-long one is
+ * not a shortened header, it is a rejected message. The tail is kept because
+ * that is the identifying end of a path.
+ */
+export function elidePath(path: string, max: number): string {
+  return path.length <= max ? path : "\u2026" + path.slice(-(max - 1));
+}
+
+/**
+ * Resolve the button budget, every identifier budget and the text budget in
+ * one pass.
+ *
+ * `maxText` is assumed to exceed the length of the gap notice (~80 characters);
+ * every surface's limit clears that by more than an order of magnitude. A
+ * budget smaller than the notice has no correct answer — there is no room to
+ * say what was dropped — and is not defended against.
+ *
+ * `block` renders one alternative and must not contain the separator itself —
+ * `stripInlineMarkup` the fields it interpolates. Blocks are kept whole: the
+ * body is cut between blocks, never inside one, which is what keeps a markup
+ * entity from being left open.
+ */
+export function renderProposalBody(
+  proposal: Proposal,
+  opts: {
+    identifiers: readonly IdentifierConstraint[];
+    maxButtons: number;
+    maxText: number;
+    header: string;
+    block: (alt: Alternative) => string;
+  },
+): RenderedProposal {
+  const total = proposal.alternatives.length;
+  const candidates = pickAddressable(proposal.alternatives, opts.identifiers).slice(
+    0,
+    Math.max(0, opts.maxButtons),
+  );
+
+  // Whether a notice is needed is only known after the text budget has been
+  // spent, but the notice has to be paid for out of that same budget. So fit
+  // twice: once assuming none is needed, and again reserving room the moment
+  // the first pass proves otherwise. Reserving unconditionally would drop an
+  // alternative from a proposal that fits whole, which is the same class of
+  // silent loss this module exists to prevent.
+  const free = fitBlocks(candidates, opts, opts.maxText);
+  if (free.shown.length === total) {
+    return { shown: free.shown, hidden: 0, notice: "", text: free.text };
+  }
+
+  // The notice's own length grows only with the digit count of a number that
+  // cannot exceed `candidates.length`, so this is a true upper bound.
+  const reserve = noticeFor(proposal, candidates.length, total).length;
+  const fitted = fitBlocks(candidates, opts, opts.maxText - reserve);
+  const notice = noticeFor(proposal, fitted.shown.length, total);
+  return {
+    shown: fitted.shown,
+    hidden: total - fitted.shown.length,
+    notice,
+    text: fitted.text + notice,
+  };
+}
+
+function fitBlocks(
+  candidates: readonly Alternative[],
+  opts: { header: string; block: (alt: Alternative) => string },
+  budget: number,
+): { shown: Alternative[]; text: string } {
+  // The header carries the proposal id, so it is the last thing to give — but
+  // it is not exempt from the budget. It interpolates `target_path`, another
+  // unbounded string: a deep enough path blows the content limit on the header
+  // alone, before a single alternative is considered, and the surface rejects
+  // the message. Callers bound the path (`elidePath`); this is the backstop
+  // that makes the return value's contract true whatever a caller passes.
+  let text = clampToLine(opts.header, budget);
+  const shown: Alternative[] = [];
+  for (const alt of candidates) {
+    const next = text + SEPARATOR + opts.block(alt);
+    if (next.length > budget) break;
+    text = next;
+    shown.push(alt);
+  }
+  return { shown, text };
+}
+
+/**
+ * Cut on a line boundary, as blocks are cut on a block boundary and for the
+ * same reason: every line of a header opens and closes its own markup, so a
+ * cut between lines cannot leave an entity open. A header with no line break
+ * to cut at is cut hard — there is nothing safer available, and a message over
+ * the limit is refused outright.
+ */
+function clampToLine(text: string, budget: number): string {
+  if (text.length <= budget) return text;
+  const cut = text.lastIndexOf("\n", Math.max(0, budget));
+  return cut <= 0 ? text.slice(0, Math.max(0, budget)) : text.slice(0, cut);
+}
+
+function noticeFor(proposal: Proposal, shown: number, total: number): string {
+  // No markup, per the contract on `RenderedProposal.notice`: this string is
+  // appended to bodies on three surfaces with three different markup dialects,
+  // and it is the one part of the message that must never be the reason the
+  // message is rejected.
+  return `${SEPARATOR}${shown} of ${total} alternatives have a button here; apply the rest with: tuner apply ${proposal.id}`;
+}

--- a/src/skills-tuner/adapters/slack.ts
+++ b/src/skills-tuner/adapters/slack.ts
@@ -1,5 +1,6 @@
 import { Adapter } from "../core/interfaces.js";
-import type { Proposal } from "../core/types.js";
+import type { Alternative, Proposal } from "../core/types.js";
+import { elidePath, renderProposalBody, stripInlineMarkup } from "./renderable.js";
 import type { CallbackHandler } from "./base.js";
 
 export interface SlackAdapterConfig {
@@ -18,9 +19,20 @@ export interface SlackAdapterConfig {
 }
 
 // Slack Block Kit limits we enforce defensively
+/** Slack caps an `actions` block at 25 elements and rejects the message past
+ *  it. Refuse and Edit take two, leaving 23 for Apply buttons. */
+const MAX_ACTIONS_ELEMENTS = 25;
+const MAX_APPLY_BUTTONS = MAX_ACTIONS_ELEMENTS - 2;
+/** Section-block text limit. */
+const MAX_SECTION_TEXT = 3000;
+
 const MAX_BUTTON_TEXT = 75; // chars
 const MAX_ACTION_VALUE = 2000; // chars
 const MAX_ACTION_ID = 255; // chars
+/** Characters that open a markup entity in Slack `mrkdwn`. */
+/** Header budget for the one unbounded field it interpolates. */
+const MAX_TARGET_PATH = 200;
+const SLACK_MARKUP = "*_~`";
 
 export class SlackAdapter extends Adapter {
   constructor(private cfg: SlackAdapterConfig) {
@@ -38,20 +50,36 @@ export class SlackAdapter extends Adapter {
 
   async renderProposal(proposal: Proposal): Promise<void> {
     const baseUrl = this.cfg.baseUrl ?? "https://slack.com/api";
-    const headerText = this.formatProposalText(proposal);
+    // Two independent limits ride on the same button. `value` is what
+    // `handleAction` parses back; `action_id` has to stay UNIQUE inside the
+    // actions block, and Slack bounds it four times tighter. Bounding only
+    // `value` let two alternatives whose ids diverge past character 255
+    // collapse onto one `action_id` — Slack then rejects the whole block, the
+    // exact failure this guard exists to prevent. Both are checked, so neither
+    // is truncated below.
+    const { shown, text: headerText } = renderProposalBody(proposal, {
+      identifiers: [
+        { build: (alt) => "apply:" + proposal.id + ":" + alt.id, max: MAX_ACTION_VALUE },
+        {
+          build: (alt) => "tuner_apply_" + proposal.id + "_" + alt.id,
+          max: MAX_ACTION_ID,
+        },
+      ],
+      maxButtons: MAX_APPLY_BUTTONS,
+      maxText: MAX_SECTION_TEXT,
+      header: this.formatHeader(proposal),
+      block: (alt) => this.formatAlternative(alt),
+    });
 
-    // Block Kit actions block — one Apply per alternative + Refuse + Edit.
-    // Slack allows up to 25 buttons per `actions` block; alternatives are
-    // capped at 3 by AlternativeSchema so the whole row always fits.
     const elements = [
-      ...proposal.alternatives.map((alt) => ({
+      ...shown.map((alt) => ({
         type: "button",
         text: {
           type: "plain_text",
           text: truncate("Apply " + alt.id + ": " + alt.label, MAX_BUTTON_TEXT),
         },
-        value: truncate("apply:" + proposal.id + ":" + alt.id, MAX_ACTION_VALUE),
-        action_id: truncate("tuner_apply_" + proposal.id + "_" + alt.id, MAX_ACTION_ID),
+        value: "apply:" + proposal.id + ":" + alt.id,
+        action_id: "tuner_apply_" + proposal.id + "_" + alt.id,
         style: "primary",
       })),
       {
@@ -152,10 +180,7 @@ export class SlackAdapter extends Adapter {
     }
   }
 
-  formatProposalText(proposal: Proposal): string {
-    const altLines = proposal.alternatives
-      .map((a) => "*" + a.id + ".* " + a.label + "\n  _" + (a.tradeoff || "no tradeoff") + "_")
-      .join("\n\n");
+  formatHeader(proposal: Proposal): string {
     return (
       "*Proposal #" +
       proposal.id +
@@ -165,10 +190,28 @@ export class SlackAdapter extends Adapter {
       proposal.kind +
       "\n\n" +
       "Target: `" +
-      proposal.target_path +
-      "`\n\n" +
-      altLines
+      elidePath(stripInlineMarkup(proposal.target_path, SLACK_MARKUP), MAX_TARGET_PATH) +
+      "`"
     );
+  }
+
+  formatAlternative(a: Alternative): string {
+    return (
+      "*" +
+      a.id +
+      ".* " +
+      stripInlineMarkup(a.label, SLACK_MARKUP) +
+      "\n  _" +
+      (stripInlineMarkup(a.tradeoff || "", SLACK_MARKUP) || "no tradeoff") +
+      "_"
+    );
+  }
+
+  formatProposalText(proposal: Proposal, only?: readonly Alternative[]): string {
+    return [
+      this.formatHeader(proposal),
+      ...(only ?? proposal.alternatives).map((a) => this.formatAlternative(a)),
+    ].join("\n\n");
   }
 }
 

--- a/src/skills-tuner/adapters/telegram.ts
+++ b/src/skills-tuner/adapters/telegram.ts
@@ -1,6 +1,21 @@
 import { Adapter } from "../core/interfaces.js";
-import type { Proposal } from "../core/types.js";
+import type { Alternative, Proposal } from "../core/types.js";
 import type { CallbackHandler } from "./base.js";
+import { elidePath, renderProposalBody, stripInlineMarkup } from "./renderable.js";
+
+/** Telegram limits: `callback_data` is 1-64 BYTES and rejects the whole
+ *  message past it; `text` is 4096 characters. The button count is capped for
+ *  readability, not by the API — a phone keyboard of forty buttons is not a
+ *  usable surface. */
+const MAX_CALLBACK_DATA_BYTES = 64;
+const MAX_TEXT = 4096;
+const MAX_BUTTONS_PER_ROW = 2;
+const MAX_APPLY_BUTTONS = 20;
+/** Characters that open an entity under `parse_mode: "Markdown"`. An
+ *  unterminated one costs the whole message, not the run it sits in. */
+/** Header budget for the one unbounded field it interpolates. */
+const MAX_TARGET_PATH = 200;
+const TELEGRAM_MARKUP = "*_`[";
 
 export interface TelegramAdapterConfig {
   botToken: string;
@@ -21,13 +36,31 @@ export class TelegramAdapter extends Adapter {
 
   async renderProposal(proposal: Proposal): Promise<void> {
     const baseUrl = this.cfg.baseUrl ?? "https://api.telegram.org";
-    const text = this.formatProposalText(proposal);
-    const reply_markup = {
-      inline_keyboard: [
-        proposal.alternatives.map((alt) => ({
+    // `callback_data` is limited to 64 BYTES and `handleCallback` parses the
+    // alternative id back out of it, so an over-long id cannot be truncated —
+    // and going over rejects the whole sendMessage with BUTTON_DATA_INVALID,
+    // costing the operator the entire proposal rather than one button.
+    //
+    // The body is cut between alternative blocks, never inside one, and every
+    // interpolated field has its markup characters removed first: `parse_mode`
+    // is set, so a single unclosed `_` turns "too long" into "can't find end
+    // of entity" and Telegram drops the message entirely.
+    const { shown, text } = this.renderBody(proposal);
+
+    // Chunked: a single row of a dozen buttons is unusable on a phone, which
+    // is where these are read.
+    const applyRows: Array<Array<{ text: string; callback_data: string }>> = [];
+    for (let i = 0; i < shown.length; i += MAX_BUTTONS_PER_ROW) {
+      applyRows.push(
+        shown.slice(i, i + MAX_BUTTONS_PER_ROW).map((alt) => ({
           text: "Apply " + alt.id + ": " + alt.label.slice(0, 30),
           callback_data: "apply:" + proposal.id + ":" + alt.id,
         })),
+      );
+    }
+    const reply_markup = {
+      inline_keyboard: [
+        ...applyRows,
         [
           { text: "Refuse", callback_data: "refuse:" + proposal.id },
           { text: "Edit", callback_data: "edit:" + proposal.id },
@@ -100,10 +133,24 @@ export class TelegramAdapter extends Adapter {
     }
   }
 
-  formatProposalText(proposal: Proposal): string {
-    const altLines = proposal.alternatives
-      .map((a) => "*" + a.id + ".* " + a.label + "\n   _" + (a.tradeoff || "no tradeoff") + "_")
-      .join("\n\n");
+  /** Header, kept alternative blocks and gap notice, within `MAX_TEXT`. */
+  private renderBody(proposal: Proposal): { shown: Alternative[]; text: string } {
+    return renderProposalBody(proposal, {
+      identifiers: [
+        {
+          build: (alt) => "apply:" + proposal.id + ":" + alt.id,
+          max: MAX_CALLBACK_DATA_BYTES,
+          measure: (v) => Buffer.byteLength(v, "utf8"),
+        },
+      ],
+      maxButtons: MAX_APPLY_BUTTONS,
+      maxText: MAX_TEXT,
+      header: this.formatHeader(proposal),
+      block: (alt) => this.formatAlternative(alt),
+    });
+  }
+
+  formatHeader(proposal: Proposal): string {
     return (
       "Proposal #" +
       proposal.id +
@@ -113,9 +160,27 @@ export class TelegramAdapter extends Adapter {
       proposal.kind +
       "\n\n" +
       "Target: `" +
-      proposal.target_path +
-      "`\n\n" +
-      altLines
+      elidePath(stripInlineMarkup(proposal.target_path, TELEGRAM_MARKUP), MAX_TARGET_PATH) +
+      "`"
     );
+  }
+
+  formatAlternative(a: Alternative): string {
+    return (
+      "*" +
+      a.id +
+      ".* " +
+      stripInlineMarkup(a.label, TELEGRAM_MARKUP) +
+      "\n   _" +
+      (stripInlineMarkup(a.tradeoff || "", TELEGRAM_MARKUP) || "no tradeoff") +
+      "_"
+    );
+  }
+
+  formatProposalText(proposal: Proposal, only?: readonly Alternative[]): string {
+    return [
+      this.formatHeader(proposal),
+      ...(only ?? proposal.alternatives).map((a) => this.formatAlternative(a)),
+    ].join("\n\n");
   }
 }


### PR DESCRIPTION
## The problem

The proposal store deliberately does not bound `alternatives` on the read path — a row written under an older, tighter bound has to stay readable — so a stored proposal can carry more alternatives than any chat API will accept.

Every one of these limits rejects the **whole message** when exceeded. The failure mode is not a shortened proposal, it is no proposal at all:

| Surface | Buttons | Identifier | Body |
|---|---|---|---|
| Discord | 5/row × 4 rows | `custom_id` ≤ 100 chars | `content` ≤ 2000 chars |
| Slack | 25 per `actions` block | `value` ≤ 2000 chars, `action_id` ≤ 255 chars **and unique in the block** | section text ≤ 3000 chars |
| Telegram | capped for readability | `callback_data` ≤ 64 **bytes** | `text` ≤ 4096 chars |

## What this changes

Each surface imposes three independent limits: how many buttons it takes, how long each identifier carried on a button may be, and how long the body may be. `renderProposalBody` resolves all three in **one pass** and derives the gap notice from the set that got **both** a block of text and a button.

Resolving them separately is the bug worth naming, because it is subtle. Pick the buttons, then trim the body, and `notice` is computed before the trim runs — so it cannot know what the trim removed. On Discord, a valid 20-alternative proposal rendered:

```
content.length              : 1999  (cap 2000)
alternatives described      : 16
Apply buttons rendered      : 20
notice present              : false
```

Four buttons offering to apply an alternative the reader cannot see, and nothing saying so. The button budget (20) equals `MAX_ALTERNATIVES`, so it never bites for a validly-emitted proposal; the content budget that does bite was silent.

Truncating an identifier is not an option where it is parsed back out: the button still renders, still looks clickable, and resolves to an alternative that does not exist. Dropping it and saying so is worse for one alternative and better for the operator, who can still act from the CLI.

## Decisions worth flagging in review

**A surface may declare more than one identifier limit.** Slack bounds the `value` it parses back at 2000 and the `action_id` that must stay unique within the actions block at 255. Checking only the value let two ids diverging past character 255 collapse onto one truncated `action_id`, and Slack rejects the whole block — the exact class of failure this guard exists to prevent. Both are checked now; `action_id` is no longer truncated, because it can no longer overflow.

**The body is cut between alternative blocks, never inside one**, and every interpolated field goes through `stripInlineMarkup` first. `label` and `tradeoff` are unbounded `z.string()`s written by subjects: a newline in a tradeoff puts an opening `_` on one line and its close on the next, and a lone `_` in `snake_case` is enough on its own. Telegram answers `can't find end of entity` and drops the message — worse than too long, and harder to read. Markup characters are removed rather than backslash-escaped because legacy `Markdown` does not accept escapes everywhere they would be needed; these are prose fields, and losing an asterisk from them costs nothing.

**The notice is paid for out of the budget it is appended to**, so fitting runs twice: once assuming none is needed, again reserving room once the first pass proves otherwise. Reserving unconditionally would drop an alternative from a proposal that fits whole — the same class of silent loss.

**The notice points at `tuner apply <id>`**, matching the CLI adapter in this directory, rather than an MCP tool backed by a different store.

## Tests

The load-bearing assertion is `expectButtonsMatchBody`: every rendered button's alternative appears in the body, and the notice counts what is actually there. It is asserted per surface on a fixture that really does overflow — and it asserts the overflow, because the earlier fixture passed while silently losing four alternatives.

Mutation-checked. Each of these fails the suite:

| Mutation | Failing tests |
|---|---|
| Telegram counts UTF-16 units instead of bytes | 1 |
| text budget ignored | 8 |
| Slack `action_id` constraint dropped | 1 |
| `stripInlineMarkup` neutered | 3 |
| notice derived from candidates instead of what fit | 4 |
| notice not reserved out of the budget | 4 |
| button cap removed | 1 |
| header not clamped to the budget | 1 |
| `elidePath` neutered | 2 |
| markup put back in the notice | 1 |

## Addressed from review

Two findings from the automated review, both real and both reproduced before fixing:

**The header was exempt from the budget.** `target_path` is another unbounded `z.string()`, and it lands in the header rather than in a droppable block — so a deep enough path blew the content limit before a single alternative was considered. Measured on Discord with a 5623-character path: `content.length` 5747 against a 2000 cap, which the surface rejects outright. `elidePath` now bounds the path at the adapter (keeping the tail, the identifying end), and `fitBlocks` clamps the header on a line boundary as a backstop so the return value's contract holds whatever a caller passes. Same path now renders at 1815 characters.

**The notice contradicted its own contract.** It is documented as plain text so it is safe to append on any surface, then interpolated the CLI hint in backticks. The backticks are gone; the doc comment now says why.

## Verification

```
bun run lint                                    exit 0
bun run typecheck                               153 errors, baseline 153 (unchanged)
bun test src/skills-tuner src/__tests__/skills-tuner   153 pass / 0 fail, 7 files
```

## Note on wiring

These adapters have no in-tree production instantiation today: nothing outside their own directory and tests imports `src/skills-tuner/adapters/`. `Registry.registerAdapter()` exists but nothing in tree calls it, and the identically-named classes wired up in `src/bus/adapter-wiring.ts` come from `src/adapters/`, a different directory this PR does not touch. So the blast radius today is nil — that calibrates the urgency, it does not change whether the code is correct when something does call it.

Split out of #352 (merged). No shared code with it.
