### PR TITLE
fix(bus): reproduce the CLI's projects-dir encoding exactly

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.229",
+      "version": "2.2.230",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.229",
+  "version": "2.2.230",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/schema-probe.test.ts
+++ b/src/bus/__tests__/schema-probe.test.ts
@@ -286,9 +286,19 @@ afterEach(() => {
 describe("encodeCwd", () => {
   it("replaces every non-alphanumeric character with a hyphen", () => {
     expect(encodeCwd("/private/tmp/abc")).toBe("-private-tmp-abc");
-    // claude preserves dots/underscores; only `/` becomes `-`. Confirmed
-    // against Spike 0.5 fixture `~/.claude/projects/-private-tmp-spike-0.2/...`.
-    expect(encodeCwd("/Users/a.b_c/Foo")).toBe("-Users-a.b_c-Foo");
+    // Re-measured against CLI 2.1.251: the CLI replaces EVERY
+    // non-alphanumeric character. The previous expectation cited a Spike 0.5
+    // fixture (`-private-tmp-spike-0.2`) that no longer exists, and across 29
+    // live project directories — each session file's recorded `cwd` against
+    // the directory it was written into — this rule matches 29 of 29, while
+    // "only `/`" misses every path containing `.` or `_`.
+    //
+    // Getting this wrong is silent: the tailer waits on a session file that
+    // can never appear, which is indistinguishable from "not written yet",
+    // so the silent-drop net is simply inert for that agent.
+    expect(encodeCwd("/Users/a.b_c/Foo")).toBe("-Users-a-b-c-Foo");
+    // Measured directly: this exact cwd produced this exact directory.
+    expect(encodeCwd("/tmp/enc:test.a_b")).toBe("-tmp-enc-test-a-b");
   });
 
   it("encodes Windows separators and the drive colon on win32", () => {
@@ -296,8 +306,43 @@ describe("encodeCwd", () => {
     expect(encodeCwd("C:\\Users\\foo\\bar", "win32")).toBe("C--Users-foo-bar");
     // Forward-slash Windows paths encode the same way.
     expect(encodeCwd("C:/Users/foo/bar", "win32")).toBe("C--Users-foo-bar");
-    // POSIX must NOT touch ':' (a legal path char) — only '/' becomes '-'.
-    expect(encodeCwd("/home/foo:bar/baz", "linux")).toBe("-home-foo:bar-baz");
+    // ':' is replaced on POSIX too. The previous expectation was an inference
+    // ("a legal path char"), not a measurement, and the CLI disagrees.
+    expect(encodeCwd("/home/foo:bar/baz", "linux")).toBe("-home-foo-bar-baz");
+  });
+
+  // The encoder has a second half: past 200 characters the CLI truncates and
+  // appends a hash. Read out of the CLI binary and confirmed by running it —
+  // a 205-char cwd produced a 207-char directory ending in `-1d9yzd`, which is
+  // what this reproduces. Without it the tailer binds to a path that cannot
+  // exist, and does so silently.
+  it("truncates past 200 characters and appends the CLI's hash", () => {
+    const cwd = `/tmp/${"d".repeat(200)}`;
+    const out = encodeCwd(cwd);
+    expect(out).toHaveLength(207);
+    expect(out.slice(0, 200)).toBe(`-tmp-${"d".repeat(195)}`);
+    expect(out.slice(200)).toBe("-1d9yzd");
+  });
+
+  it("leaves anything at or under 200 characters untruncated", () => {
+    const exact = `/${"a".repeat(199)}`; // encodes to exactly 200
+    expect(encodeCwd(exact)).toHaveLength(200);
+    expect(encodeCwd(exact)).not.toContain("--");
+  });
+
+  // The hash is over the ORIGINAL cwd, not the encoded string. Two paths that
+  // share their first 200 encoded characters must still land in different
+  // directories — hashing the truncated form would collide them.
+  it("hashes the original cwd, so paths sharing a prefix stay distinct", () => {
+    const a = `/tmp/${"d".repeat(200)}/alpha`;
+    const b = `/tmp/${"d".repeat(200)}/beta`;
+    expect(encodeCwd(a).slice(0, 200)).toBe(encodeCwd(b).slice(0, 200));
+    expect(encodeCwd(a)).not.toBe(encodeCwd(b));
+  });
+
+  it("is independent of the platform argument", () => {
+    const cwd = "/home/simon/a.b_c";
+    expect(encodeCwd(cwd, "win32")).toBe(encodeCwd(cwd, "linux"));
   });
 });
 

--- a/src/bus/jsonl-line-types.ts
+++ b/src/bus/jsonl-line-types.ts
@@ -219,25 +219,62 @@ export type JsonlLine =
 /* ───────────────────────────────────────────────────────────────────── */
 
 /**
- * Encode an absolute realpath'd cwd into the directory name Claude Code
- * uses under `~/.claude/projects/`. Claude replaces the platform's path
- * separators with `-`; case is preserved. Empirically:
- *   POSIX:   `/Users/foo/bar`        → `-Users-foo-bar`   (`/` only)
- *   Windows: `C:\Users\foo\bar`      → `C--Users-foo-bar` (`\`, `/` and the
- *            drive `:`) — verified against claude.exe on a Win11 host.
- * `:` must NOT be replaced on POSIX, where it is a legal path character.
+ * Session Manager calls `fs.realpathSync(cwd)` before handing the cwd to the
+ * Tailer (resolves the macOS `/tmp` → `/private/tmp` symlink, per Spike 0.5).
+ * The encoder below trusts that contract and does not resolve anything itself.
+ */
+/** Max length of the encoded segment before the CLI truncates it. */
+const PROJECTS_DIR_MAX_LEN = 200;
+
+/**
+ * The CLI's hash of the ORIGINAL cwd, appended when the encoded form is
+ * truncated. `(h << 5) - h` is `h * 31`; `| 0` keeps it a signed 32-bit int,
+ * and the result is rendered in base 36.
  *
- * `platform` is injectable so both branches are testable off-Windows.
+ * It hashes the cwd, not the encoded string, so it cannot be recovered after
+ * encoding — the truncated form has to be built from the original path.
+ */
+function hashCwdForProjectsDir(cwd: string): string {
+  let h = 0;
+  for (let i = 0; i < cwd.length; i++) {
+    h = ((h << 5) - h + cwd.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h).toString(36);
+}
+
+/**
+ * Reproduce the directory name the CLI writes a session transcript into.
  *
- * Session Manager already calls `fs.realpathSync(cwd)` before passing
- * cwd to the Tailer (resolves macOS `/tmp` → `/private/tmp` symlink per
- * Spike 0.5). Tailer trusts that contract.
+ * Two rules, both taken from the CLI implementation and confirmed by running
+ * it:
+ *
+ * 1. Every NON-ALPHANUMERIC character becomes `-` — not just separators. The
+ *    regex has no `u` flag, so it operates per UTF-16 code unit, and this
+ *    function must match that (an accented letter becomes one `-`, an
+ *    astral-plane emoji becomes two).
+ * 2. If the result exceeds 200 characters it is truncated to 200 and suffixed
+ *    with `-<hash>`, the hash being over the ORIGINAL cwd.
+ *
+ *      /home/simon/agent      -> -home-simon-agent
+ *      /tmp/enc:test.a_b      -> -tmp-enc-test-a-b
+ *      /tmp/<205 chars>       -> -tmp-<truncated to 200>-1d9yzd
+ *
+ * This is platform-independent: the CLI has a single encoder with no win32
+ * branch, and the same rule produces `C--Users-foo-bar` for `C:\Users\foo\bar`.
+ * `platform` is kept so existing callers and tests still compile.
+ *
+ * Getting this wrong is silent. `JsonlTailer.start()` polls for the session
+ * file with no timeout and nothing logged, so a wrong path is indistinguishable
+ * from "a fresh session has not written one yet" — the tail never starts and
+ * the silent-drop safety net is inert for that agent.
  */
 export function encodeCwdForProjectsDir(
   cwd: string,
-  platform: NodeJS.Platform = process.platform,
+  _platform: NodeJS.Platform = process.platform,
 ): string {
-  return platform === "win32" ? cwd.replace(/[/\\:]/g, "-") : cwd.replace(/\//g, "-");
+  const encoded = cwd.replace(/[^a-zA-Z0-9]/g, "-");
+  if (encoded.length <= PROJECTS_DIR_MAX_LEN) return encoded;
+  return `${encoded.slice(0, PROJECTS_DIR_MAX_LEN)}-${hashCwdForProjectsDir(cwd)}`;
 }
 
 /* ───────────────────────────────────────────────────────────────────── */

--- a/src/bus/schema-probe.ts
+++ b/src/bus/schema-probe.ts
@@ -80,16 +80,20 @@ interface CacheEntry {
 }
 
 /* ───────────────────────────────────────────────────────────────────── */
-/* Helpers — path encoding (matches claude's own scheme; Spike 0.5)      */
+/* Helpers — path encoding (matches claude's own scheme)                 */
 /* ───────────────────────────────────────────────────────────────────── */
 
 /**
  * Encode a realpath cwd into the directory name claude uses under
- * `~/.claude/projects/`. claude replaces `/` with `-` only — other
- * characters (dots, underscores) are preserved. Empirically confirmed
- * against fixture: cwd `/private/tmp/spike-0.2` encodes as
- * `-private-tmp-spike-0.2` (dot kept). Re-exported from
- * `jsonl-line-types.ts` so the Tailer and the probe stay in lock-step.
+ * `~/.claude/projects/`. Re-exported from `jsonl-line-types.ts` so the Tailer
+ * and the probe stay in lock-step; see that file for the rule and how it was
+ * derived.
+ *
+ * The previous note here claimed dots and underscores are preserved, citing a
+ * Spike 0.5 fixture. They are not: the CLI replaces every non-alphanumeric
+ * character, and truncates past 200 characters with a hash of the original
+ * cwd. Kept as a warning because a stale comment on a re-export is worse than
+ * none — it is read as documentation of the shared contract.
  */
 export { encodeCwdForProjectsDir as encodeCwd } from "./jsonl-line-types";
 import { encodeCwdForProjectsDir as _encodeCwdImpl } from "./jsonl-line-types";


### PR DESCRIPTION
Closes #365.

`encodeCwdForProjectsDir` names the directory the CLI writes a session
transcript into. It got both halves of that wrong.

The failure is silent by construction: `JsonlTailer.start()` polls for the
session file with no timeout and nothing logged, so a wrong path is
indistinguishable from "a fresh session has not written one yet". The tail
never starts, and the silent-drop safety net it feeds (#215) is inert for that
agent — permanently, with nothing to see.

## The CLI's encoder

Read out of the 2.1.251 binary:

```js
const MAX = 200;
hash   = cwd => { let h = 0; for (c of cwd) h = ((h << 5) - h + code(c)) | 0;
                  return Math.abs(h).toString(36) }
encode = cwd => { const n = cwd.replace(/[^a-zA-Z0-9]/g, "-");
                  return n.length <= MAX ? n : `${n.slice(0, MAX)}-${hash(cwd)}` }
```

Two corrections follow from it.

**Every non-alphanumeric character is replaced**, not just separators. Measured
directly — cwd `/tmp/enc:test.a_b` produced directory `-tmp-enc-test-a-b`.

**Past 200 characters the name is truncated and hashed.** A 205-character cwd
produced a 207-character directory ending in `-1d9yzd`, which this branch
reproduces exactly. The hash is over the **original** cwd, so it cannot be
recovered after encoding — hashing the truncated form instead would put two
distinct paths in one directory.

Matching each session file's recorded `cwd` against the directory it was
actually written into, across the project directories on one host:

| rule | matches |
| --- | --- |
| old (`/` only) | 27 / 32 |
| characters only | 31 / 32 |
| **both halves** | **32 / 32** |

## The tests asserted the opposite

Their own titles disagreed with them. The case named *"replaces every
non-alphanumeric character with a hyphen"* then asserted that dots and
underscores survive, citing a Spike 0.5 fixture (`-private-tmp-spike-0.2`)
that no longer exists. A second expectation held that POSIX leaves `:` alone
because it is a legal path character — an inference rather than a measurement,
and the binary has no platform branch at all.

Both corrected against the runs above. The Win11-verified expectation
`C:\Users\foo\bar` → `C--Users-foo-bar` is untouched: the same rule produces
it, which is why the win32 branch is deleted rather than extended.

## Compatibility

Backward compatible. Every pre-existing project directory contains only
alphanumerics and hyphens, so none is orphaned — it was the *old* rule that
orphaned directories like `-tmp-spike-0-4-cwd-w0yij0s1`. The exported
signature and its `platform` parameter are unchanged, so no caller moves.

Two agents whose cwds differ only by punctuation now share a directory, as
they already do under the CLI; every consumer keys by session UUID inside it
(`<sessionId>.jsonl`), so they still read distinct files.

## Verification

`src/bus`: 556 pass, 0 fail. Full suite: 0 new failures against the merge base.
Biome and the typecheck ratchet both unchanged at baseline.

Mutation-checked — reverting the character rule fails two tests; removing the
truncation fails one; hashing the encoded form instead of the original fails
one.

An independent adversarial review decompiled the CLI rather than sampling it,
which is where the 200-character half came from: the first version of this
change omitted it and left the reported failure open for any cwd whose encoded
form exceeds 200 characters. It also flagged the stale JSDoc, now replaced, and
the absence of any length coverage, now three tests.
