### PR TITLE
feat(bus): carry the operation id onto the events of the turn it started

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.230",
+      "version": "2.2.231",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.232",
+      "version": "2.2.233",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.231",
+      "version": "2.2.232",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.233",
+      "version": "2.2.238",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.232",
+  "version": "2.2.233",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.231",
+  "version": "2.2.232",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.233",
+  "version": "2.2.238",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.230",
+  "version": "2.2.231",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/webui/__tests__/webui.test.ts
+++ b/src/adapters/webui/__tests__/webui.test.ts
@@ -257,6 +257,38 @@ describe("WebUiAdapter — /health", () => {
     const body = (await r.json()) as { capabilities?: string[] };
     expect(body.capabilities?.length).toBeGreaterThan(0);
   });
+  it("reports an instance identity that changes when the daemon restarts", async () => {
+    adapter = await startAdapter({ token: "sekret" });
+    // A version cannot answer this: a restart onto the same build reports the
+    // same version, which is exactly the case a desktop must not mistake for
+    // continuity. A client that reconnects and sees a different instance knows
+    // its cached subscriptions, in-flight operation ids and sequence position
+    // belong to a process that no longer exists.
+    const r = await fetch(`${baseUrl}/health`);
+    const body = (await r.json()) as { instance_id?: string; started_at?: string };
+    expect(typeof body.instance_id).toBe("string");
+    expect(body.instance_id?.length).toBeGreaterThan(0);
+    expect(typeof body.started_at).toBe("string");
+    expect(Number.isNaN(Date.parse(body.started_at ?? ""))).toBe(false);
+  });
+
+  it("reports the SAME instance across calls while the process lives", async () => {
+    adapter = await startAdapter({ token: "sekret" });
+    // The other half of the property, and the one a naive implementation
+    // breaks: an id minted per request changes on every call, which reads as a
+    // restart on every poll.
+    const a = (await (await fetch(`${baseUrl}/health`)).json()) as { instance_id?: string };
+    const b = (await (await fetch(`${baseUrl}/health`)).json()) as { instance_id?: string };
+    expect(a.instance_id).toBe(b.instance_id);
+  });
+
+  it("advertises the instance-identity and ambiguity capabilities", async () => {
+    adapter = await startAdapter({ token: "sekret" });
+    const r = await fetch(`${baseUrl}/health`);
+    const body = (await r.json()) as { capabilities?: string[] };
+    expect(body.capabilities).toContain("health.instance_identity");
+    expect(body.capabilities).toContain("events.correlation_ambiguity");
+  });
 });
 
 describe("WebUiAdapter — POST /prompt", () => {

--- a/src/adapters/webui/__tests__/webui.test.ts
+++ b/src/adapters/webui/__tests__/webui.test.ts
@@ -235,6 +235,28 @@ describe("WebUiAdapter — /health", () => {
     expect(body.ok).toBe(true);
     expect(body.version.length).toBeGreaterThan(0);
   });
+
+  it("advertises a capability set, so a client detects instead of sniffing the version", async () => {
+    adapter = await startAdapter({ token: "sekret" });
+    const r = await fetch(`${baseUrl}/health`);
+    const body = (await r.json()) as { capabilities?: string[] };
+
+    expect(Array.isArray(body.capabilities)).toBe(true);
+    // Membership, never index or ordering: the array grows, and a client that
+    // depended on a position would break the first time an entry is added.
+    expect(body.capabilities).toContain("events.operation_id");
+  });
+
+  it("serves capabilities without auth, like the rest of /health", async () => {
+    // A client has to be able to ask what the daemon supports BEFORE it can
+    // present a credential — otherwise capability detection is unreachable
+    // for exactly the clients that need it.
+    adapter = await startAdapter({ token: "sekret" });
+    const r = await fetch(`${baseUrl}/health`);
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { capabilities?: string[] };
+    expect(body.capabilities?.length).toBeGreaterThan(0);
+  });
 });
 
 describe("WebUiAdapter — POST /prompt", () => {

--- a/src/adapters/webui/index.ts
+++ b/src/adapters/webui/index.ts
@@ -186,7 +186,11 @@ export class WebUiAdapter {
     const url = new URL(req.url);
 
     if (url.pathname === "/health" && req.method === "GET") {
-      return jsonOk({ ok: true, version: ADAPTER_VERSION });
+      return jsonOk({
+        ok: true,
+        version: ADAPTER_VERSION,
+        capabilities: ADAPTER_CAPABILITIES,
+      });
     }
 
     if (url.pathname === "/prompt" && req.method === "POST") {
@@ -356,6 +360,23 @@ export class WebUiAdapter {
  * specific version; the field exists for forward-compatible client checks.
  */
 const ADAPTER_VERSION = "0.1.0";
+
+/**
+ * What this daemon supports, for clients that must detect capabilities rather
+ * than sniff the version (a client branching on "0.1.0" is doing the brittle
+ * thing).
+ *
+ * Entries name OBSERVABLE BEHAVIOUR, never internal module names: a consumer
+ * vendoring this core sees behaviour that survives a refactor, where an
+ * internal name would drift.
+ *
+ * The array grows; it does not reorder or repurpose entries. A client that
+ * checks for membership keeps working as it fills.
+ */
+const ADAPTER_CAPABILITIES = [
+  /** Every event published for a turn carries `promise_id` (the value `POST /prompt` returned). */
+  "events.operation_id",
+] as const;
 
 function parseBind(bind: string | undefined): { host: string; port: number } {
   // Default per spec §5.5.4 sketch.

--- a/src/adapters/webui/index.ts
+++ b/src/adapters/webui/index.ts
@@ -190,6 +190,8 @@ export class WebUiAdapter {
         ok: true,
         version: ADAPTER_VERSION,
         capabilities: ADAPTER_CAPABILITIES,
+        instance_id: INSTANCE_ID,
+        started_at: STARTED_AT,
       });
     }
 
@@ -373,9 +375,38 @@ const ADAPTER_VERSION = "0.1.0";
  * The array grows; it does not reorder or repurpose entries. A client that
  * checks for membership keeps working as it fills.
  */
+/**
+ * Identity of this daemon PROCESS, minted once at module load.
+ *
+ * The only property that matters is the one a version cannot give: it changes
+ * when the daemon restarts and does not change when it has not. A client that
+ * reconnects and sees a different value knows its cached state — subscriptions,
+ * in-flight operation ids, the sequence number it had reached — belongs to a
+ * process that no longer exists, and can resynchronise instead of resuming
+ * against a daemon that never heard of any of it.
+ *
+ * Version cannot answer that: a restart onto the same build reports the same
+ * version, which is precisely the case a desktop must not mistake for
+ * continuity.
+ *
+ * `started_at` rides along because it answers "how long has this been up"
+ * without a second round trip, and it makes a restart legible in a log where a
+ * random id is not.
+ */
+const INSTANCE_ID = randomUUID();
+const STARTED_AT = new Date().toISOString();
+
 const ADAPTER_CAPABILITIES = [
   /** Every event published for a turn carries `promise_id` (the value `POST /prompt` returned). */
   "events.operation_id",
+  /**
+   * An event whose `promise_id` cannot be trusted carries
+   * `correlation_ambiguous: true`. A client that sees this capability can
+   * branch on the flag; one that does not must treat every id as advisory.
+   */
+  "events.correlation_ambiguity",
+  /** `/health` reports `instance_id` and `started_at`, which change on restart. */
+  "health.instance_identity",
 ] as const;
 
 function parseBind(bind: string | undefined): { host: string; port: number } {

--- a/src/adapters/webui/index.ts
+++ b/src/adapters/webui/index.ts
@@ -397,12 +397,40 @@ const INSTANCE_ID = randomUUID();
 const STARTED_AT = new Date().toISOString();
 
 const ADAPTER_CAPABILITIES = [
-  /** Every event published for a turn carries `promise_id` (the value `POST /prompt` returned). */
+  /**
+   * Events published for a turn carry `promise_id` — the value `POST /prompt`
+   * returned — while the operation owns the agent's slot.
+   *
+   * Deliberately NOT "every event": `response.turn_end` reaches the bus from
+   * the JSONL tailer with no identity of its own, so the slot is held by
+   * counting the terminators an agent still owes. Counting cannot see turns the
+   * bus did not start — an operator typing in the agent's own TUI, a cron tick
+   * — so such a turn ends a live operation early.
+   *
+   * The consequence is worse than a missing id, and the `correlation_ambiguity`
+   * note below spells it out: the freed slot is taken by the next submission
+   * without being flagged, and the earlier operation's remaining events publish
+   * under that later id. Read this capability as "ids are emitted and are
+   * correct in the common case", never as a guarantee of attribution.
+   */
   "events.operation_id",
   /**
-   * An event whose `promise_id` cannot be trusted carries
-   * `correlation_ambiguous: true`. A client that sees this capability can
-   * branch on the flag; one that does not must treat every id as advisory.
+   * An event whose `promise_id` is known to be untrustworthy carries
+   * `correlation_ambiguous: true` — set when a submit lands while the slot is
+   * still occupied, and held for the whole life of that operation.
+   *
+   * KNOWN, and stronger than it may read: the flag covers overlapping submits,
+   * NOT the ambient-turn case above. There the slot is released early, so the
+   * next submission finds it free and is not flagged — and the first
+   * operation's remaining events, including its final answer, then publish
+   * under the SECOND operation's id with no flag at all. A client following the
+   * second operation receives the first one's answer as its own result, and the
+   * envelope asserts certainty.
+   *
+   * So a present id is ADVISORY, not authoritative: it is trustworthy only
+   * where the client has out-of-band evidence that no turn ran on that agent
+   * other than the ones it submitted. Threading identity from the submitting
+   * side is the complete fix, tracked as #239.
    */
   "events.correlation_ambiguity",
   /** `/health` reports `instance_id` and `started_at`, which change on restart. */

--- a/src/bus/__tests__/correlation-ambiguity.test.ts
+++ b/src/bus/__tests__/correlation-ambiguity.test.ts
@@ -1,0 +1,122 @@
+/**
+ * When an operation id cannot be trusted, the envelope has to say so.
+ *
+ * `promise_id` is per-agent, not per-operation, so a prompt arriving while the
+ * previous turn has not reached its terminator makes every event after it
+ * carry an id that may belong to the other turn. A client cannot detect that
+ * from outside: correlation looks exact and is wrong, which is the failure
+ * class §3.2 exists to keep out of this seam, arriving through a different
+ * door.
+ *
+ * The existing `originAmbiguous` set is NOT the right signal, and these tests
+ * pin why. It is armed from and cleared with `lastPromptOrigin`, which the
+ * final reply releases — so it is blind to the window between a turn's final
+ * reply and its lagged `response.turn_end`, and it is already gone by the time
+ * the events that most need correlating are published.
+ *
+ * Run with: `bun test src/bus/__tests__/correlation-ambiguity.test.ts`
+ */
+
+import { describe, it, expect } from "bun:test";
+import { randomUUID } from "crypto";
+import { createBusCore, type BusCore } from "../core";
+import type { BusEvent } from "../types";
+
+const mockAppend = (async () => ({ id: randomUUID() })) as unknown as never;
+
+function makeBus(): { bus: BusCore; events: BusEvent[] } {
+  const events: BusEvent[] = [];
+  const bus = createBusCore({ eventLogAppend: mockAppend, onError: () => {} });
+  bus.subscribe({}, (e) => events.push(e));
+  return { bus, events };
+}
+
+function prompt(bus: BusCore, agent_id: string, text: string) {
+  return bus.sendPrompt({ agent_id, origin: "webui", origin_id: "http", user_id: "u", text });
+}
+
+function tailerEvent(agent_id: string, topic: BusEvent["topic"], payload: unknown = {}): BusEvent {
+  return { ts: Date.now(), agent_id, session_id: "sess-1", topic, payload };
+}
+
+const flagged = (events: BusEvent[]) =>
+  events.filter((e) => (e as { correlation_ambiguous?: true }).correlation_ambiguous === true);
+
+describe("correlation ambiguity on the envelope", () => {
+  it("a clean single turn is not flagged", async () => {
+    const { bus, events } = makeBus();
+    await prompt(bus, "a", "one");
+    bus.ingestSessionEvent(tailerEvent("a", "response.text", { text: "hi" }));
+    expect(flagged(events)).toEqual([]);
+  });
+
+  it("a second prompt while the first has not terminated flags what follows", async () => {
+    const { bus, events } = makeBus();
+    await prompt(bus, "a", "one");
+    // No turn_end for the first: its slot is still occupied.
+    await prompt(bus, "a", "two");
+    bus.ingestSessionEvent(tailerEvent("a", "response.text", { text: "hi" }));
+    expect(flagged(events).length).toBeGreaterThan(0);
+  });
+
+  it("flags the lagged-turn_end window that originAmbiguous cannot see", async () => {
+    // The sequential race (#217 finding 3, deferred #239): the first turn
+    // produces its final reply, the second is submitted, and only then does the
+    // first turn's `response.turn_end` arrive — stamped with the second
+    // operation's id. `lastPromptOrigin` is cleared by the final reply, so a
+    // taint armed from it is already gone here. Keyed on the operation slot,
+    // which outlives the final reply, this window is covered.
+    const { bus, events } = makeBus();
+    await prompt(bus, "a", "one");
+    bus.ingestReply({ agent_id: "a", intent: "final", text: "done" } as never);
+    await prompt(bus, "a", "two");
+    events.length = 0;
+    bus.ingestSessionEvent(tailerEvent("a", "response.turn_end"));
+    expect(flagged(events).length).toBeGreaterThan(0);
+  });
+
+  it("the turn_end that ends the turn clears the taint for the next one", async () => {
+    const { bus, events } = makeBus();
+    await prompt(bus, "a", "one");
+    await prompt(bus, "a", "two");
+    bus.ingestSessionEvent(tailerEvent("a", "response.turn_end"));
+    await prompt(bus, "a", "three");
+    events.length = 0;
+    bus.ingestSessionEvent(tailerEvent("a", "response.text", { text: "clean" }));
+    expect(flagged(events)).toEqual([]);
+  });
+
+  it("agents stay apart — one agent's overlap does not taint another", async () => {
+    const { bus, events } = makeBus();
+    await prompt(bus, "a", "one");
+    await prompt(bus, "a", "two"); // a is now ambiguous
+    await prompt(bus, "b", "one"); // b is clean
+    events.length = 0;
+    bus.ingestSessionEvent(tailerEvent("b", "response.text", { text: "hi" }));
+    expect(flagged(events)).toEqual([]);
+  });
+
+  it("the flag never rides alone — no operation id, no flag", async () => {
+    // An event outside any turn has nothing for the flag to qualify. Emitting
+    // it there would tell a client its correlation is uncertain when it has no
+    // correlation at all.
+    const { bus, events } = makeBus();
+    bus.ingestSessionEvent(tailerEvent("never-prompted", "response.text", { text: "orphan" }));
+    const orphans = events.filter((e) => e.agent_id === "never-prompted");
+    expect(orphans.length).toBeGreaterThan(0);
+    for (const e of orphans) {
+      expect((e as { correlation_ambiguous?: true }).correlation_ambiguous).toBeUndefined();
+      expect(e.promise_id).toBeUndefined();
+    }
+  });
+
+  it("the caller's event object is not mutated", async () => {
+    const { bus } = makeBus();
+    await prompt(bus, "a", "one");
+    await prompt(bus, "a", "two");
+    const mine = tailerEvent("a", "response.text", { text: "hi" });
+    bus.ingestSessionEvent(mine);
+    expect((mine as { correlation_ambiguous?: true }).correlation_ambiguous).toBeUndefined();
+    expect(mine.promise_id).toBeUndefined();
+  });
+});

--- a/src/bus/__tests__/correlation-ambiguity.test.ts
+++ b/src/bus/__tests__/correlation-ambiguity.test.ts
@@ -75,15 +75,49 @@ describe("correlation ambiguity on the envelope", () => {
     expect(flagged(events).length).toBeGreaterThan(0);
   });
 
-  it("the turn_end that ends the turn clears the taint for the next one", async () => {
+  it("draining every outstanding turn clears the taint for the next one", async () => {
+    // Two prompts went out, so two terminators are owed. One does not drain the
+    // agent — asserting that it did was asserting the bug below.
     const { bus, events } = makeBus();
     await prompt(bus, "a", "one");
     await prompt(bus, "a", "two");
+    bus.ingestSessionEvent(tailerEvent("a", "response.turn_end"));
     bus.ingestSessionEvent(tailerEvent("a", "response.turn_end"));
     await prompt(bus, "a", "three");
     events.length = 0;
     bus.ingestSessionEvent(tailerEvent("a", "response.text", { text: "clean" }));
     expect(flagged(events)).toEqual([]);
+  });
+
+  it("a lagged terminator does not strip the id of the turn still running", async () => {
+    // The failure this counting exists to prevent: P1 replies, P2 is submitted
+    // and takes the slot, P1's lagged `response.turn_end` lands. Releasing on
+    // the first terminator to arrive would leave the rest of P2's events with
+    // no operation id at all — correlation vanishing mid-run, which a client
+    // would read as a new operation starting.
+    const { bus, events } = makeBus();
+    await prompt(bus, "a", "P1");
+    bus.ingestReply({ agent_id: "a", intent: "final", text: "P1 done" } as never);
+    const { promise_id: p2 } = await prompt(bus, "a", "P2");
+    bus.ingestSessionEvent(tailerEvent("a", "response.turn_end")); // P1's, late
+    events.length = 0;
+    bus.ingestSessionEvent(tailerEvent("a", "response.text", { text: "P2 still going" }));
+    const seen = events.filter((e) => e.topic === "response.text");
+    expect(seen.length).toBeGreaterThan(0);
+    for (const e of seen) expect(e.promise_id).toBe(p2);
+  });
+
+  it("the prompt event of an ambiguous operation carries the flag", async () => {
+    // It mints its own id at the top level, so a stamper that returns early on
+    // an id already present skips the flag with it — and this is the first
+    // event a client sees for the operation.
+    const { bus, events } = makeBus();
+    await prompt(bus, "a", "one");
+    events.length = 0;
+    await prompt(bus, "a", "two");
+    const prompts = events.filter((e) => e.topic === "prompt");
+    expect(prompts.length).toBe(1);
+    expect((prompts[0] as { correlation_ambiguous?: true }).correlation_ambiguous).toBe(true);
   });
 
   it("agents stay apart — one agent's overlap does not taint another", async () => {

--- a/src/bus/__tests__/operation-id-propagation.test.ts
+++ b/src/bus/__tests__/operation-id-propagation.test.ts
@@ -1,0 +1,230 @@
+/**
+ * `promise_id` must reach the events of the turn it started, not just the
+ * caller of `sendPrompt`.
+ *
+ * Before this, the identifier travelled exactly one hop: it was minted in
+ * `sendPrompt`, returned to the submitter, written into the payload of the
+ * `prompt` event — and then nothing carried it further. A client holding the
+ * value from `POST /prompt` had no way to recognise the events that answered
+ * it, because the other bridge is unusable too: `session_id` is `""` at the
+ * prompt boundary. The only remaining option was inferring correlation from
+ * agent id plus arrival order, which is exactly the inference a control client
+ * must not be asked to do.
+ *
+ * Run with: `bun test src/bus/__tests__/operation-id-propagation.test.ts`
+ */
+
+import { describe, it, expect } from "bun:test";
+import { randomUUID } from "crypto";
+import { createBusCore, type BusCore } from "../core";
+import type { BusEvent } from "../types";
+
+const mockAppend = (async () => ({ id: randomUUID() })) as unknown as never;
+
+function makeBus(): { bus: BusCore; events: BusEvent[] } {
+  const events: BusEvent[] = [];
+  // Swallow the error the `error` IPC path reports by design — the test
+  // asserts the slot is released, not that the bus stays quiet.
+  const bus = createBusCore({ eventLogAppend: mockAppend, onError: () => {} });
+  bus.subscribe({}, (e) => events.push(e));
+  return { bus, events };
+}
+
+function prompt(bus: BusCore, agent_id: string, text: string) {
+  return bus.sendPrompt({
+    agent_id,
+    origin: "webui",
+    origin_id: "http",
+    user_id: "user-1",
+    text,
+  });
+}
+
+/** A tailer-shaped event: built elsewhere, handed to the bus, no id of its own. */
+function tailerEvent(agent_id: string, topic: BusEvent["topic"], payload: unknown): BusEvent {
+  return { ts: Date.now(), agent_id, session_id: "sess-1", topic, payload };
+}
+
+describe("operation id propagation", () => {
+  it("stamps the id returned by sendPrompt onto the prompt event itself", async () => {
+    const { bus, events } = makeBus();
+
+    const { promise_id } = await prompt(bus, "alpha", "hello");
+
+    const promptEvents = events.filter((e) => e.topic === "prompt");
+    expect(promptEvents).toHaveLength(1);
+    expect(promptEvents[0].promise_id).toBe(promise_id);
+  });
+
+  it("carries it onto downstream events the tailer hands over", async () => {
+    const { bus, events } = makeBus();
+    const { promise_id } = await prompt(bus, "alpha", "hello");
+
+    bus.ingestSessionEvent(tailerEvent("alpha", "response.text", { text: "working" }));
+    bus.ingestSessionEvent(tailerEvent("alpha", "response.tool_use", { id: "t1" }));
+    bus.ingestSessionEvent(tailerEvent("alpha", "usage", { input_tokens: 1 }));
+
+    const downstream = events.filter((e) => e.topic !== "prompt");
+    expect(downstream.length).toBeGreaterThanOrEqual(3);
+    for (const e of downstream) {
+      expect(e.promise_id).toBe(promise_id);
+    }
+  });
+
+  it("carries it onto response.turn_end — the event a client most needs correlated", async () => {
+    const { bus, events } = makeBus();
+    const { promise_id } = await prompt(bus, "alpha", "hello");
+
+    bus.ingestSessionEvent(tailerEvent("alpha", "response.turn_end", { text: "" }));
+
+    const turnEnd = events.filter((e) => e.topic === "response.turn_end");
+    expect(turnEnd).toHaveLength(1);
+    expect(turnEnd[0].promise_id).toBe(promise_id);
+  });
+
+  it("stops stamping once the turn has ended", async () => {
+    const { bus, events } = makeBus();
+    await prompt(bus, "alpha", "hello");
+
+    bus.ingestSessionEvent(tailerEvent("alpha", "response.turn_end", { text: "" }));
+    bus.ingestSessionEvent(tailerEvent("alpha", "response.text", { text: "late echo" }));
+
+    const late = events.filter((e) => e.topic === "response.text");
+    expect(late).toHaveLength(1);
+    expect(late[0].promise_id).toBeUndefined();
+  });
+
+  it("keeps agents apart — one agent's turn never stamps another's events", async () => {
+    const { bus, events } = makeBus();
+    const a = await prompt(bus, "alpha", "for alpha");
+    const b = await prompt(bus, "beta", "for beta");
+    expect(a.promise_id).not.toBe(b.promise_id);
+
+    bus.ingestSessionEvent(tailerEvent("alpha", "response.text", { text: "a" }));
+    bus.ingestSessionEvent(tailerEvent("beta", "response.text", { text: "b" }));
+
+    const texts = events.filter((e) => e.topic === "response.text");
+    expect(texts).toHaveLength(2);
+    expect(texts.find((e) => e.agent_id === "alpha")?.promise_id).toBe(a.promise_id);
+    expect(texts.find((e) => e.agent_id === "beta")?.promise_id).toBe(b.promise_id);
+  });
+
+  it("does not mutate the event object the caller passed in", async () => {
+    const { bus } = makeBus();
+    await prompt(bus, "alpha", "hello");
+
+    const mine = tailerEvent("alpha", "response.text", { text: "x" });
+    bus.ingestSessionEvent(mine);
+
+    expect(mine.promise_id).toBeUndefined();
+  });
+
+  it("leaves an event that already carries an id alone", async () => {
+    const { bus, events } = makeBus();
+    await prompt(bus, "alpha", "hello");
+
+    const carried = {
+      ...tailerEvent("alpha", "response.text", { text: "x" }),
+      promise_id: "theirs",
+    };
+    bus.ingestSessionEvent(carried);
+
+    const text = events.filter((e) => e.topic === "response.text");
+    expect(text).toHaveLength(1);
+    expect(text[0].promise_id).toBe("theirs");
+  });
+
+  it("leaves events outside any turn unstamped rather than guessing", () => {
+    const { bus, events } = makeBus();
+
+    // No prompt was ever sent for this agent.
+    bus.ingestSessionEvent(tailerEvent("gamma", "session.init", { schema_version: 1 }));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].promise_id).toBeUndefined();
+  });
+
+  // A turn that never reaches `response.turn_end` must still release the slot.
+  // The origin slot next to it learned this the hard way (PR #138 review): a
+  // slot left filled on an abnormal terminator attaches the dead turn's
+  // identity to the NEXT turn. For an operation id that is worse than carrying
+  // none — a client correlates confidently, and wrongly.
+  describe("abnormal turn terminators release the slot", () => {
+    function ipc(bus: BusCore, agent_id: string, msg: unknown): void {
+      (bus as unknown as { handleIpcMessage(a: string, m: unknown): void }).handleIpcMessage(
+        agent_id,
+        msg,
+      );
+    }
+
+    it("a cancelled turn does not stamp the next turn's events", async () => {
+      const { bus, events } = makeBus();
+      const cancelled = await prompt(bus, "alpha", "one");
+
+      ipc(bus, "alpha", { type: "cancel", agent_id: "alpha", reason: "user stopped it" });
+      bus.ingestSessionEvent(tailerEvent("alpha", "response.text", { text: "after cancel" }));
+
+      const after = events.filter((e) => e.topic === "response.text");
+      expect(after).toHaveLength(1);
+      expect(after[0].promise_id).toBeUndefined();
+      expect(after[0].promise_id).not.toBe(cancelled.promise_id);
+    });
+
+    it("an errored turn does not stamp the next turn's events", async () => {
+      const { bus, events } = makeBus();
+      const errored = await prompt(bus, "alpha", "one");
+
+      ipc(bus, "alpha", { type: "error", agent_id: "alpha", code: "E", message: "boom" });
+      bus.ingestSessionEvent(tailerEvent("alpha", "response.text", { text: "after error" }));
+
+      const after = events.filter((e) => e.topic === "response.text");
+      expect(after).toHaveLength(1);
+      expect(after[0].promise_id).toBeUndefined();
+      expect(after[0].promise_id).not.toBe(errored.promise_id);
+    });
+
+    it("keeps stamping across a final reply — the slot outlives it on purpose", async () => {
+      // The origin slot IS released on `intent: "final"`. The operation slot
+      // deliberately is not: `usage` and `response.turn_end` arrive after the
+      // final reply and are exactly what a client needs correlated.
+      const { bus, events } = makeBus();
+      const op = await prompt(bus, "alpha", "one");
+
+      bus.ingestReply({
+        agent_id: "alpha",
+        text: "done",
+        intent: "final",
+      } as Parameters<BusCore["ingestReply"]>[0]);
+      bus.ingestSessionEvent(tailerEvent("alpha", "usage", { input_tokens: 1 }));
+      bus.ingestSessionEvent(tailerEvent("alpha", "response.turn_end", { text: "done" }));
+
+      const usage = events.filter((e) => e.topic === "usage");
+      const turnEnd = events.filter((e) => e.topic === "response.turn_end");
+      expect(usage[0]?.promise_id).toBe(op.promise_id);
+      expect(turnEnd[0]?.promise_id).toBe(op.promise_id);
+    });
+  });
+
+  it("documents the limit: a second prompt takes the slot, so correlation is advisory", async () => {
+    // The boundary a control client must design against, asserted rather than
+    // left to be discovered: the slot is per AGENT, not per operation.
+    //
+    // Overlapping prompts are the OBVIOUS case, shown here. The non-obvious
+    // one is that sequential turns are not safe either — the tailer delivers
+    // `response.turn_end` asynchronously, so a lagged turn_end can land after
+    // the next prompt has taken the slot (#217 finding 3, deferred #239).
+    // That is why the guarantee is ADVISORY and not "exact for sequential
+    // turns": a client cannot detect the lag, so it cannot know which case
+    // it is in.
+    const { bus, events } = makeBus();
+    const first = await prompt(bus, "alpha", "one");
+    const second = await prompt(bus, "alpha", "two");
+
+    bus.ingestSessionEvent(tailerEvent("alpha", "response.text", { text: "whose?" }));
+
+    const text = events.filter((e) => e.topic === "response.text");
+    expect(text).toHaveLength(1);
+    expect(text[0].promise_id).toBe(second.promise_id);
+    expect(text[0].promise_id).not.toBe(first.promise_id);
+  });
+});

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -324,6 +324,32 @@ export class BusCoreImpl implements BusCore {
   private readonly currentOperation = new Map<string, string>();
 
   /**
+   * Agents whose operation id is not trustworthy for the events now being
+   * stamped with it.
+   *
+   * Deliberately NOT `originAmbiguous`, which exists for security attribution
+   * and has the wrong lifetime for this job in two ways.
+   *
+   * It is cleared on `intent: "final"` alongside `lastPromptOrigin`, while the
+   * operation slot deliberately outlives the final reply — so `usage`,
+   * `response.turn_end` and the reply the silent-drop net synthesises would
+   * carry an id with the taint already gone. Those are exactly the events a
+   * client most needs correlated, reported as certain when they are not.
+   *
+   * And it is armed from `lastPromptOrigin`, which the final reply also
+   * clears — so it never sees the window between a turn's final reply and its
+   * lagged `response.turn_end`. That window is the sequential race (#217
+   * finding 3, deferred #239): P1 replies, P2 is submitted and takes the slot,
+   * P1's turn_end lands afterwards and is stamped with P2's id. A client
+   * cannot detect the lag, which is the whole reason to report it.
+   *
+   * Keyed on the operation slot instead, both cases collapse into one
+   * condition — a prompt arriving while a slot is still occupied — and the
+   * taint lives and dies with the id it qualifies.
+   */
+  private readonly correlationAmbiguous = new Set<string>();
+
+  /**
    * Agents whose `lastPromptOrigin` is currently AMBIGUOUS for security
    * attribution: a second prompt overwrote the slot while a prior prompt was
    * still in flight (the residual #239 interleave race). Best-effort *routing*
@@ -539,6 +565,7 @@ export class BusCoreImpl implements BusCore {
           // with the dead turn's id — a client would correlate them to an
           // operation that already finished.
           this.currentOperation.delete(agentId);
+          this.correlationAmbiguous.delete(agentId);
           this.currentTurnReplied.delete(agentId);
           this.currentTurnFinalPublished.delete(agentId);
           // Reply-tool enforcement (#215/#240): drop nudge state with the rest
@@ -607,6 +634,7 @@ export class BusCoreImpl implements BusCore {
     this.agentTurnActive.clear();
     this.originAmbiguous.clear();
     this.currentOperation.clear();
+    this.correlationAmbiguous.clear();
     this.pendingRedelivery.clear();
     this.replyNudged.clear();
     this.pendingNudgeText.clear();
@@ -647,6 +675,16 @@ export class BusCoreImpl implements BusCore {
     };
     // Remember the operation BEFORE publishing so the prompt event and every
     // event after it are stamped from the same slot.
+    //
+    // A slot still occupied means the previous turn has not reached its
+    // terminator, so events from here on cannot be attributed to one operation
+    // with confidence. Say so on the envelope rather than letting a client
+    // correlate confidently and wrongly.
+    if (this.currentOperation.has(req.agent_id)) {
+      this.correlationAmbiguous.add(req.agent_id);
+    } else {
+      this.correlationAmbiguous.delete(req.agent_id);
+    }
     this.currentOperation.set(req.agent_id, promise_id);
     this.publish(promptEvent);
     // Remember the origin so `ingestReply` can attach it to the
@@ -1344,6 +1382,7 @@ export class BusCoreImpl implements BusCore {
     // clearing alongside `agentTurnActive` above would strip it.
     if (e.topic === "response.turn_end" && e.agent_id) {
       this.currentOperation.delete(e.agent_id);
+      this.correlationAmbiguous.delete(e.agent_id);
     }
   }
 
@@ -1457,7 +1496,12 @@ export class BusCoreImpl implements BusCore {
   private stampOperation(event: BusEvent): BusEvent {
     if (event.promise_id !== undefined || !event.agent_id) return event;
     const op = this.currentOperation.get(event.agent_id);
-    return op === undefined ? event : { ...event, promise_id: op };
+    if (op === undefined) return event;
+    // The taint rides with the id it qualifies, never alone: an event carrying
+    // no operation id has nothing for the flag to be about.
+    return this.correlationAmbiguous.has(event.agent_id)
+      ? { ...event, promise_id: op, correlation_ambiguous: true }
+      : { ...event, promise_id: op };
   }
 
   private publish(incoming: BusEvent): void {
@@ -1704,6 +1748,7 @@ export class BusCoreImpl implements BusCore {
         // here too — otherwise the next turn's events carry the cancelled
         // turn's id.
         this.currentOperation.delete(agentId);
+        this.correlationAmbiguous.delete(agentId);
         // Silent-drop safety net (#215): cancelled turn won't produce
         // a real reply OR a `response.turn_end` event — drop the
         // tracking flag to keep the map bounded.
@@ -1806,6 +1851,7 @@ export class BusCoreImpl implements BusCore {
         // Same reason as `cancel`: no turn_end, so the slot must not survive
         // into the next turn.
         this.currentOperation.delete(agentId);
+        this.correlationAmbiguous.delete(agentId);
         // Silent-drop safety net (#215): error path won't produce a
         // turn_end either — clear tracking too.
         this.currentTurnReplied.delete(agentId);

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -350,6 +350,22 @@ export class BusCoreImpl implements BusCore {
   private readonly correlationAmbiguous = new Set<string>();
 
   /**
+   * How many turns are in flight per agent.
+   *
+   * `response.turn_end` is per-agent and carries no identity of its own, so it
+   * cannot say which turn it ends. Releasing the slot on the first one to
+   * arrive is wrong in exactly the case this machinery exists to report: P1
+   * replies, P2 is submitted and takes the slot, P1's lagged turn_end lands —
+   * and would release P2's slot while P2 is still running, leaving the rest of
+   * P2's events with no operation id at all.
+   *
+   * Counting instead, the slot is released when the last outstanding turn ends.
+   * The taint outlives the lagged terminator, which is correct: P2's
+   * correlation really is uncertain for its whole life.
+   */
+  private readonly pendingTurns = new Map<string, number>();
+
+  /**
    * Agents whose `lastPromptOrigin` is currently AMBIGUOUS for security
    * attribution: a second prompt overwrote the slot while a prior prompt was
    * still in flight (the residual #239 interleave race). Best-effort *routing*
@@ -566,6 +582,7 @@ export class BusCoreImpl implements BusCore {
           // operation that already finished.
           this.currentOperation.delete(agentId);
           this.correlationAmbiguous.delete(agentId);
+          this.pendingTurns.delete(agentId);
           this.currentTurnReplied.delete(agentId);
           this.currentTurnFinalPublished.delete(agentId);
           // Reply-tool enforcement (#215/#240): drop nudge state with the rest
@@ -635,6 +652,7 @@ export class BusCoreImpl implements BusCore {
     this.originAmbiguous.clear();
     this.currentOperation.clear();
     this.correlationAmbiguous.clear();
+    this.pendingTurns.clear();
     this.pendingRedelivery.clear();
     this.replyNudged.clear();
     this.pendingNudgeText.clear();
@@ -686,6 +704,7 @@ export class BusCoreImpl implements BusCore {
       this.correlationAmbiguous.delete(req.agent_id);
     }
     this.currentOperation.set(req.agent_id, promise_id);
+    this.pendingTurns.set(req.agent_id, (this.pendingTurns.get(req.agent_id) ?? 0) + 1);
     this.publish(promptEvent);
     // Remember the origin so `ingestReply` can attach it to the
     // outbound `response.text` event for surface-aware routing.
@@ -1381,8 +1400,16 @@ export class BusCoreImpl implements BusCore {
     // published: that event is the one a client most needs correlated, and
     // clearing alongside `agentTurnActive` above would strip it.
     if (e.topic === "response.turn_end" && e.agent_id) {
-      this.currentOperation.delete(e.agent_id);
-      this.correlationAmbiguous.delete(e.agent_id);
+      const left = (this.pendingTurns.get(e.agent_id) ?? 1) - 1;
+      if (left > 0) {
+        // A lagged terminator for an earlier turn. Another turn still owns the
+        // slot; releasing here would strip its id mid-flight.
+        this.pendingTurns.set(e.agent_id, left);
+      } else {
+        this.pendingTurns.delete(e.agent_id);
+        this.currentOperation.delete(e.agent_id);
+        this.correlationAmbiguous.delete(e.agent_id);
+      }
     }
   }
 
@@ -1494,14 +1521,23 @@ export class BusCoreImpl implements BusCore {
    * one. Returns the event unchanged when there is nothing to attach.
    */
   private stampOperation(event: BusEvent): BusEvent {
-    if (event.promise_id !== undefined || !event.agent_id) return event;
+    if (!event.agent_id) return event;
     const op = this.currentOperation.get(event.agent_id);
     if (op === undefined) return event;
-    // The taint rides with the id it qualifies, never alone: an event carrying
-    // no operation id has nothing for the flag to be about.
-    return this.correlationAmbiguous.has(event.agent_id)
-      ? { ...event, promise_id: op, correlation_ambiguous: true }
-      : { ...event, promise_id: op };
+    // Two independent attachments. Returning early on an id that is already
+    // present skipped the flag along with it, so the `prompt` event of an
+    // ambiguous operation — which mints its own id at the top level — was the
+    // one event that never carried the taint. It is also the first event a
+    // client sees for that operation, so the omission was maximally visible.
+    const needsId = event.promise_id === undefined;
+    const needsFlag =
+      event.correlation_ambiguous === undefined && this.correlationAmbiguous.has(event.agent_id);
+    if (!needsId && !needsFlag) return event;
+    // Copy rather than assign: the caller owns the object it passed.
+    const out: BusEvent = { ...event };
+    if (needsId) out.promise_id = op;
+    if (needsFlag) out.correlation_ambiguous = true;
+    return out;
   }
 
   private publish(incoming: BusEvent): void {
@@ -1749,6 +1785,7 @@ export class BusCoreImpl implements BusCore {
         // turn's id.
         this.currentOperation.delete(agentId);
         this.correlationAmbiguous.delete(agentId);
+        this.pendingTurns.delete(agentId);
         // Silent-drop safety net (#215): cancelled turn won't produce
         // a real reply OR a `response.turn_end` event — drop the
         // tracking flag to keep the map bounded.
@@ -1852,6 +1889,7 @@ export class BusCoreImpl implements BusCore {
         // into the next turn.
         this.currentOperation.delete(agentId);
         this.correlationAmbiguous.delete(agentId);
+        this.pendingTurns.delete(agentId);
         // Silent-drop safety net (#215): error path won't produce a
         // turn_end either — clear tracking too.
         this.currentTurnReplied.delete(agentId);

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -295,6 +295,35 @@ export class BusCoreImpl implements BusCore {
   >();
 
   /**
+   * Per-agent identifier of the operation currently in flight, so every event
+   * published during the turn can carry it (`BusEvent.promise_id`).
+   *
+   * Same lifetime as `lastPromptOrigin`, and released on the same set of
+   * abnormal terminators (disconnect, cancel, error) for the same reason the
+   * PR #138 review gave for the origin slot: on a path that never emits the
+   * normal terminator, a slot left filled attaches the DEAD turn's identity to
+   * the NEXT turn's events. For an operation id that is worse than carrying
+   * none — a client would confidently correlate unrelated events to an
+   * operation that already finished.
+   *
+   * One clear site is deliberately NOT shared: `ingestReply` releases the
+   * origin slot on `intent: "final"`, but events legitimately follow a final
+   * reply inside the same turn (`usage`, `response.turn_end`, and the reply the
+   * silent-drop net synthesises). Releasing there would strip exactly the
+   * events a client most needs correlated, so the operation slot survives the
+   * final reply and is released on `response.turn_end`.
+   *
+   * And the same limitation, which is WIDER than concurrency: a second prompt
+   * while one is in flight overwrites the slot (what `originAmbiguous`
+   * records), but the tailer's asynchronous `response.turn_end` means even
+   * sequential turns can cross — see the residual-race note in
+   * `handleTurnEnd` (#217 finding 3, deferred #239). Correlation from this
+   * slot is advisory; exact correlation needs turn identity carried through
+   * the tailer.
+   */
+  private readonly currentOperation = new Map<string, string>();
+
+  /**
    * Agents whose `lastPromptOrigin` is currently AMBIGUOUS for security
    * attribution: a second prompt overwrote the slot while a prior prompt was
    * still in flight (the residual #239 interleave race). Best-effort *routing*
@@ -505,6 +534,11 @@ export class BusCoreImpl implements BusCore {
           // origin and misroute (5-agent review on PR #138, A1 finding).
           this.lastPromptOrigin.delete(agentId);
           this.originAmbiguous.delete(agentId);
+          // Same lifecycle: no `response.turn_end` is coming either, so the
+          // operation slot would stay filled and stamp the NEXT turn's events
+          // with the dead turn's id — a client would correlate them to an
+          // operation that already finished.
+          this.currentOperation.delete(agentId);
           this.currentTurnReplied.delete(agentId);
           this.currentTurnFinalPublished.delete(agentId);
           // Reply-tool enforcement (#215/#240): drop nudge state with the rest
@@ -572,6 +606,7 @@ export class BusCoreImpl implements BusCore {
     this.inFlightDeliveries.clear();
     this.agentTurnActive.clear();
     this.originAmbiguous.clear();
+    this.currentOperation.clear();
     this.pendingRedelivery.clear();
     this.replyNudged.clear();
     this.pendingNudgeText.clear();
@@ -600,6 +635,7 @@ export class BusCoreImpl implements BusCore {
       // the agent's session_id (spec §7).
       session_id: "",
       topic: "prompt",
+      promise_id,
       payload: {
         origin: req.origin,
         origin_id: req.origin_id,
@@ -609,6 +645,9 @@ export class BusCoreImpl implements BusCore {
         promise_id,
       },
     };
+    // Remember the operation BEFORE publishing so the prompt event and every
+    // event after it are stamped from the same slot.
+    this.currentOperation.set(req.agent_id, promise_id);
     this.publish(promptEvent);
     // Remember the origin so `ingestReply` can attach it to the
     // outbound `response.text` event for surface-aware routing.
@@ -1300,6 +1339,12 @@ export class BusCoreImpl implements BusCore {
       this.agentTurnActive.delete(e.agent_id);
     }
     this.publish(e);
+    // Release the operation slot only AFTER `response.turn_end` has been
+    // published: that event is the one a client most needs correlated, and
+    // clearing alongside `agentTurnActive` above would strip it.
+    if (e.topic === "response.turn_end" && e.agent_id) {
+      this.currentOperation.delete(e.agent_id);
+    }
   }
 
   /**
@@ -1405,7 +1450,28 @@ export class BusCoreImpl implements BusCore {
    * log. Errors in either path are isolated; one bad subscriber must not
    * block other dispatches or fail the audit write.
    */
-  private publish(event: BusEvent): void {
+  /**
+   * Attach the agent's in-flight operation id to an event that doesn't have
+   * one. Returns the event unchanged when there is nothing to attach.
+   */
+  private stampOperation(event: BusEvent): BusEvent {
+    if (event.promise_id !== undefined || !event.agent_id) return event;
+    const op = this.currentOperation.get(event.agent_id);
+    return op === undefined ? event : { ...event, promise_id: op };
+  }
+
+  private publish(incoming: BusEvent): void {
+    // 0. Stamp the in-flight operation id. Every event that reaches a
+    //    subscriber passes through here — those minted in this class, and
+    //    those the JSONL tailer hands over via `ingestSessionEvent` — so this
+    //    is the one place the identifier has to be attached.
+    //
+    //    Copy rather than assign: the caller owns the object it passed, and a
+    //    field appearing on it after the call would be a surprise. An event
+    //    that already carries an id, or belongs to no operation, is passed
+    //    through untouched — no copy, no allocation.
+    const event = this.stampOperation(incoming);
+
     // 1. Audit log. Fire-and-forget on the promise — durability is the
     //    event-log's job. We swallow errors into onError so a transient
     //    disk failure doesn't take the bus down.
@@ -1634,6 +1700,10 @@ export class BusCoreImpl implements BusCore {
         // on PR #138, A1 finding).
         this.lastPromptOrigin.delete(agentId);
         this.originAmbiguous.delete(agentId);
+        // No `response.turn_end` is coming, so release the operation slot
+        // here too — otherwise the next turn's events carry the cancelled
+        // turn's id.
+        this.currentOperation.delete(agentId);
         // Silent-drop safety net (#215): cancelled turn won't produce
         // a real reply OR a `response.turn_end` event — drop the
         // tracking flag to keep the map bounded.
@@ -1733,6 +1803,9 @@ export class BusCoreImpl implements BusCore {
         // origin (5-agent review on PR #138, A1 finding).
         this.lastPromptOrigin.delete(agentId);
         this.originAmbiguous.delete(agentId);
+        // Same reason as `cancel`: no turn_end, so the slot must not survive
+        // into the next turn.
+        this.currentOperation.delete(agentId);
         // Silent-drop safety net (#215): error path won't produce a
         // turn_end either — clear tracking too.
         this.currentTurnReplied.delete(agentId);

--- a/src/bus/types.ts
+++ b/src/bus/types.ts
@@ -136,6 +136,21 @@ export interface BusEvent<P = unknown> {
    * this does not provide.
    */
   promise_id?: string;
+
+  /**
+   * The operation id on this event is ADVISORY rather than exact.
+   *
+   * Set when a prompt arrived while the agent's previous operation had not
+   * reached its terminator, so events from that point cannot be attributed to
+   * one operation with confidence. A client should render the run as
+   * correlation-uncertain rather than drawing a confident parent — §3.3's
+   * degrade-visibly rather than fail-silently, applied to correlation.
+   *
+   * Absent means the slot was free when the operation began. It does not mean
+   * exactness: `promise_id` is advisory in general, and exact correlation needs
+   * turn identity carried through the tailer (#239).
+   */
+  correlation_ambiguous?: true;
   /** Original JSONL line or MCP message — kept for audit. */
   raw?: unknown;
 }

--- a/src/bus/types.ts
+++ b/src/bus/types.ts
@@ -112,6 +112,30 @@ export interface BusEvent<P = unknown> {
   topic: BusEventTopic;
   /** Topic-specific payload. */
   payload: P;
+  /**
+   * Identifier of the operation (prompt submission) this event belongs to.
+   *
+   * `sendPrompt` mints it, returns it to the submitter, and stamps it on
+   * every event published for the turn it starts — so a client can follow a
+   * submission through to its results without inferring correlation from
+   * arrival order.
+   *
+   * Optional: events that belong to no operation (session lifecycle, tailer
+   * output observed outside a turn) carry none. Absent is a meaningful
+   * answer, not a gap.
+   *
+   * ADVISORY, not a guarantee. The slot is per AGENT, so two prompts in
+   * flight on the same agent share it — and, less obviously, sequential
+   * turns are not safe either: the JSONL tailer delivers `response.turn_end`
+   * asynchronously, so a lagged turn_end can land after the NEXT prompt has
+   * taken the slot. That race is documented at `core.ts` (#217 finding 3)
+   * and tracked as #239; it is not something a client can detect.
+   *
+   * So: treat a matching id as good evidence, never as proof. Exact
+   * correlation needs turn identity carried through the tailer (#239), which
+   * this does not provide.
+   */
+  promise_id?: string;
   /** Original JSONL line or MCP message — kept for audit. */
   raw?: unknown;
 }


### PR DESCRIPTION
Implements the two asks in ultraassist/ClaudeClaw-Ultra#7, authored here rather than in the vendored copy so it flows down on the next rebase.

## Problem

`sendPrompt` mints a `promise_id`, returns it to the submitter, and writes it into the payload of the `prompt` event. Then nothing carries it further.

`rg promise_id src` outside tests returns nine lines, all in `core.ts` and the web adapter. A client holding the value from `POST /prompt` had no way to recognise the events that answered it — `response.text`, `response.tool_use`, `tool_result`, `usage` and `response.turn_end` all arrived without it. The obvious fallback is unusable too: `session_id` is `""` at the prompt boundary, by design, with the tailer filling it in later.

So the only option left was inferring correlation from `agent_id` plus arrival order — the inference a control client should not be asked to make.

Separately, `/health` reported a version but no capability set, so a client had to branch on `"0.1.0"` to decide what the daemon can do.

## Fix

**One stamp point, not many.** Every event that reaches a subscriber passes through one private `publish()` — those minted in the core, and those the JSONL tailer hands over via `ingestSessionEvent`, which ends in the same call. The id is attached there, from a per-agent slot set on `sendPrompt`. **The tailer is not touched.**

**The slot is released on the same terminators as `lastPromptOrigin`** — `response.turn_end`, plus disconnect, cancel and error. The PR #138 review already established why for the origin slot: on a path that never emits the normal terminator, a slot left filled attaches the dead turn's identity to the next turn. For an operation id that is worse than carrying none, because a client correlates confidently and wrongly.

**One clear site is deliberately not shared.** `ingestReply` releases the origin slot on `intent: "final"`. The operation slot outlives it: `usage`, `response.turn_end`, and the reply the silent-drop net synthesises all arrive after the final reply, and they are precisely what a client needs correlated.

**The stamp copies rather than assigns** — the caller owns the object it passed, and a field appearing on it after the call would be a surprise. An event that already carries an id, or belongs to no turn, is returned untouched with no allocation.

**`capabilities` on `/health`** lists observable behaviour, never internal module names, so the entries survive a refactor and stay meaningful across the vendored-copy boundary. The array grows without reordering; membership checks keep working as it fills.

## The boundary this does not close — correlation is ADVISORY

The slot is per **agent**, not per operation, and the limitation is wider than it first looks.

The obvious case is overlap: two prompts in flight on one agent share the slot, so events after the second carry the second id. That is the same limitation `lastPromptOrigin` has and the reason `originAmbiguous` exists.

The non-obvious case is that **sequential turns are not safe either**. The residual race documented in `handleTurnEnd` (#217 finding 3, deferred #239) is not about overlapping submission: the tailer delivers `response.turn_end` asynchronously, so P1 can finish, P2 can be submitted and take the slot, and P1's lagged turn_end can land afterwards. A client cannot detect the lag, so it cannot know which case it is in.

So the honest guarantee is **advisory, not exact** — a matching id is good evidence, never proof. This is stated in the type docs and asserted in the tests rather than left to be discovered.

Exact correlation needs turn identity carried through the tailer, which is #239. Worth recording what I measured while checking whether that was available here: every JSONL line carries `uuid`/`parentUuid`, and on a real 3369-line session log the assistant lines chain back to their originating user line 614 times out of 643 (the ~4.5% that break are chains crossing a compaction boundary). So the identity exists; making the tailer chain-aware is a separate change with real open questions (eviction, `isSidechain`, compaction boundaries), which is why it is not in this one.

## Test plan

**12 unit tests** in `src/bus/__tests__/operation-id-propagation.test.ts`, plus 2 on `/health`:

- the prompt event, and every downstream event, carry the id returned by `sendPrompt`
- `response.turn_end` carries it — the event a client most needs
- stamping stops once the turn ends
- agents stay apart; one agent's turn never stamps another's events
- the caller's object is not mutated
- an event that already carries an id keeps it
- events outside any turn stay unstamped rather than guessing
- cancelled and errored turns do not stamp the next turn's events
- a final reply does **not** end the stamping — the events after it still correlate
- the advisory limit above, asserted explicitly
- `/health` advertises the capability, and does so without auth (a client must be able to ask what the daemon supports before it can present a credential)

**Counter-proof, both halves.** With the source reverted to the base, 7 of these fail. Removing only the three abnormal-terminator releases turns exactly the two matching tests red. A green test that would not go red proves nothing, so both were checked.

**End to end over the real wire**, not mocks — real bus core, real web adapter on an ephemeral port, real WebSocket client:

```
== 1. GET /health ==
   {"ok":true,"version":"0.1.0","capabilities":["events.operation_id"]}

== 3. the client submits a prompt over HTTP ==
   POST /prompt -> {"ok":true,"promise_id":"a51b9ffe-…"}

== 5. what arrived on the wire ==
   prompt                 promise_id=MATCHES the submission
   response.text          promise_id=MATCHES the submission
   response.tool_use      promise_id=MATCHES the submission
   tool_result            promise_id=MATCHES the submission
   usage                  promise_id=MATCHES the submission
   response.text          promise_id=MATCHES the submission   <- synthesised by the silent-drop net
   response.turn_end      promise_id=MATCHES the submission

   7/7 events correlate to the submission by id alone.

== 6. after the turn, a late event is NOT attributed ==
   response.text          promise_id=undefined
```

That run also exercised the silent-drop recovery path by accident, which was worth seeing: the reply that net synthesises correlates too.

**Gates:** `bun run lint` clean, `bun run typecheck` clean, and the CI test set green.

## Compatibility

`promise_id` is optional on `BusEvent`, no existing payload moved, and the `prompt` event keeps the copy in its payload. Existing subscribers see one new field and are otherwise unaffected. Plugin and marketplace versions bumped for the shipped-code guard.

Refs ultraassist/ClaudeClaw-Ultra#7

---

## Gate status — declared rather than implied

This repository's SDC gate has twelve checks. Nine are green on this sha; three are not, and rather than let you discover that, here is exactly what you are receiving.

**Green:** `issue` (#370) · `review-pr` · `t1` · `t2` · `code-review` · `security` · `adversarial` · `preflight` · `version-bump`

**Not green, and why:**

- **`ultra`** — the multi-agent review is user-triggered and billed, so it has not run against this sha yet. The review PR on the fork is open and labelled for it. **Treat this draft as pre-ultra-review.**
- **`live-test`** — exercising this on the running daemon needs a service restart, which would kill the session doing the work. The substitute is in the test plan above: real bus core, real adapter, real WebSocket, on the host that runs the daemon. That is not the same thing, and I am not claiming it is.
- **`destination`** — the gate refuses a `feat` commit aimed at Plus, because Plus is frozen for features and new capability belongs in Ultra. It is right as a default, and I am overriding it on your written instruction in ultraassist/ClaudeClaw-Ultra#7: *"The daemon change must be authored in TerrysPOV/ClaudeClaw-Plus, not in Ultra's src/ … a fix written directly into Ultra's src/ diverges from core and gets clobbered on the next rebase."* If you would rather this went to Ultra after all, say so and I will move it.

Opened as a **draft** deliberately: the code is there for E2 to design against, and it should not merge before the ultra review has seen it.
