### PR TITLE
fix(bus): a spinner-only auto-compaction is read as a started turn, silently losing the prompt

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.228",
+      "version": "2.2.229",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.228",
+  "version": "2.2.229",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -428,3 +428,289 @@ describe("PtyAgentProcess CHA-collapsed REPL footer (#271)", () => {
     expect(writes).toEqual([]); // disengaged -> no key into a live REPL
   });
 });
+
+describe("PtyAgentProcess compaction latch", () => {
+  // The real CLI paints "Compacting conversation…" ONCE and then renders a bare
+  // spinner. The confirm loop clears `recentOut` at the top of every window, so
+  // an in-window probe only sees the banner if the CLI repaints it inside that
+  // slice. When the inbound prompt is what pushed the context over the limit the
+  // compaction starts BEFORE the prompt is written, so the banner is already
+  // gone at the first reset. The window then reads "non-empty output, no idle
+  // footer" and the loop declares a turn that never started.
+  //
+  // These cases assert on PTY writes only, so they hold regardless of how a
+  // turn-start is reported to callers.
+  it("retypes when the compaction leaves the REPL idle (the prompt was swallowed)", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 30,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 5000,
+    });
+    emit("\nCompacting conversation… (esc to interrupt)"); // painted once, before the prompt
+    const p = proc.send_prompt_stream("hello");
+    let compacting = true;
+    const iv = setInterval(
+      () => emit(compacting ? "\n⠋" : "\n⏵ accept edits on (shift+tab to cycle)"),
+      5,
+    );
+    setTimeout(() => {
+      compacting = false;
+      emit("\nCompacted (ctrl+o to see full summary)");
+    }, 150);
+    await p;
+    clearInterval(iv);
+    // The compaction re-rendered the REPL and left it idle, so the prompt is
+    // gone from the input box: a bare CR would submit nothing. Retype once.
+    expect(writes.filter((w) => w === "hello").length).toBe(2);
+    // The footer never gives way to a streaming turn, so the loop ends on a
+    // give-up and clears the stranded input line LAST. An earlier \x15 belongs
+    // to the retype, so only the final write separates the two outcomes.
+    expect(writes[writes.length - 1]).toBe("\x15");
+  });
+
+  it("does NOT retype when the turn is already streaming after the compaction", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 30,
+      maxSubmitNudges: 3,
+      maxCompactionWaitMs: 5000,
+    });
+    emit("\nCompacting at auto window");
+    const p = proc.send_prompt_stream("hello");
+    let phase: "compacting" | "streaming" = "compacting";
+    const iv = setInterval(
+      () => emit(phase === "compacting" ? "\n⠙" : "\nassistant is streaming a chunk"),
+      5,
+    );
+    setTimeout(() => {
+      emit("\nCompacted (ctrl+o to see full summary)");
+      phase = "streaming";
+    }, 120);
+    await p;
+    clearInterval(iv);
+    // The CLI buffered the keystrokes through the compaction and submitted them
+    // itself: a turn IS running. Retyping here would push the same prompt into a
+    // live turn and run it twice.
+    expect(writes.filter((w) => w === "hello").length).toBe(1);
+    expect(writes).not.toContain("\x15");
+  });
+
+  it("a spinner frame does not clear the latch once compaction is seen", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 300,
+    });
+    emit("\nCompacting conversation…");
+    const p = proc.send_prompt_stream("hello");
+    // Nothing but spinner frames, forever: the latch must hold, so the loop waits
+    // out maxCompactionWaitMs instead of reading the spinner as a live turn.
+    const iv = setInterval(() => emit("\n⠸"), 5);
+    const t0 = Date.now();
+    await p;
+    const elapsed = Date.now() - t0;
+    clearInterval(iv);
+    // 200ms pre-CR settle + the full 300ms compaction deadline. An in-window
+    // probe that misses the banner returns at ~220ms (settle + one 20ms window),
+    // so this threshold discriminates instead of being met by the settle alone.
+    // Headroom below the ~500ms nominal (200ms settle + 300ms budget): a loaded
+    // box only makes real timers fire LATE, so the discriminating gap is against
+    // the ~220ms an early false turn-start would take, not against the ceiling.
+    expect(elapsed).toBeGreaterThanOrEqual(400);
+    expect(writes.filter((w) => w === "\r").length).toBe(1); // no nudge spent
+  });
+
+  it("clears the latch when the end marker is split across PTY chunks", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 30,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 5000,
+    });
+    emit("\nCompacting conversation…");
+    const p = proc.send_prompt_stream("hello");
+    let compacting = true;
+    const iv = setInterval(
+      () => emit(compacting ? "\n⠋" : "\n⏵ accept edits on (shift+tab to cycle)"),
+      5,
+    );
+    setTimeout(() => {
+      compacting = false;
+      // The marker arrives in two pieces, as a real PTY read boundary would
+      // deliver it. Detecting on a single chunk misses this and leaves the
+      // latch armed for the rest of the process's life.
+      emit("\nCompact");
+      emit("ed (ctrl+o to see full summary)");
+    }, 120);
+    await p;
+    clearInterval(iv);
+    expect(writes.filter((w) => w === "hello").length).toBe(2); // latch cleared -> retype ran
+  });
+
+  it("does not retype when a short buffered turn started and finished in one window", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 40,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 5000,
+    });
+    emit("\nCompacting conversation…");
+    const p = proc.send_prompt_stream("hello");
+    let phase: "compacting" | "burst" | "idle" = "compacting";
+    const iv = setInterval(() => {
+      if (phase === "compacting") emit("\n⠋");
+      else if (phase === "idle") emit("\n⏵ accept edits on (shift+tab to cycle)");
+    }, 5);
+    setTimeout(() => {
+      emit("\nCompacted (ctrl+o to see full summary)");
+      phase = "burst";
+      // The CLI had buffered the keystrokes and ran the turn itself. It is short
+      // enough that its output AND the repainted idle footer land in the SAME
+      // confirm window — so the footer alone cannot be read as "no turn ran".
+      emit("\nassistant answered already\n⏵ accept edits on (shift+tab to cycle)");
+      phase = "idle";
+      // 260ms: past the 200ms pre-CR settle, so this lands INSIDE a confirm
+      // window rather than before the loop starts.
+    }, 260);
+    await p;
+    clearInterval(iv);
+    expect(writes.filter((w) => w === "hello").length).toBe(1); // no duplicate submit
+  });
+
+  it("retypes even when output appeared BEFORE the compaction started", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 40,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 5000,
+    });
+    const p = proc.send_prompt_stream("hello");
+    // Window 1: the REPL is idle and repaints its bottom chrome — the input box
+    // still holding the un-submitted prompt, plus the footer. That echoed line is
+    // non-footer output, but it proves nothing about a turn: treating it as
+    // evidence would gate off the retype below and drop the prompt silently.
+    let phase: "echo" | "compacting" | "idle" = "echo";
+    const iv = setInterval(() => {
+      if (phase === "echo") emit("\n> hello\n⏵ accept edits on (shift+tab to cycle)");
+      else if (phase === "compacting") emit("\n⠋");
+      else emit("\n⏵ accept edits on (shift+tab to cycle)");
+    }, 5);
+    setTimeout(() => {
+      phase = "compacting";
+      emit("\nCompacting conversation… (esc to interrupt)");
+    }, 260);
+    setTimeout(() => {
+      phase = "idle";
+      emit("\nCompacted (ctrl+o to see full summary)");
+    }, 420);
+    await p;
+    clearInterval(iv);
+    expect(writes.filter((w) => w === "hello").length).toBe(2); // retype still runs
+  });
+
+  it("counts non-ASCII turn output as evidence (no duplicate submit)", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 40,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 5000,
+    });
+    emit("\nCompacting conversation…");
+    const p = proc.send_prompt_stream("hello");
+    let phase: "compacting" | "idle" = "compacting";
+    const iv = setInterval(() => {
+      if (phase === "compacting") emit("\n⠋");
+      else emit("\n⏵ accept edits on (shift+tab to cycle)");
+    }, 5);
+    setTimeout(() => {
+      emit("\nCompacted (ctrl+o to see full summary)");
+      // The buffered turn ran and its visible output is entirely non-ASCII —
+      // emoji and box-drawing tool chrome, no Latin text. Filtering the window
+      // down to ASCII would erase it, read "no turn ran", and retype into the
+      // live turn.
+      emit("\n╭──────────╮\n│ ✅ 🎉 📦 │\n╰──────────╯\n⏵ accept edits on (shift+tab to cycle)");
+      phase = "idle";
+    }, 260);
+    await p;
+    clearInterval(iv);
+    expect(writes.filter((w) => w === "hello").length).toBe(1);
+  });
+
+  it("a prompt whose own text contains the banner does not arm the latch", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 30,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 2000,
+    });
+    const poisoned = "explain what Compacting conversation means";
+    const t0 = Date.now();
+    const p = proc.send_prompt_stream(poisoned);
+    // The CLI echoes the typed text back on the output stream. Matching markers
+    // against that echo lets any chat message arm a sticky, process-wide latch
+    // and stall the serialised write chain for the whole compaction budget.
+    const iv = setInterval(() => {
+      emit("\n> " + poisoned);
+      emit("\nassistant is streaming a chunk");
+    }, 5);
+    await p;
+    const elapsed = Date.now() - t0;
+    clearInterval(iv);
+    // A real turn is streaming, so this must confirm on the first window
+    // (~230ms). If the echo armed the latch the loop would instead wait out
+    // maxCompactionWaitMs and only return after ~2200ms.
+    expect(elapsed).toBeLessThan(1000);
+    expect(writes.filter((w) => w === "\r").length).toBe(1); // confirmed, no nudge
+  });
+
+  it("strips the echo as the TUI actually renders it (bordered input box)", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 30,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 2000,
+    });
+    const poisoned = "explain what Compacting conversation means";
+    const t0 = Date.now();
+    const p = proc.send_prompt_stream(poisoned);
+    // The real TUI paints the input box with borders and padding. Stripping only
+    // the LEADING glyphs leaves the trailing bar, the echo stops matching what we
+    // typed, and remote text reaches the marker probes again.
+    const iv = setInterval(() => {
+      emit("\n│ > " + poisoned + "        │");
+      emit("\nassistant is streaming a chunk");
+    }, 5);
+    await p;
+    const elapsed = Date.now() - t0;
+    clearInterval(iv);
+    expect(elapsed).toBeLessThan(1000);
+    expect(writes.filter((w) => w === "\r").length).toBe(1);
+  });
+
+  it("keeps the real footer when the prompt quotes it verbatim (Copilot #359)", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 30,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 5000,
+    });
+    // A plausible prompt: the user pastes a CLI transcript that contains the
+    // idle footer verbatim. Stripping every line that is merely a substring of
+    // what we typed would erase the CLI's OWN footer, so an idle REPL would read
+    // as a started turn and the prompt would be dropped — the inverse of the
+    // echo-poisoning this filter exists to stop.
+    const quoted = "regarde ce transcript: accept edits on (shift+tab to cycle) — explique-moi";
+    const p = proc.send_prompt_stream(quoted);
+    const iv = setInterval(() => {
+      emit("\n⏵ accept edits on (shift+tab to cycle)");
+      emit("\nassistant is streaming a chunk");
+    }, 5);
+    await p;
+    clearInterval(iv);
+    // Footer preserved ⇒ the REPL is correctly seen as idle ⇒ the loop nudges
+    // instead of declaring a turn. 1 initial submit + 2 nudges.
+    expect(writes.filter((w) => w === "\r").length).toBe(3);
+  });
+});

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -119,6 +119,106 @@ export class PtyAgentProcess implements AgentProcess {
   /** ANSI-stripped tail of PTY output, reset after each submit so the
    *  delivery-confirm check only inspects post-submit frames (#wedge). */
   private recentOut = "";
+  /**
+   * Sticky auto-compaction state, maintained on the DATA STREAM rather than
+   * sampled from `recentOut`.
+   *
+   * Why sticky: the delivery-confirm loop clears `recentOut` at the top of every
+   * confirm window, so an in-window `includes("Compacting…")` probe only sees the
+   * banner if the CLI happens to REPAINT that phrase inside that 1.5s slice. The
+   * real CLI paints it once and then renders a bare spinner -- and when the
+   * compaction started BEFORE the prompt arrived (the common case: the inbound
+   * prompt is what pushed the context over the limit) the banner is emitted
+   * before the loop even begins and is wiped by the first reset. The probe then
+   * sees "non-empty output, no idle footer" and declares a turn started that
+   * never existed. Dossier 20260825T071822: compaction at 11:12:35, prompt
+   * written 11:12:36.8, false turn-start stamped 11:12:38.313.
+   */
+  private compacting = false;
+  /** Incremented on every compaction START, so a compaction that begins AND ends
+   *  between the prompt write and the first confirm window is still observable. */
+  private compactionEpoch = 0;
+  /** Small rolling buffer used ONLY for compaction-marker detection. Separate
+   *  from `recentOut` because the confirm loop clears that one, and a marker
+   *  split across two PTY chunks would otherwise be missed -- missing the CLEAR
+   *  would latch `compacting` forever and make every later prompt burn the full
+   *  `maxCompactionWaitMs`. */
+  private markerTail = "";
+  /** The exact text last typed into the PTY. The output stream echoes it back,
+   *  so without excluding it a chat message containing "Compacting conversation"
+   *  would arm the latch below — remote text controlling a process-wide, sticky
+   *  state. The pre-image was window-scoped so poisoning cost ~1.5s; a sticky
+   *  latch costs `maxCompactionWaitMs` (240s) on a write chain that serialises
+   *  EVERY prompt for the agent. The inverse is just as bad: text containing
+   *  "to cycle" would clear a genuine compaction. This is not only an abuse
+   *  case — an agent discussing its own compaction logic reproduces these
+   *  strings in ordinary output. */
+  private lastWritten = "";
+  /** Cap on the text `stripEcho` matches against — see where it is assigned. */
+  private static readonly ECHO_MATCH_MAX = 4096;
+
+  /**
+   * Remove our own echo from a slice of PTY output.
+   *
+   * The CLI renders the prompt we typed in its input box, so the text a chat
+   * user sent comes straight back on the output stream. Every probe in this file
+   * reads that stream, which means remote text can impersonate CLI status lines:
+   * a message containing "Compacting conversation" makes the delivery loop wait
+   * out `maxCompactionWaitMs` (240s by default) on a write chain that serialises
+   * EVERY prompt for the agent, and one containing "to cycle" makes a genuine
+   * compaction look finished.
+   *
+   * SCOPE, precisely: this removes OUR OWN ECHO only — lines that are a
+   * substring of the prompt we just typed. Model OUTPUT containing the same
+   * strings still arms the latch; that path is bounded because the idle footer
+   * repaint clears it at turn end, but it is NOT closed here. Do not read this
+   * helper as covering "an agent that discusses its own compaction logic".
+   *
+   * It also cuts both ways: a prompt that is a pasted CLI transcript containing
+   * "to cycle" makes the genuine footer line a substring of `lastWritten`, so it
+   * is stripped from every window and an idle REPL reads as a started turn. That
+   * is the pre-patch behaviour, not a new regression, but it is a live
+   * false-positive path for a plausible prompt.
+   *
+   * Filter by LINE rather than by exact occurrence: the buffers are rolling, so
+   * the echo is routinely truncated mid-string and an exact match would leave a
+   * fragment that still carries the marker. A line that is itself a substring of
+   * what we typed is our echo; a genuine CLI status line never is.
+   */
+  private stripEcho(s: string): string {
+    if (this.lastWritten.length < 8) return s;
+    return s
+      .split("\n")
+      .filter((l, i) => {
+        // TWO conditions, both required.
+        //
+        // (a) The row must LOOK like the input box: optional border/padding
+        //     glyphs, then the prompt caret `>`. The TUI paints our text as
+        //     `| > <text>  ...padding... |`, while CLI status lines start with a
+        //     letter ("Compacting conversation…") and the idle footer with its
+        //     own glyph and no caret ("> accept edits … to cycle" has no caret
+        //     before "accept"). Without this, a prompt that merely CONTAINS
+        //     "Compacting conversation" or "to cycle" would strip the CLI's own
+        //     status and footer lines, killing detection and reintroducing the
+        //     dropped-prompt wedge — the inverse of the bug this helper fixes.
+        //
+        // (b) The content must be a substring of what we typed. Strip BOTH ends
+        //     first: keeping the trailing border made the match fail and let the
+        //     echo through.
+        // The FIRST line is the only one the rolling buffer can have truncated
+        // mid-way, which strips its caret. Judge that one on content alone; every
+        // other line must show the caret to count as our echo.
+        if (i > 0 && !/^[^A-Za-z0-9]*>/.test(l)) return true;
+        const bare = l
+          .replace(/^[^A-Za-z0-9]*>/, "")
+          .replace(/[^A-Za-z0-9]+$/, "")
+          .trim();
+        return bare.length < 8 || !this.lastWritten.includes(bare);
+      })
+      .join("\n");
+  }
+  /** When the latch was armed, so a missed clear cannot strand it indefinitely. */
+  private compactingSince = 0;
   private readonly submitConfirmMs: number;
   private readonly maxSubmitNudges: number;
   private readonly maxCompactionWaitMs: number;
@@ -177,7 +277,33 @@ export class PtyAgentProcess implements AgentProcess {
       // Keep a small ANSI-stripped tail so send_prompt_stream can tell whether a
       // submit actually started a turn (the idle REPL footer disappears on turn
       // start) -- see the delivery-confirm loop. Observation only.
-      this.recentOut = (this.recentOut + stripAnsiEscapes(chunk)).slice(-2000);
+      const cleanChunk = stripAnsiEscapes(chunk);
+      this.recentOut = (this.recentOut + cleanChunk).slice(-2000);
+      // Sticky compaction latch (see `compacting`): set on the banner, cleared
+      // only on POSITIVE evidence the compaction ended -- the "Compacted"
+      // confirmation or the idle REPL footer coming back. A spinner frame in
+      // between must NOT clear it.
+      this.markerTail = (this.markerTail + cleanChunk).slice(-400);
+      const markerView = this.stripEcho(this.markerTail);
+      // Compare the LAST position of a start marker against the last position of
+      // an end marker, so whichever happened most recently wins. A plain
+      // set-then-else-clear would stay latched whenever both strings are still
+      // in the buffer, and testing a single chunk would miss a marker split
+      // across a chunk boundary.
+      const iStart = Math.max(
+        markerView.lastIndexOf("Compacting conversation"),
+        markerView.lastIndexOf("Compacting at auto"),
+      );
+      const endMatches = [...markerView.matchAll(/Compacted \(|to\s*cycle/g)];
+      const iEnd = endMatches.length ? (endMatches[endMatches.length - 1].index ?? -1) : -1;
+      if (iStart >= 0 || iEnd >= 0) {
+        const nowCompacting = iStart > iEnd;
+        if (nowCompacting && !this.compacting) {
+          this.compactionEpoch++;
+          this.compactingSince = Date.now();
+        }
+        this.compacting = nowCompacting;
+      }
       // Crash-signal observation ONLY (spec §5.3). Never parsed as model output.
       for (const h of this.dataHandlers) {
         try {
@@ -241,6 +367,22 @@ export class PtyAgentProcess implements AgentProcess {
     const text = sanitizePtyPromptText(line);
     const run = this.writeChain.then(async () => {
       if (this._exited) throw new Error(`agent ${this.agent_id} has exited`);
+      // Snapshot the compaction state at write time. A compaction that was
+      // ALREADY running when the prompt arrived (the common case -- the inbound
+      // prompt is what overflowed the context) can also FINISH during the 200ms
+      // settle below, i.e. before the confirm loop ever looks. Both the live
+      // latch and the epoch counter are captured so neither case is missed.
+      // A prompt must not inherit the previous one's markers: the buffer is
+      // rolling and 400 chars of A's output can still be resident when B lands.
+      this.markerTail = "";
+      // Bound what the echo filter scans. `text` is caller-supplied and only
+      // length-bounded by the adapter, while `stripEcho` runs `includes()` per
+      // line on EVERY PTY chunk -- an oversized prompt would make each chunk
+      // cost O(prompt x lines) for the life of the process. The input box only
+      // ever echoes a screenful, so the head is the part that can come back.
+      this.lastWritten = text.slice(0, PtyAgentProcess.ECHO_MATCH_MAX);
+      const compactingAtWrite = this.compacting;
+      const compactionEpochAtWrite = this.compactionEpoch;
       this.pty.write(text);
       await new Promise((r) => setTimeout(r, 200));
       if (this._exited) throw new Error(`agent ${this.agent_id} has exited`);
@@ -273,6 +415,16 @@ export class PtyAgentProcess implements AgentProcess {
       // surfaced, since a silently-dropped prompt is the failure this loop fixes.
       const compactionDeadline = Date.now() + this.maxCompactionWaitMs;
       let outcome: "turn-started" | "stuck-compaction" | "unconfirmed-idle" = "unconfirmed-idle";
+      let sawCompaction = compactingAtWrite || this.compactionEpoch !== compactionEpochAtWrite;
+      let retypedAfterCompaction = false;
+      // Latched as soon as any window shows real output that is neither the idle
+      // footer nor compaction chatter. If the CLI buffered the keystrokes through
+      // the compaction and ran the turn itself, that turn's output lands here --
+      // and a short turn can start AND finish inside one confirm window, so the
+      // same window can hold both the output and the repainted footer. Without
+      // this latch the footer alone would read as "no turn ran" and the retype
+      // would submit the prompt a second time.
+      let turnEvidenceSinceCompaction = false;
       for (let nudge = 0; nudge < this.maxSubmitNudges; ) {
         this.recentOut = "";
         await new Promise((r) => setTimeout(r, this.submitConfirmMs));
@@ -287,16 +439,83 @@ export class PtyAgentProcess implements AgentProcess {
         // streaming that word would otherwise be mistaken for a compaction and
         // stall this loop -- and the serialised writeChain behind it -- up to the
         // deadline.
+        // Every probe below reads this echo-free view, never `recentOut`
+        // directly: our own prompt text must not be able to impersonate a CLI
+        // status line, an idle footer, or turn output.
+        const visible = this.stripEcho(this.recentOut);
+        if (this.compactionEpoch !== compactionEpochAtWrite) sawCompaction = true;
+        // A latch that never saw its clear (marker lost) must not strand the
+        // process: treat it as stale once it outlives the compaction budget.
         if (
-          this.recentOut.includes("Compacting conversation") ||
-          this.recentOut.includes("Compacting at auto")
+          this.compacting &&
+          this.compactingSince > 0 &&
+          Date.now() - this.compactingSince > 2 * this.maxCompactionWaitMs
         ) {
+          this.compacting = false;
+          // Also drop the buffer: leaving the start marker resident means the
+          // next chunk re-evaluates it, sees `!compacting`, and re-arms with a
+          // fresh budget — the escape hatch would never actually fire.
+          this.markerTail = "";
+          // Do not judge THIS window: it still holds the output of the
+          // compaction that is (apparently) still running, and reading it as a
+          // started turn is the exact regression the latch exists to prevent.
+          if (Date.now() > compactionDeadline) {
+            outcome = "stuck-compaction";
+            break;
+          }
+          continue;
+        }
+        if (
+          this.compacting ||
+          visible.includes("Compacting conversation") ||
+          visible.includes("Compacting at auto")
+        ) {
+          sawCompaction = true;
+          // Evidence of a running turn only means anything AFTER the compaction:
+          // before it, the echoed input line (the prompt sitting un-submitted in
+          // the box) is itself non-footer output and would gate the retype off.
+          turnEvidenceSinceCompaction = false;
           if (Date.now() > compactionDeadline) {
             outcome = "stuck-compaction";
             break;
           }
           continue; // compaction in progress -> wait, do not spend a nudge
         }
+        const footerVisible = /to\s*cycle/.test(visible);
+        // Everything in this window that is not a footer repaint and not a
+        // spinner glyph. Printable ASCII only, so box-drawing and braille
+        // spinner frames do not register as output.
+        // Drop footer repaints and compaction chatter LINE BY LINE, not
+        // window-wide: the window in which a short buffered turn finishes also
+        // carries the "Compacted (…)" line, so discarding the whole window on
+        // that basis would throw away the very output that proves a turn ran.
+        const nonFooterOutput = visible
+          .split("\n")
+          .filter((l) => !/to\s*cycle/.test(l) && !/Compact(ing|ed)/.test(l))
+          .join("")
+          // Drop spinner frames and whitespace ONLY. Stripping everything
+          // non-ASCII would erase a turn whose output is emoji or box-drawing
+          // chrome, read the window as "no turn ran", and retype into a live
+          // turn — the one path that submits a prompt twice.
+          .replace(/[\u2800-\u28ff\u2500-\u257f\u25a0-\u25ff\u2022\u00b7\s]/g, "")
+          .trim();
+        if (nonFooterOutput.length > 0) {
+          turnEvidenceSinceCompaction = true;
+        }
+        // The compaction's own tail ("Compacted (ctrl+o …)") is non-empty output
+        // with no idle footer -- i.e. it looks exactly like a streaming turn to
+        // the check below. It is not evidence of anything: stay inconclusive
+        // (bounded by the same deadline) rather than spend a nudge on it.
+        // Only "Compacted (" is reachable here: the two "Compacting…" markers are
+        // already `continue`d by the branch above.
+        if (!footerVisible && visible.includes("Compacted (")) {
+          if (Date.now() > compactionDeadline) {
+            outcome = "stuck-compaction";
+            break;
+          }
+          continue;
+        }
+
         // A turn-start is POSITIVE evidence -- the streaming view replaced the
         // footer. An EMPTY confirm window is NOT that: a long-idle, quiet REPL
         // emits nothing, so `!/to\s*cycle/.test(...)` on an empty buffer falsely
@@ -307,13 +526,32 @@ export class PtyAgentProcess implements AgentProcess {
         // fix stack already active). Require real output before trusting the
         // footer's absence; an empty/whitespace window stays inconclusive and
         // spends a nudge instead of claiming a phantom success.
-        if (this.recentOut.trim().length > 0 && !/to\s*cycle/.test(this.recentOut)) {
+        if (visible.trim().length > 0 && !footerVisible) {
           outcome = "turn-started";
           // A turn confirmed → re-arm the one-shot wedge warning, so a LATER
           // genuine wedge on this long-lived process still surfaces a diagnostic
           // instead of being silenced for the rest of the process lifetime.
           this.warnedUnconfirmedDelivery = false;
           break;
+        }
+        // Only now, with the idle footer positively on screen (so no turn is
+        // running), consider that a compaction wiped the input box. Retyping
+        // without that gate would push a duplicate prompt into a live turn if
+        // the CLI had buffered the keystrokes and submitted them itself.
+        if (
+          sawCompaction &&
+          !retypedAfterCompaction &&
+          footerVisible &&
+          !turnEvidenceSinceCompaction
+        ) {
+          retypedAfterCompaction = true;
+          if (this._exited) throw new Error(`agent ${this.agent_id} has exited`);
+          this.pty.write("\x15"); // clear whatever survived the re-render
+          this.pty.write(text);
+          await new Promise((r) => setTimeout(r, 200));
+          if (this._exited) throw new Error(`agent ${this.agent_id} has exited`);
+          this.pty.write("\r");
+          continue; // the retype is not a nudge
         }
         this.pty.write("\r"); // footer still idle (or silent) -> CR did not submit -> nudge
         nudge++;
@@ -328,6 +566,10 @@ export class PtyAgentProcess implements AgentProcess {
         // clearing on any non-turn-started outcome is safe and symmetric.
         this.pty.write("\x15"); // Ctrl-U: kill the input line
       }
+      // The prompt is no longer in the input box once this resolves, so the echo
+      // filter has nothing left to match. Clearing it keeps the filter from
+      // running against unrelated output for the whole idle period after a turn.
+      this.lastWritten = "";
       if (outcome !== "turn-started" && !this.warnedUnconfirmedDelivery) {
         this.warnedUnconfirmedDelivery = true;
         console.warn(


### PR DESCRIPTION
## The bug

`PtyAgentProcess.send_prompt_stream` confirms delivery by sampling `recentOut`
inside a `submitConfirmMs` window. It probes for an in-flight auto-compaction with

```ts
this.recentOut.includes("Compacting conversation") || this.recentOut.includes("Compacting at auto")
```

but `recentOut` is cleared at the top of **every** confirm window:

```ts
for (let nudge = 0; nudge < this.maxSubmitNudges; ) {
  this.recentOut = "";                    // <-- the banner is discarded here
  await new Promise((r) => setTimeout(r, this.submitConfirmMs));
```

So the probe only fires if the CLI **repaints** that banner inside the sampled
slice. It does not — the banner is painted once and the rest of the compaction
renders as a bare spinner. And in the most common case the compaction starts
*before* the prompt is written (the inbound prompt is what pushed the context
over the limit), so the banner is already gone when the first reset runs.

The window then reads "non-empty output, no idle footer", which the loop treats
as positive evidence of a turn:

```ts
if (this.recentOut.trim().length > 0 && !/to\s*cycle/.test(this.recentOut)) {
  outcome = "turn-started";
  opts?.onTurnStarted?.();
```

It stamps `turn_started_at` and reports success for a prompt that was never
submitted — the compaction had seized the REPL and swallowed the submit CR. The
message is lost, and the only signal is a receipt that times out five minutes
later.

## Why this also corrupts the wedge discriminator

`turn_started_at` is stamped **inside** the loop; `stdin_written_at` is stamped
by `createPromptStreamHandler` only **after** `send_prompt_stream` resolves. So
whenever this false positive fires, `turn_started_at` lands a millisecond or two
*before* `stdin_written_at`.

Across 109 timeout receipts on a long-running deployment: 36 carry
`turn_started_at`, and **24 of those 36 sit within 5ms of `stdin_written_at`**
(median 0ms, min −1ms). Only 12 show a delta above one second. Forensic tooling
that reads "`turn_started_at` present ⇒ the turn started, the reply was lost
downstream" is therefore misreading two thirds of these cases and pointing
investigation downstream of a failure that is upstream.

## The fix

1. **Latch the compaction on the data stream** instead of sampling a buffer that
   gets cleared. Set on the banner in `onData`; cleared only on positive
   end-evidence (`Compacted`, or the idle footer returning). A spinner frame in
   between does not clear it.
2. **Snapshot the latch and a compaction-start epoch at write time**, so a
   compaction that both starts and ends during the 200ms settle is still
   observed by the loop that runs afterwards.
3. **Retype the prompt once after a compaction.** The compaction re-renders the
   REPL, so the typed text is no longer in the input box — a bare CR nudge would
   submit an empty line and lose the prompt silently, which is the exact failure
   this loop exists to prevent.

## Tests

Three cases in `session-agent-process.test.ts` that reproduce the wedge: the
banner is painted **once**, then spinner frames only.

The pre-existing compaction test emitted `"Compacting conversation…"` every 8ms
for the whole compaction, so the marker was present in every sampled window —
which is why the gap survived. The new tests drop that assumption.

All three fail on the unpatched loop. The third lands at 223ms, matching the
predicted false turn-start (200ms pre-CR settle + one 20ms confirm window).

- Target file: 23 pass / 0 fail (was 20 pass, 3 fail with the new tests).
- Full suite: **164 fail / 109 errors before and after** — unchanged,
  pre-existing, no regressions. Pass count 1662 → 1665, the three new tests.
- `tsc --noEmit`: single error, outside the touched file, pre-existing.
- Biome clean.


## Known limitation

This narrows the failure. It does not close it. Confirmed in production on
2026-08-27, after this branch was deployed:

```
14:02:15.474Z  prompt received
14:02:15       /compact starts — same second
14:04:43       "Compacted (ctrl+o to see full summary)"  — 2m28s of compaction
14:04:47.206Z  turn_started_at  ─┐  delta 0 ms
14:04:47.206Z  stdin_written_at ─┘
               no end_turn in the session for that window
               prompt never answered
```

One compaction that day. One lost prompt.

**What the patch does get right.** The sticky latch held for the full 2m28s
without burning a single nudge and without emitting a warning — the
`delivery-confirm` counter was unchanged and `stuck-compaction` stayed at zero.
That half works, and it is why this is worth landing.

**Where it still fails.** Roughly four seconds *after* the compaction ends, the
loop concludes a turn started. The guard meant to cover that window keys on the
literal `Compacted (` still being present in the sampled tail. Once that string
scrolls out of the rolling buffer while the CLI keeps repainting the restored
transcript, the next window contains real text and no idle footer — precisely
the shape the loop treats as positive evidence of a turn.

This is **not version drift**: `to cycle`, `Compacting conversation`,
`Compacting at auto` and `Compacted` are all still present in the CLI binary
(checked against 2.1.247).

**Why a fourth guard would not settle it.** Every probe in this loop reads the
rendered terminal, and on that surface "the CLI submitted my text" and "the CLI
drew something" are the same bytes. Each guard added so far trades one failure
for its inverse rather than removing the ambiguity — three rounds of review
(security, adversarial, Copilot) each found a real defect in the previous
round's guard. That pattern is the tell: the input to the decision does not
carry the distinction being asked of it.

**The direction that does settle it** is an authoritative signal from outside
the terminal rendering. The runtime already tails the session JSONL —
`jsonl-tailer` attaches per agent at boot and feeds `ingestSessionEvent` — and
the transcript records a `user` entry when the CLI actually ingests a prompt.
Tracked in #362, which also lists the constraints any such fix has to respect.

Landing this PR is still a net improvement over the current `main`; the
remaining gap is documented rather than silent.
