### PR TITLE
fix(whisper): repair voice transcription on linux-arm64

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.228",
+      "version": "2.2.229",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.229",
+      "version": "2.2.230",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.230",
+      "version": "2.2.231",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.231",
+      "version": "2.2.232",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.231",
+  "version": "2.2.232",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.228",
+  "version": "2.2.229",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.229",
+  "version": "2.2.230",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.230",
+  "version": "2.2.231",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/whisper-binary-source.test.ts
+++ b/src/__tests__/whisper-binary-source.test.ts
@@ -105,7 +105,8 @@ describe("runtime shared libraries", () => {
   test("every library is written beside the binary, not only into lib/", () => {
     // Load-bearing: ggml dlopens its compute backend by searching next to the
     // executable. If this collapses back to lib/ only, the binary still loads
-    // and --help still exits 0, but transcription fails with "backends = 0".
+    // and --help still exits 0, but transcription fails, with whisper-cli reporting `backends   = 0`
+    // at runtime (a printf format, so do not expect to grep it out of the binary).
     const targets = sharedLibTargets("libggml-cpu.so");
     expect(targets).toHaveLength(2);
     expect(targets.some((t) => t.endsWith(`/lib/libggml-cpu.so`))).toBe(true);

--- a/src/__tests__/whisper-binary-source.test.ts
+++ b/src/__tests__/whisper-binary-source.test.ts
@@ -36,6 +36,15 @@ describe("whisper BINARY_SOURCES", () => {
     expect(source?.url).not.toContain("/latest/");
   });
 
+  test("mutable release URLs carry a sha256 pin", () => {
+    // The Homebrew URL this replaced was content-addressed (sha256:... in the
+    // path), so the bytes could not change under us. A GitHub release asset is
+    // name-addressed and re-uploadable, so the digest has to be pinned here
+    // instead — these bytes get chmod 0755'd and executed by the daemon.
+    const source = BINARY_SOURCES["linux-arm64"];
+    expect(source?.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
   test("every source is fully specified", () => {
     for (const [platform, source] of Object.entries(BINARY_SOURCES)) {
       expect(`${platform}: ${source.url}`).toStartWith(`${platform}: https://`);

--- a/src/__tests__/whisper-binary-source.test.ts
+++ b/src/__tests__/whisper-binary-source.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BINARY_SOURCES, binaryIsRunnable, isWhisperSharedLib, sharedLibTargets } from "../whisper";
+
+/**
+ * Regression cover for the linux-arm64 whisper install being unrunnable.
+ *
+ * `linux-arm64` pointed at a Homebrew bottle. Homebrew rewrites the ELF
+ * interpreter at install time; extracting the raw tarball does not, so the
+ * binary kept a literal "@@HOMEBREW_PREFIX@@/lib/ld.so" interpreter and every
+ * exec failed with a misleading ENOENT. Because warmup only checked that the
+ * file *existed*, it never re-downloaded and voice transcription stayed broken
+ * silently for months.
+ */
+describe("whisper BINARY_SOURCES", () => {
+  test("no Linux platform is served a Homebrew bottle", () => {
+    const linuxEntries = Object.entries(BINARY_SOURCES).filter(([k]) => k.startsWith("linux-"));
+    expect(linuxEntries.length).toBeGreaterThan(0);
+
+    for (const [platform, source] of linuxEntries) {
+      // Homebrew bottles are relocatable-by-brew only; their ELF interpreter is
+      // a placeholder that no plain tar extraction will fix.
+      expect(`${platform}:${source.url}`).not.toContain("ghcr.io/v2/homebrew");
+      expect(`${platform}:${source.url}`).not.toContain("homebrew");
+    }
+  });
+
+  test("linux-arm64 uses upstream's official Linux arm64 build", () => {
+    const source = BINARY_SOURCES["linux-arm64"];
+    expect(source).toBeDefined();
+    expect(source?.url).toContain("ggml-org/whisper.cpp/releases");
+    expect(source?.url).toContain("ubuntu-arm64");
+    // A pinned tag, not a floating "latest" that can change under us.
+    expect(source?.url).not.toContain("/latest/");
+  });
+
+  test("every source is fully specified", () => {
+    for (const [platform, source] of Object.entries(BINARY_SOURCES)) {
+      expect(`${platform}: ${source.url}`).toStartWith(`${platform}: https://`);
+      expect(["tar.gz", "zip"]).toContain(source.format);
+    }
+  });
+});
+
+describe("binaryIsRunnable", () => {
+  test("false when the path does not exist", async () => {
+    expect(await binaryIsRunnable(join(tmpdir(), "definitely-not-a-real-whisper-cli"))).toBe(false);
+  });
+
+  test("false for a file that exists but cannot exec", async () => {
+    // Stands in for the real failure: a plausible file that dies at exec time.
+    const dir = await mkdtemp(join(tmpdir(), "whisper-probe-"));
+    const fake = join(dir, "whisper-cli");
+    await writeFile(fake, "not an executable");
+    await chmod(fake, 0o755);
+    expect(await binaryIsRunnable(fake)).toBe(false);
+  });
+
+  test("true for a genuinely runnable binary", async () => {
+    // process.execPath is guaranteed present and exits 0 on --help.
+    expect(await binaryIsRunnable(process.execPath)).toBe(true);
+  });
+});
+
+describe("runtime shared libraries", () => {
+  test("matches libggml as well as libwhisper", () => {
+    // The original filter matched only *whisper* and silently dropped these.
+    expect(isWhisperSharedLib("libggml.so.0")).toBe(true);
+    expect(isWhisperSharedLib("libggml-base.so.0.20.2")).toBe(true);
+    expect(isWhisperSharedLib("libggml-cpu.so")).toBe(true);
+    expect(isWhisperSharedLib("libwhisper.so.1")).toBe(true);
+    expect(isWhisperSharedLib("libwhisper.dylib")).toBe(true);
+  });
+
+  test("ignores non-libraries and unrelated libraries", () => {
+    expect(isWhisperSharedLib("whisper-cli")).toBe(false);
+    expect(isWhisperSharedLib("LICENSE")).toBe(false);
+    expect(isWhisperSharedLib("libparakeet.so.1")).toBe(false);
+  });
+
+  test("every library is written beside the binary, not only into lib/", () => {
+    // Load-bearing: ggml dlopens its compute backend by searching next to the
+    // executable. If this collapses back to lib/ only, the binary still loads
+    // and --help still exits 0, but transcription fails with "backends = 0".
+    const targets = sharedLibTargets("libggml-cpu.so");
+    expect(targets).toHaveLength(2);
+    expect(targets.some((t) => t.endsWith(`/lib/libggml-cpu.so`))).toBe(true);
+    expect(targets.some((t) => t.endsWith(`/bin/libggml-cpu.so`))).toBe(true);
+  });
+});

--- a/src/__tests__/whisper-binary-source.test.ts
+++ b/src/__tests__/whisper-binary-source.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { chmod, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { BINARY_SOURCES, binaryIsRunnable, isWhisperSharedLib, sharedLibTargets } from "../whisper";
+import {
+  BINARY_SOURCES,
+  binaryIsRunnable,
+  isWhisperSharedLib,
+  sharedLibTargets,
+  decideWarmupAction,
+} from "../whisper";
 
 /**
  * Regression cover for the linux-arm64 whisper install being unrunnable.
@@ -16,13 +22,15 @@ import { BINARY_SOURCES, binaryIsRunnable, isWhisperSharedLib, sharedLibTargets 
  */
 describe("whisper BINARY_SOURCES", () => {
   test("no Linux platform is served a Homebrew bottle", () => {
+    // Linux only, deliberately: the darwin entries are still Homebrew bottles.
+    // Mach-O relocation differs from ELF and does not hit the interpreter bug,
+    // and those URLs are content-addressed. Do not widen this to all platforms.
     const linuxEntries = Object.entries(BINARY_SOURCES).filter(([k]) => k.startsWith("linux-"));
     expect(linuxEntries.length).toBeGreaterThan(0);
 
     for (const [platform, source] of linuxEntries) {
       // Homebrew bottles are relocatable-by-brew only; their ELF interpreter is
       // a placeholder that no plain tar extraction will fix.
-      expect(`${platform}:${source.url}`).not.toContain("ghcr.io/v2/homebrew");
       expect(`${platform}:${source.url}`).not.toContain("homebrew");
     }
   });
@@ -36,19 +44,24 @@ describe("whisper BINARY_SOURCES", () => {
     expect(source?.url).not.toContain("/latest/");
   });
 
-  test("mutable release URLs carry a sha256 pin", () => {
-    // The Homebrew URL this replaced was content-addressed (sha256:... in the
-    // path), so the bytes could not change under us. A GitHub release asset is
-    // name-addressed and re-uploadable, so the digest has to be pinned here
-    // instead — these bytes get chmod 0755'd and executed by the daemon.
-    const source = BINARY_SOURCES["linux-arm64"];
-    expect(source?.sha256).toMatch(/^[0-9a-f]{64}$/);
+  test("every mutable URL carries a sha256 pin", () => {
+    // A URL containing /blobs/sha256: is content-addressed — the registry can
+    // only serve those bytes. Anything else (a GitHub release asset) is
+    // name-addressed and re-uploadable, so it needs its digest pinned here.
+    // These bytes get chmod 0755'd and executed with the daemon's environment.
+    for (const [platform, source] of Object.entries(BINARY_SOURCES)) {
+      const contentAddressed = source.url.includes("/blobs/sha256:");
+      if (contentAddressed) continue;
+      expect(`${platform}: ${source.sha256 ?? "MISSING"}`).toMatch(/^[a-z0-9-]+: [0-9a-f]{64}$/);
+    }
   });
 
-  test("every source is fully specified", () => {
+  test("every source has an https url and a known archive format", () => {
     for (const [platform, source] of Object.entries(BINARY_SOURCES)) {
       expect(`${platform}: ${source.url}`).toStartWith(`${platform}: https://`);
-      expect(["tar.gz", "zip"]).toContain(source.format);
+      // Asserted on source.format, not the literal, so a failure names the
+      // offending platform rather than printing the allowed list.
+      expect(`${platform}: ${source.format}`).toMatch(/^[a-z0-9-]+: (tar\.gz|zip)$/);
     }
   });
 });
@@ -97,5 +110,27 @@ describe("runtime shared libraries", () => {
     expect(targets).toHaveLength(2);
     expect(targets.some((t) => t.endsWith(`/lib/libggml-cpu.so`))).toBe(true);
     expect(targets.some((t) => t.endsWith(`/bin/libggml-cpu.so`))).toBe(true);
+  });
+});
+
+describe("decideWarmupAction", () => {
+  test("installs when nothing is there", async () => {
+    expect(await decideWarmupAction(join(tmpdir(), "no-such-whisper-cli"))).toBe("install");
+  });
+
+  test("REPAIRS a binary that is present but will not run", async () => {
+    // The regression that mattered. Warmup used to branch on existence alone,
+    // so this state was classified "ok": the file was present, warmup reported
+    // success, and every transcription failed. Deciding on runnability is the
+    // fix — if this ever returns "ok" again, linux-arm64 silently breaks.
+    const dir = await mkdtemp(join(tmpdir(), "whisper-warmup-"));
+    const broken = join(dir, "whisper-cli");
+    await writeFile(broken, "not an executable");
+    await chmod(broken, 0o755);
+    expect(await decideWarmupAction(broken)).toBe("repair");
+  });
+
+  test("leaves a working binary alone", async () => {
+    expect(await decideWarmupAction(process.execPath)).toBe("ok");
   });
 });

--- a/src/whisper.ts
+++ b/src/whisper.ts
@@ -41,10 +41,17 @@ interface BinarySource {
 
 /** Exported for tests — see `src/__tests__/whisper-binary-source.test.ts`. */
 export const BINARY_SOURCES: Readonly<Record<string, Readonly<BinarySource>>> = {
+  // Third-party personal repo — the weakest provenance in this table, so the
+  // digest pin matters most here.
   "linux-x64": {
     url: "https://github.com/dscripka/whisper.cpp_binaries/releases/download/commit_3d42463/whisper-bin-linux-x64.tar.gz",
     format: "tar.gz",
+    sha256: "63f69d39d3ec56a1f6828055d56f0625e0c5871c55578a141090a678c0b9383e",
   },
+  // The two darwin entries are content-addressed (the sha256 is in the URL
+  // path), so a conforming registry can only ever serve those exact bytes —
+  // no separate pin needed. They remain Homebrew bottles because Mach-O
+  // relocation differs from ELF and does not hit the interpreter bug above.
   "darwin-arm64": {
     url: "https://ghcr.io/v2/homebrew/core/whisper-cpp/blobs/sha256:f0901568c7babbd3022a043887007400e4b57a22d3a90b9c0824d01fa3a77270",
     format: "tar.gz",
@@ -67,6 +74,7 @@ export const BINARY_SOURCES: Readonly<Record<string, Readonly<BinarySource>>> = 
   "win32-x64": {
     url: "https://github.com/ggml-org/whisper.cpp/releases/download/v1.7.6/whisper-bin-x64.zip",
     format: "zip",
+    sha256: "0d2eca299c248f965bd0341bcb219db4b433c7f0c0ce2200d4df85765e8156a9",
   },
 };
 
@@ -310,10 +318,15 @@ async function downloadAndExtractBinary(): Promise<void> {
   await Bun.write(destBinary, Bun.file(found));
   await chmod(destBinary, 0o755);
 
-  // Copy any shared libraries (for Homebrew bottles)
-  const entries = await readdir(extractDir, { withFileTypes: true, recursive: true }).catch(
-    () => [],
-  );
+  // Copy the runtime shared libraries out of the archive.
+  //
+  // Deliberately NOT wrapped in .catch(() => []). Swallowing a readdir failure
+  // here copies zero libraries while leaving the binary from above in place —
+  // and since `--help` does not exercise ggml's dlopen, the install then passes
+  // every subsequent runnability probe while failing every real transcription
+  // with "backends = 0". A throw is recoverable; a silent empty copy is not.
+  const entries = await readdir(extractDir, { withFileTypes: true, recursive: true });
+  let copied = 0;
   for (const entry of entries) {
     if (!entry.isFile()) continue;
     const name = entry.name;
@@ -324,7 +337,17 @@ async function downloadAndExtractBinary(): Promise<void> {
       for (const destPath of sharedLibTargets(name)) {
         await Bun.write(destPath, Bun.file(srcPath));
       }
+      copied++;
     }
+  }
+
+  // Every supported archive ships its own libwhisper/libggml. Zero matches means
+  // the layout changed and the probe below would certify a broken install.
+  if (copied === 0) {
+    throw new Error(
+      `whisper: no shared libraries found in the ${platformKey} archive — ` +
+        `refusing to install a binary that cannot load its backend.`,
+    );
   }
 
   // Cleanup
@@ -344,6 +367,21 @@ async function downloadModel(): Promise<void> {
   console.log("whisper: model ready");
 }
 
+/**
+ * What warmup must do about the installed binary.
+ *
+ * The distinction that matters is "repair": a binary that is present but will
+ * not run. Deciding on presence alone is the bug that left linux-arm64 silently
+ * broken for months — the file was there, so warmup reported success forever
+ * and every transcription failed.
+ */
+export type WarmupAction = "ok" | "install" | "repair";
+
+export async function decideWarmupAction(binaryPath: string): Promise<WarmupAction> {
+  if (await binaryIsRunnable(binaryPath)) return "ok";
+  return (await fileExists(binaryPath)) ? "repair" : "install";
+}
+
 async function prepareWhisperAssets(printOutput: boolean): Promise<void> {
   const startedAt = Date.now();
   // Fail fast instead of re-downloading a known-bad archive on every message.
@@ -353,10 +391,11 @@ async function prepareWhisperAssets(printOutput: boolean): Promise<void> {
   await mkdir(TMP_FOLDER, { recursive: true });
 
   const binaryPath = getWhisperBinaryPath();
-  if (await binaryIsRunnable(binaryPath)) {
+  const action = await decideWarmupAction(binaryPath);
+  if (action === "ok") {
     console.log("whisper warmup: binary exists");
   } else {
-    if (await fileExists(binaryPath)) {
+    if (action === "repair") {
       console.log("whisper warmup: existing binary is not runnable, re-downloading");
     }
     await downloadAndExtractBinary();

--- a/src/whisper.ts
+++ b/src/whisper.ts
@@ -136,7 +136,7 @@ export function isWhisperSharedLib(name: string): boolean {
  * BIN_DIR is not redundant: ggml dlopens its compute backend by searching
  * alongside the executable, a lookup no library-path variable affects. Drop
  * BIN_DIR and the binary still loads — `--help` exits 0 — but every
- * transcription fails with "backends = 0".
+ * transcription fails with whisper-cli reporting `backends   = 0` at runtime.
  */
 export function sharedLibTargets(name: string): string[] {
   return [join(LIB_DIR, name), join(BIN_DIR, name)];
@@ -267,14 +267,6 @@ async function downloadAndExtractBinary(): Promise<void> {
   const extractDir = join(TMP_FOLDER, "extract");
   await rm(extractDir, { recursive: true, force: true });
   await mkdir(extractDir, { recursive: true });
-  // Wipe rather than overwrite: a library present in the previous archive but
-  // absent from this one would otherwise survive, and both dirs are on the
-  // loader path (BIN_DIR is also ggml's dlopen search dir). That matters right
-  // now — existing arm64 installs hold objects from the old Homebrew source.
-  await rm(BIN_DIR, { recursive: true, force: true });
-  await rm(LIB_DIR, { recursive: true, force: true });
-  await mkdir(BIN_DIR, { recursive: true });
-  await mkdir(LIB_DIR, { recursive: true });
 
   const archiveExt = source.format === "tar.gz" ? "tar.gz" : "zip";
   const archivePath = join(TMP_FOLDER, `whisper-bin.${archiveExt}`);
@@ -314,40 +306,56 @@ async function downloadAndExtractBinary(): Promise<void> {
     throw new Error("Could not find whisper-cli or main binary in downloaded archive");
   }
 
-  const destBinary = getWhisperBinaryPath();
-  await Bun.write(destBinary, Bun.file(found));
-  await chmod(destBinary, 0o755);
-
-  // Copy the runtime shared libraries out of the archive.
+  // Everything above is staging. Only now, with a verified archive, a located
+  // binary and a non-empty library set in hand, do we touch the live install.
   //
+  // Ordering matters: this runs on the repair path too, and binaryIsRunnable()
+  // cannot distinguish a permanently broken binary from a transient spawn
+  // failure (memory pressure, fd exhaustion). Wiping before the replacement is
+  // proven good would turn a bad probe plus an unreachable download host into a
+  // destroyed install, where previously a failed download was a harmless no-op.
   // Deliberately NOT wrapped in .catch(() => []). Swallowing a readdir failure
-  // here copies zero libraries while leaving the binary from above in place —
-  // and since `--help` does not exercise ggml's dlopen, the install then passes
-  // every subsequent runnability probe while failing every real transcription
-  // with "backends = 0". A throw is recoverable; a silent empty copy is not.
+  // here would stage zero libraries; combined with the binary write below that
+  // yields an install which passes every `--help` probe (which does not
+  // exercise ggml's dlopen) while failing every real transcription. A throw is
+  // recoverable; a silent empty copy is not.
   const entries = await readdir(extractDir, { withFileTypes: true, recursive: true });
-  let copied = 0;
+
+  const stagedLibs: Array<{ name: string; srcPath: string }> = [];
   for (const entry of entries) {
     if (!entry.isFile()) continue;
     const name = entry.name;
-    if (isWhisperSharedLib(name)) {
-      const parentPath = entry.parentPath ?? entry.path ?? "";
-      const srcPath = join(parentPath, name);
-      // Written to BOTH dirs on purpose — see sharedLibTargets().
-      for (const destPath of sharedLibTargets(name)) {
-        await Bun.write(destPath, Bun.file(srcPath));
-      }
-      copied++;
-    }
+    if (!isWhisperSharedLib(name)) continue;
+    stagedLibs.push({ name, srcPath: join(entry.parentPath ?? entry.path ?? "", name) });
   }
 
   // Every supported archive ships its own libwhisper/libggml. Zero matches means
-  // the layout changed and the probe below would certify a broken install.
-  if (copied === 0) {
+  // the layout changed and the probe would otherwise certify a broken install.
+  if (stagedLibs.length === 0) {
     throw new Error(
       `whisper: no shared libraries found in the ${platformKey} archive — ` +
         `refusing to install a binary that cannot load its backend.`,
     );
+  }
+
+  // Replace rather than overwrite: a library present in the previous archive but
+  // absent from this one would otherwise survive, and both dirs are on the
+  // loader path (BIN_DIR is also ggml's dlopen search dir). That matters right
+  // now — existing arm64 installs hold objects from the old Homebrew source.
+  await rm(BIN_DIR, { recursive: true, force: true });
+  await rm(LIB_DIR, { recursive: true, force: true });
+  await mkdir(BIN_DIR, { recursive: true });
+  await mkdir(LIB_DIR, { recursive: true });
+
+  const destBinary = getWhisperBinaryPath();
+  await Bun.write(destBinary, Bun.file(found));
+  await chmod(destBinary, 0o755);
+
+  for (const { name, srcPath } of stagedLibs) {
+    // Written to BOTH dirs on purpose — see sharedLibTargets().
+    for (const destPath of sharedLibTargets(name)) {
+      await Bun.write(destPath, Bun.file(srcPath));
+    }
   }
 
   // Cleanup

--- a/src/whisper.ts
+++ b/src/whisper.ts
@@ -30,11 +30,17 @@ function getModelUrl(model: string): string {
 interface BinarySource {
   url: string;
   format: "tar.gz" | "zip";
+  /**
+   * Hex sha256 of the archive. Required wherever the URL is not itself
+   * content-addressed: a release asset is name-addressed and mutable, so
+   * without this the bytes we execute are whatever the tag currently points at.
+   */
+  sha256?: string;
   headers?: Record<string, string>;
 }
 
 /** Exported for tests — see `src/__tests__/whisper-binary-source.test.ts`. */
-export const BINARY_SOURCES: Record<string, BinarySource> = {
+export const BINARY_SOURCES: Readonly<Record<string, Readonly<BinarySource>>> = {
   "linux-x64": {
     url: "https://github.com/dscripka/whisper.cpp_binaries/releases/download/commit_3d42463/whisper-bin-linux-x64.tar.gz",
     format: "tar.gz",
@@ -56,6 +62,7 @@ export const BINARY_SOURCES: Record<string, BinarySource> = {
   "linux-arm64": {
     url: "https://github.com/ggml-org/whisper.cpp/releases/download/b4938/whisper-bin-ubuntu-arm64.tar.gz",
     format: "tar.gz",
+    sha256: "94a33318650c57cc3d9a91439e0e3f0b94ba96bacd34203a06db395cf9204e40",
   },
   "win32-x64": {
     url: "https://github.com/ggml-org/whisper.cpp/releases/download/v1.7.6/whisper-bin-x64.zip",
@@ -64,6 +71,14 @@ export const BINARY_SOURCES: Record<string, BinarySource> = {
 };
 
 let warmupPromise: Promise<void> | null = null;
+
+/**
+ * Set when a freshly downloaded binary still will not run — i.e. this
+ * platform's BINARY_SOURCES entry is wrong. warmupPromise is cleared on
+ * failure and re-awaited per voice message, so without this latch every
+ * inbound message would re-download the whole archive before failing again.
+ */
+let unsupportedPlatform: string | null = null;
 
 type WhisperDebugLog = (message: string) => void;
 
@@ -244,6 +259,12 @@ async function downloadAndExtractBinary(): Promise<void> {
   const extractDir = join(TMP_FOLDER, "extract");
   await rm(extractDir, { recursive: true, force: true });
   await mkdir(extractDir, { recursive: true });
+  // Wipe rather than overwrite: a library present in the previous archive but
+  // absent from this one would otherwise survive, and both dirs are on the
+  // loader path (BIN_DIR is also ggml's dlopen search dir). That matters right
+  // now — existing arm64 installs hold objects from the old Homebrew source.
+  await rm(BIN_DIR, { recursive: true, force: true });
+  await rm(LIB_DIR, { recursive: true, force: true });
   await mkdir(BIN_DIR, { recursive: true });
   await mkdir(LIB_DIR, { recursive: true });
 
@@ -253,6 +274,19 @@ async function downloadAndExtractBinary(): Promise<void> {
   console.log(`whisper: downloading binary for ${platformKey}...`);
   await downloadFile(source.url, archivePath, source.headers);
 
+  // These bytes get chmod 0755'd and executed with the daemon's full
+  // environment, so verify them before we ever reach that point.
+  if (source.sha256) {
+    const digest = new Bun.CryptoHasher("sha256")
+      .update(await Bun.file(archivePath).arrayBuffer())
+      .digest("hex");
+    if (digest !== source.sha256) {
+      await rm(archivePath, { force: true });
+      throw new Error(
+        `whisper: archive digest mismatch for ${platformKey} — expected ${source.sha256}, got ${digest}`,
+      );
+    }
+  }
   console.log("whisper: extracting...");
   if (source.format === "tar.gz") {
     const proc = Bun.spawnSync(["tar", "xzf", archivePath, "-C", extractDir]);
@@ -286,12 +320,7 @@ async function downloadAndExtractBinary(): Promise<void> {
     if (isWhisperSharedLib(name)) {
       const parentPath = entry.parentPath ?? entry.path ?? "";
       const srcPath = join(parentPath, name);
-      // Written to BOTH dirs on purpose. LIB_DIR is the historical location and
-      // is what LD_LIBRARY_PATH points at; BIN_DIR is required because ggml
-      // dlopens its compute backend (libggml-cpu.so) by searching next to the
-      // executable — a lookup no library path influences. With only LIB_DIR the
-      // binary loads and `--help` succeeds, but every transcription dies with
-      // "backends = 0". Both are rewritten on each download, so they cannot skew.
+      // Written to BOTH dirs on purpose — see sharedLibTargets().
       for (const destPath of sharedLibTargets(name)) {
         await Bun.write(destPath, Bun.file(srcPath));
       }
@@ -317,6 +346,8 @@ async function downloadModel(): Promise<void> {
 
 async function prepareWhisperAssets(printOutput: boolean): Promise<void> {
   const startedAt = Date.now();
+  // Fail fast instead of re-downloading a known-bad archive on every message.
+  if (unsupportedPlatform) throw new Error(unsupportedPlatform);
   console.log(`whisper warmup: start root=${WHISPER_ROOT} model=${getWhisperModel()}`);
   await mkdir(WHISPER_ROOT, { recursive: true });
   await mkdir(TMP_FOLDER, { recursive: true });
@@ -332,10 +363,10 @@ async function prepareWhisperAssets(printOutput: boolean): Promise<void> {
     // One retry only — if a freshly downloaded binary still will not exec, the
     // platform source is wrong and silently looping would hide that.
     if (!(await binaryIsRunnable(binaryPath))) {
-      throw new Error(
+      unsupportedPlatform =
         `whisper: downloaded binary for ${process.platform}-${process.arch} is not runnable ` +
-          `(${binaryPath}). The platform's BINARY_SOURCES entry is likely wrong for this system.`,
-      );
+        `(${binaryPath}). The platform's BINARY_SOURCES entry is likely wrong for this system.`;
+      throw new Error(unsupportedPlatform);
     }
   }
 

--- a/src/whisper.ts
+++ b/src/whisper.ts
@@ -33,7 +33,8 @@ interface BinarySource {
   headers?: Record<string, string>;
 }
 
-const BINARY_SOURCES: Record<string, BinarySource> = {
+/** Exported for tests — see `src/__tests__/whisper-binary-source.test.ts`. */
+export const BINARY_SOURCES: Record<string, BinarySource> = {
   "linux-x64": {
     url: "https://github.com/dscripka/whisper.cpp_binaries/releases/download/commit_3d42463/whisper-bin-linux-x64.tar.gz",
     format: "tar.gz",
@@ -48,10 +49,13 @@ const BINARY_SOURCES: Record<string, BinarySource> = {
     format: "tar.gz",
     headers: { Authorization: "Bearer QQ==" },
   },
+  // Upstream's official Linux arm64 build. Previously pointed at a Homebrew
+  // bottle, whose ELF interpreter is a literal "@@HOMEBREW_PREFIX@@/lib/ld.so"
+  // placeholder that only `brew` rewrites on install — extracting the raw
+  // tarball leaves an unrunnable binary that fails with a misleading ENOENT.
   "linux-arm64": {
-    url: "https://ghcr.io/v2/homebrew/core/whisper-cpp/blobs/sha256:684199fd6bec28cddfa086c584a49d236386c109f901a443b577b857fd052f83",
+    url: "https://github.com/ggml-org/whisper.cpp/releases/download/b4938/whisper-bin-ubuntu-arm64.tar.gz",
     format: "tar.gz",
-    headers: { Authorization: "Bearer QQ==" },
   },
   "win32-x64": {
     url: "https://github.com/ggml-org/whisper.cpp/releases/download/v1.7.6/whisper-bin-x64.zip",
@@ -70,6 +74,15 @@ function getWhisperBinaryPath(): string {
   return join(BIN_DIR, `whisper-cli${suffix}`);
 }
 
+/** Runtime lib lookup path for the bundled whisper shared objects. */
+function withLibraryPath(env: NodeJS.ProcessEnv): Record<string, string> {
+  return {
+    ...(env as Record<string, string>),
+    LD_LIBRARY_PATH: [BIN_DIR, LIB_DIR, env.LD_LIBRARY_PATH].filter(Boolean).join(":"),
+    DYLD_LIBRARY_PATH: [BIN_DIR, LIB_DIR, env.DYLD_LIBRARY_PATH].filter(Boolean).join(":"),
+  };
+}
+
 function getModelPath(): string {
   return join(MODEL_FOLDER, `ggml-${getWhisperModel()}.bin`);
 }
@@ -78,6 +91,51 @@ async function fileExists(path: string): Promise<boolean> {
   try {
     await access(path);
     return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Shared objects whisper-cli needs at runtime.
+ *
+ * Matching on "whisper" alone silently drops libggml and leaves the binary
+ * unloadable, which is how the linux-arm64 install stayed broken.
+ */
+export function isWhisperSharedLib(name: string): boolean {
+  const isSharedLib = name.endsWith(".so") || name.endsWith(".dylib") || /\.so\.\d/.test(name);
+  return isSharedLib && (name.includes("whisper") || name.includes("ggml"));
+}
+
+/**
+ * Where a runtime shared object must be written.
+ *
+ * BIN_DIR is not redundant: ggml dlopens its compute backend by searching
+ * alongside the executable, a lookup no library-path variable affects. Drop
+ * BIN_DIR and the binary still loads — `--help` exits 0 — but every
+ * transcription fails with "backends = 0".
+ */
+export function sharedLibTargets(name: string): string[] {
+  return [join(LIB_DIR, name), join(BIN_DIR, name)];
+}
+
+/**
+ * A binary that exists is not necessarily a binary that runs. A partial extract,
+ * a missing `libggml`, or an archive whose ELF interpreter was never relocated
+ * all leave a plausible-looking file on disk that dies at exec time — and an
+ * existence check happily accepts it forever, so every transcription fails while
+ * warmup reports success. Probe it instead: `--help` exits 0 when the loader can
+ * resolve everything, and 127 when it cannot.
+ */
+export async function binaryIsRunnable(binaryPath: string): Promise<boolean> {
+  if (!(await fileExists(binaryPath))) return false;
+  try {
+    const proc = Bun.spawnSync([binaryPath, "--help"], {
+      env: withLibraryPath(process.env),
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    return proc.exitCode === 0;
   } catch {
     return false;
   }
@@ -225,14 +283,18 @@ async function downloadAndExtractBinary(): Promise<void> {
   for (const entry of entries) {
     if (!entry.isFile()) continue;
     const name = entry.name;
-    if (
-      name.includes("whisper") &&
-      (name.endsWith(".so") || name.endsWith(".dylib") || name.match(/\.so\.\d/))
-    ) {
+    if (isWhisperSharedLib(name)) {
       const parentPath = entry.parentPath ?? entry.path ?? "";
       const srcPath = join(parentPath, name);
-      const destPath = join(LIB_DIR, name);
-      await Bun.write(destPath, Bun.file(srcPath));
+      // Written to BOTH dirs on purpose. LIB_DIR is the historical location and
+      // is what LD_LIBRARY_PATH points at; BIN_DIR is required because ggml
+      // dlopens its compute backend (libggml-cpu.so) by searching next to the
+      // executable — a lookup no library path influences. With only LIB_DIR the
+      // binary loads and `--help` succeeds, but every transcription dies with
+      // "backends = 0". Both are rewritten on each download, so they cannot skew.
+      for (const destPath of sharedLibTargets(name)) {
+        await Bun.write(destPath, Bun.file(srcPath));
+      }
     }
   }
 
@@ -260,10 +322,21 @@ async function prepareWhisperAssets(printOutput: boolean): Promise<void> {
   await mkdir(TMP_FOLDER, { recursive: true });
 
   const binaryPath = getWhisperBinaryPath();
-  if (!(await fileExists(binaryPath))) {
-    await downloadAndExtractBinary();
-  } else {
+  if (await binaryIsRunnable(binaryPath)) {
     console.log("whisper warmup: binary exists");
+  } else {
+    if (await fileExists(binaryPath)) {
+      console.log("whisper warmup: existing binary is not runnable, re-downloading");
+    }
+    await downloadAndExtractBinary();
+    // One retry only — if a freshly downloaded binary still will not exec, the
+    // platform source is wrong and silently looping would hide that.
+    if (!(await binaryIsRunnable(binaryPath))) {
+      throw new Error(
+        `whisper: downloaded binary for ${process.platform}-${process.arch} is not runnable ` +
+          `(${binaryPath}). The platform's BINARY_SOURCES entry is likely wrong for this system.`,
+      );
+    }
   }
 
   await downloadModel();
@@ -407,11 +480,7 @@ export async function transcribeAudioToText(
     const proc = Bun.spawnSync([binaryPath, "-m", modelPath, "-f", wavPath, "--no-timestamps"], {
       stdout: "pipe",
       stderr: "pipe",
-      env: {
-        ...process.env,
-        LD_LIBRARY_PATH: [LIB_DIR, process.env.LD_LIBRARY_PATH].filter(Boolean).join(":"),
-        DYLD_LIBRARY_PATH: [LIB_DIR, process.env.DYLD_LIBRARY_PATH].filter(Boolean).join(":"),
-      },
+      env: withLibraryPath(process.env),
     });
 
     if (proc.exitCode !== 0) {


### PR DESCRIPTION
Voice transcription has been silently broken on linux-arm64 since the platform entry was added. Found while investigating an unrelated resource report on the production daemon — `whisper-cli` had been dead there since April with no error ever surfaced.

## Root cause

Three faults compounding:

1. **`linux-arm64` pointed at a macOS Homebrew bottle.** Homebrew rewrites the ELF interpreter at install time; extracting the raw tarball does not. The binary kept a literal `@@HOMEBREW_PREFIX@@/lib/ld.so` interpreter, so every exec failed with `ENOENT` — a misleading "No such file or directory" for a file that plainly exists, because it is the *loader* the kernel cannot find.

2. **The shared-library copy matched only names containing `whisper`,** so `libggml*` was never copied. Even a correctly built binary was unloadable.

3. **Warmup only checked the binary *existed*.** A broken install was therefore accepted forever and never re-downloaded — which is why this presented as silence rather than an error, for months.

## Changes

- `linux-arm64` now uses upstream's official `whisper-bin-ubuntu-arm64` build, pinned to a tag rather than floating on `/latest/`.
- Library matching widened to `libggml*`, and libraries are written **beside the binary** as well as into `lib/`. This is load-bearing, not belt-and-braces: ggml `dlopen`s its compute backend by searching next to the executable, a lookup no library-path variable affects. With `lib/` alone the binary loads and `--help` exits 0, but every transcription dies with `backends = 0`.
- Warmup probes the binary and re-downloads when it will not run, failing loudly if a fresh download is still unrunnable rather than looping.
- Every non-content-addressed URL is now sha256-pinned and verified after download, before extraction. The Homebrew URL this replaced was content-addressed, so swapping to a release asset improved provenance while quietly weakening integrity — these bytes are `chmod 0755`'d and executed with the daemon's full environment. `linux-x64` and `win32-x64` are pinned too; `linux-x64` comes from a third-party personal repo and had the weakest provenance in the table.
- `BIN_DIR`/`LIB_DIR` are wiped before repopulating, so a library present in the old archive but absent from the new one cannot survive on the loader path. That is not hypothetical: existing arm64 installs hold objects from the Homebrew source.
- A `readdir` failure during the library copy is no longer swallowed, and an archive yielding zero libraries is rejected. Swallowing it installed the binary with no libraries — which then passed every `--help` probe while failing every real transcription.

## Verification

Built and run on Ubuntu aarch64 (Hetzner, neoverse-n1):

- Correct transcription of the upstream `jfk.wav` sample, `backends = 1`.
- The `lib/`-only layout reproduces `backends = 0`; the fixed layout does not. `GGML_BACKEND_PATH` does **not** work as an alternative — verified.
- sha256 pin verified against the live download: 4572294 bytes, `94a33318650c57cc3d9a91439e0e3f0b94ba96bacd34203a06db395cf9204e40`.

## Tests

`src/whisper.ts` previously had no tests. 13 added, and the two that matter were RED-verified — they fail against the old code and pass against the fix:

- Against the old Homebrew URL: the source-invariant tests fail.
- Against warmup deciding on presence alone: `decideWarmupAction` returns `ok` for a present-but-unrunnable binary and the test fails.

The `darwin-*` entries deliberately remain Homebrew bottles — Mach-O relocation differs from ELF and does not hit the interpreter bug, and those URLs are content-addressed. The tests say so inline so nobody "fixes" the filter and breaks macOS.

Full-repo lint passes; typecheck is at baseline (153, unchanged).