### PR TITLE
docs: record feature freeze and contribution guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.229",
+      "version": "2.2.230",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.229",
+  "version": "2.2.230",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ Everything from upstream lives here too. Plus has now diverged significantly fro
 
 ---
 
+## Project status
+
+**ClaudeClaw+ is in feature freeze. Fixes and hygiene work continue; new features are not
+currently being merged here.**
+
+What this means in practice:
+
+- **Bug fixes, platform and hygiene PRs are welcome** and will be reviewed as normal.
+- **Large new-feature PRs are unlikely to be merged right now.** Please open an issue to discuss
+  before investing significant time, so nobody spends a weekend on something that cannot land.
+- The project remains MIT licensed and independently runnable. Nothing about the freeze changes
+  what is already here or how you may use it.
+
+For transparency: development effort has shifted to a separate, private commercial product built
+on this daemon. MIT permits that, and it does not affect your rights to this code — but it would
+be discourteous not to say so plainly, particularly to anyone considering a substantial
+contribution.
+
+---
+
 ## Standing on the shoulders of giants
 
 ClaudeClaw+ is built on top of the original [`moazbuilds/claudeclaw`](https://github.com/moazbuilds/claudeclaw), created by [@moazbuilds](https://github.com/moazbuilds). The core daemon, Telegram/Discord adapters, heartbeat, web dashboard, skills system — all of that comes from upstream and the amazing contributors who built it.


### PR DESCRIPTION
Records the outcome of the 20 August call: this project is frozen for features and stays open for fixes, with new development moving to a separate private repository.

Adds a **Project status** section near the top of the README, before the technical content, so contributors see it before investing time.

### Please review the wording before merging

Two judgment calls in here that are yours, not mine:

1. **The transparency paragraph.** It states plainly that effort has moved to a private commercial product built on this daemon. MIT permits this and it changes nothing about anyone's rights, but it is a disclosure decision. I included it because staying quiet while contributors keep filing PRs seemed the worse option — the alternative is to cut that paragraph and say only that the project is in feature freeze.

2. **"Large new-feature PRs are unlikely to be merged right now."** This is deliberately blunt to reduce inbound volume, which the call flagged as a concern. Soften if you would rather not discourage contribution that firmly.

Docs only — no code paths touched. Version guards bumped as required.