### PR TITLE
fix(mcp-multiplexer): keep onsessionclosed from eating the SDK's teardown

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.226",
+      "version": "2.2.227",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.226",
+  "version": "2.2.227",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/mcp-multiplexer-integration.test.ts
+++ b/src/__tests__/mcp-multiplexer-integration.test.ts
@@ -1069,3 +1069,69 @@ describe("mcp-multiplexer integration — crash + health probe transition", () =
     }
   });
 });
+
+// ── 7) onsessionclosed runs in front of the SDK's own teardown ───────────────
+
+describe("mcp-multiplexer integration — onsessionclosed is throw-proof", () => {
+  it("a synchronously-throwing persistence drop still lets the SDK close the transport", async () => {
+    const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+
+    // An in-memory stand-in for `SessionPersistenceStore`. Nothing here
+    // touches disk, which is why this test lives in THIS file: its sibling
+    // `session-persistence-integration.test.ts` is deliberately excluded
+    // from CI for a load-sensitive flake (#326), so a test placed there
+    // would never actually gate anything.
+    const store = {
+      record: async () => {},
+      touch: async () => {},
+      loadAll: async () => [],
+      garbageCollect: async () => ({ scanned: 0, kept: 0, dropped: 0 }),
+      // The one that matters: a SYNCHRONOUS throw, not a rejected promise.
+      // `drop()` is `async` today, so the `.catch()` in the callback always
+      // attaches and this shape is unreachable — that is the point. The
+      // callback runs BEFORE the SDK's own `await this.close()` inside
+      // `handleDeleteRequest`, so the day someone drops that `async`, an
+      // unguarded body takes the transport teardown down with it and
+      // answers the client's DELETE with a 500.
+      drop: () => {
+        throw new Error("drop exploded");
+      },
+    };
+
+    plugin = new McpMultiplexerPlugin({
+      configPath: cfg,
+      settingsView: makeMuxSettingsView({
+        webEnabled: true,
+        shared: ["alpha"],
+        sessionPersistenceEnabled: true,
+        sessionPersistencePath: join(tmpDir, "sessions"),
+      }),
+      persistenceFactory: () => store as unknown as SessionPersistenceStore,
+      gcTickMs: 0,
+    });
+    await plugin.start();
+    gateway = startTestGateway();
+
+    const ident = plugin.issueIdentity("pty-throw");
+    const conn = await connectClient({
+      origin: gateway.origin,
+      server: "alpha",
+      ptyId: "pty-throw",
+      bearer: ident.headers.Authorization,
+    });
+    await conn.client.callTool({ name: "echo", arguments: { message: "pre-delete" } });
+
+    const handler = plugin._getHandler("alpha");
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual(["pty-throw"]);
+
+    // The assertion IS the absence of a throw: `terminateSession()` raises on
+    // any non-2xx (405 excepted), so a 500 from a poisoned callback fails here.
+    await conn.transport.terminateSession();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // And the bucket still went with the session it belonged to.
+    expect((handler?.health() as { bucket_keys: string[] }).bucket_keys).toEqual([]);
+
+    await conn.close();
+  });
+});

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -948,11 +948,26 @@ export class McpHttpHandler {
         // `400 -32600 "Server already initialized"`. Guard on transport
         // identity so a bucket already replaced by the reinitialize path
         // above is not evicted out from under its successor.
-        if (this_buckets.get(bucketKey)?.transport === transport) {
-          this_buckets.delete(bucketKey);
+        //
+        // The body is wrapped because of WHERE this callback sits, not
+        // because of what it does. `handleDeleteRequest` runs
+        // `await this._onsessionclosed?.(...)` and only THEN
+        // `await this.close()` — so a throw in here skips the SDK's own
+        // teardown while the bucket is already out of the map, leaving it
+        // unreachable by both `stop()` and `releasePty()`. Nothing below
+        // can throw today (`drop()` is `async`, so it rejects rather than
+        // throwing), which is exactly how the `audit.append` blocker on
+        // the sibling PR looked right up until a signature changed.
+        try {
+          if (this_buckets.get(bucketKey)?.transport === transport) {
+            this_buckets.delete(bucketKey);
+          }
+          if (!persistence || stateless) return;
+          persistence.drop(serverName, bucketKey).catch(() => {});
+        } catch {
+          // Deliberately swallowed: the caller's `close()` is worth more
+          // than this callback's bookkeeping.
         }
-        if (!persistence || stateless) return;
-        persistence.drop(serverName, bucketKey).catch(() => {});
       },
     });
     await sdkServer.connect(transport);


### PR DESCRIPTION
Follow-up to #354, which merged while this was in flight.

## What the report was

Copilot flagged `onsessionclosed` in `http-handler.ts` for deleting the bucket from `this.buckets` without closing the underlying SDK `Server` or HTTP transport, and read that as a leak: once the entry is gone from the map, neither `stop()` nor `releasePty()` can reach it to close it either.

## Why that reading is wrong

The SDK closes itself. `handleDeleteRequest` runs the callback and then immediately tears down:

```js
await Promise.resolve(this._onsessionclosed?.(this.sessionId));
await this.close();
```
<sub>`@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js:576-577`</sub>

`transport.close()` fires `onclose`, which `Protocol` wires to `_onclose()` — clearing the timeout handles, aborting every in-flight request handler, and dropping `_transport`. And `Server.close()` is only `await this._transport?.close()`, so calling it here would be a second close of a transport the SDK already closed. Nothing waits on GC.

## What the report does point at

The ordering. This callback runs **in front of** the SDK's own teardown, and by the time it returns the bucket is already out of the map. So a throw inside it skips `await this.close()` *and* leaves the bucket unreachable from `stop()` and `releasePty()` — the state Copilot described, reached by a different route than the one it named.

Nothing in the body can throw today: `drop()` is `async`, so it rejects rather than throwing and the `.catch()` always attaches. That is a property of a signature, not of this code, and it is exactly how the `audit.append` defect on the sibling PR looked right up until it wasn't. Guard the class, not the line.

## The test

Poisons `drop` with a **synchronous** throw — not a rejected promise — and asserts the client's `terminateSession()` DELETE still comes back clean. Verified to fail on its own mutation: without the try/catch the DELETE answers `500`.

It lives in `mcp-multiplexer-integration.test.ts` rather than beside the persistence tests on purpose. `session-persistence-integration.test.ts` is the natural home, but the test job's path list deliberately excludes it for the load-sensitive flake tracked in #326 — a test placed there would gate nothing. Using an in-memory stand-in for the store instead of the real one keeps this test off disk and out of that flake's way.

## Gates

- `bun run lint` exit 0
- typecheck ratchet 153, baseline 153 — unchanged
- `mcp-multiplexer-integration.test.ts`: 13 pass / 0 fail
