### PR TITLE
fix(telegram): stop acking a 'discuss' tap as approved

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.238",
+      "version": "2.2.239",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.238",
+  "version": "2.2.239",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/commands/__tests__/telegram-pending-ack.test.ts
+++ b/src/commands/__tests__/telegram-pending-ack.test.ts
@@ -33,12 +33,50 @@ describe("ackForAlready (#314)", () => {
     );
   });
 
-  it("omits the timestamp when absent or unparseable, defaults to approved", () => {
+  it("omits the timestamp when absent or unparseable", () => {
     expect(ackForAlready("already:approve")).toBe("✅ Déjà approuvé");
     expect(ackForAlready("already:approve:not-a-date")).toBe("✅ Déjà approuvé");
-    // Unknown decision string → treated as the approve default (informative, not alarming).
+  });
+
+  it("reports an unknown decision instead of calling it approved", () => {
+    // This assertion is the reverse of the one it replaces, deliberately. The
+    // old test asserted that an unrecognised decision defaults to "Déjà
+    // approuvé" — "informative, not alarming". That default is the defect: the
+    // decision vocabulary is not owned here, and the live database holds 39
+    // distinct values. Answering "approved" to a value this layer has never
+    // seen is not informative, it is a guess presented as a fact.
     expect(ackForAlready("already:done:2026-07-16T11:51:00")).toBe(
-      "✅ Déjà approuvé (16/07 11:51)",
+      "↩︎ Déjà traité — done (16/07 11:51)",
+    );
+  });
+
+  it("does not call a refusal an approval, in either ack path", () => {
+    // `refuse` runs `tuner refuse`, which blocks the pattern for 30 days, and
+    // its button reads "je le refuse pour 30 jours". It reached the default
+    // branch, so both paths answered approved. Telling someone their refusal
+    // was approved is the sharpest form of this bug.
+    expect(ackForResolution("ok", "refuse")).toBe("❌ Rejeté");
+    expect(ackForAlready("already:refuse:2026-07-16T11:51:00")).toBe(
+      "❌ Déjà rejeté (16/07 11:51)",
+    );
+  });
+
+  it("does not call a look at the details a decision", () => {
+    // `details` deliberately leaves the action pending — it shows something and
+    // decides nothing. Acking it as approved reported a decision that was never
+    // taken.
+    expect(ackForResolution("ok", "details")).toBe("👀 Consulté");
+    expect(ackForAlready("already:details:2026-07-16T11:51:00")).toBe(
+      "👀 Déjà consulté (16/07 11:51)",
+    );
+  });
+
+  it("answers `discuss` the same way in both paths — the rule lived in one and not the other", () => {
+    expect(ackForResolution("ok", "discuss")).toBe(
+      "💬 Envoyé en discussion — réponds pour continuer",
+    );
+    expect(ackForAlready("already:discuss:2026-07-16T11:51:00")).toBe(
+      "💬 Déjà envoyé en discussion (16/07 11:51)",
     );
   });
 });
@@ -79,6 +117,16 @@ describe("ackForResolution", () => {
     expect(ackForResolution("ok", "skip")).toBe("⏸ Plus tard");
     expect(ackForResolution("ok", "reject")).toBe("❌ Rejeté");
     expect(ackForResolution("ok", "cancel")).toBe("❌ Rejeté");
+    // `discuss` does not apply the proposal — it routes to the discussion
+    // handler, which opens a thread on it. Acking it as "Approuvé" would tell
+    // the operator something that did not happen. Case-insensitive, because the
+    // decision arrives from a callback payload that is not normalised.
+    expect(ackForResolution("ok", "discuss")).toBe(
+      "💬 Envoyé en discussion — réponds pour continuer",
+    );
+    expect(ackForResolution("ok", "DISCUSS")).toBe(
+      "💬 Envoyé en discussion — réponds pour continuer",
+    );
   });
 
   it("delegates an already-resolved tap to ackForAlready", () => {
@@ -148,5 +196,19 @@ describe("describeResolverFailure", () => {
     expect(describeResolverFailure({ timedOut: false, signal: "SIGKILL", code: null })).toBe(
       "killed by SIGKILL",
     );
+  });
+});
+
+describe("an unknown decision reads the same in both paths", () => {
+  it("echoes one normalised form, whatever case the caller passed", () => {
+    // The earlier tests all used a lowercase value, so they could not see this:
+    // `ackForAlready` lower-cases while parsing and `ackForResolution` does not,
+    // so the same decision printed two different ways depending only on which
+    // path resolved it. Classification was never wrong — the display was.
+    expect(ackForResolution("ok", "Done")).toBe("↩︎ Décision enregistrée — done");
+    expect(ackForAlready("already:Done:2026-07-16T11:51:00")).toBe(
+      "↩︎ Déjà traité — done (16/07 11:51)",
+    );
+    expect(ackForResolution("ok", "  DONE  ")).toBe("↩︎ Décision enregistrée — done");
   });
 });

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1834,6 +1834,52 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
  * `resolved_at` is the ISO timestamp the resolver reports; it is rendered
  * `DD/MM HH:MM` when parseable, omitted otherwise.
  */
+/**
+ * What a decision value actually did, as far as this layer can honestly tell.
+ *
+ * The decision vocabulary is not owned here: the value comes from whoever built
+ * the proposal's buttons, and one live database holds 39 distinct values. A
+ * deny-list of the four we happen to know therefore answers `✅ Approuvé` for
+ * everything else — including `refuse`, whose own button reads "je le refuse
+ * pour 30 jours". Telling someone their refusal was approved is a worse failure
+ * than saying nothing.
+ *
+ * So: an allow-list for approval, explicit answers for the outcomes we do know,
+ * and for anything unknown an ack that reports the decision without claiming a
+ * meaning it cannot verify.
+ *
+ * Shared by both ack paths on purpose. They answer the same question and had
+ * drifted — `discuss` was handled in one and left lying in the other — which is
+ * what a rule duplicated in two places does.
+ */
+type AckKind = "approved" | "rejected" | "postponed" | "discussed" | "informational" | "unknown";
+
+/**
+ * The one normalised form of a decision, used both to classify it and to echo it
+ * back. `ackForAlready` lower-cases while parsing and `ackForResolution` does
+ * not, so echoing each function's own local variable made the same decision
+ * print two different ways — `Done` from a fresh tap, `done` from a repeated
+ * one. Classification was right either way; only the display diverged, which is
+ * precisely the drift this change exists to remove.
+ */
+export function normalizeDecision(decision: string): string {
+  return decision.trim().toLowerCase();
+}
+
+export function classifyDecision(decision: string): AckKind {
+  const d = normalizeDecision(decision);
+  if (d === "skip" || d === "skipped" || d === "later" || d === "snooze") return "postponed";
+  if (d === "reject" || d === "cancel" || d === "rejected" || d === "refuse" || d === "drop")
+    return "rejected";
+  if (d === "discuss") return "discussed";
+  // `details` shows something and deliberately leaves the action pending; it is
+  // not a decision at all, so it must not be acked as one.
+  if (d === "details" || d === "note" || d === "keep") return "informational";
+  if (d === "approve" || d === "approved" || d === "ok" || d === "yes" || d.startsWith("apply"))
+    return "approved";
+  return "unknown";
+}
+
 export function ackForAlready(resolution: string): string {
   const rest = resolution.slice("already:".length);
   const sep = rest.indexOf(":");
@@ -1842,10 +1888,20 @@ export function ackForAlready(resolution: string): string {
   // "2026-07-16T11:51…" → " (16/07 11:51)"
   const m = at.match(/^\d{4}-(\d{2})-(\d{2})T(\d{2}:\d{2})/);
   const when = m ? ` (${m[2]}/${m[1]} ${m[3]})` : "";
-  if (decision === "reject" || decision === "cancel" || decision === "rejected")
-    return `❌ Déjà rejeté${when}`;
-  if (decision === "skip" || decision === "skipped") return `⏸ Déjà reporté${when}`;
-  return `✅ Déjà approuvé${when}`;
+  switch (classifyDecision(decision)) {
+    case "rejected":
+      return `❌ Déjà rejeté${when}`;
+    case "postponed":
+      return `⏸ Déjà reporté${when}`;
+    case "discussed":
+      return `💬 Déjà envoyé en discussion${when}`;
+    case "informational":
+      return `👀 Déjà consulté${when}`;
+    case "approved":
+      return `✅ Déjà approuvé${when}`;
+    default:
+      return `↩︎ Déjà traité — ${normalizeDecision(decision)}${when}`;
+  }
 }
 
 /** The four outcomes a pending resolver can report. `no_answer` is not a
@@ -1886,10 +1942,23 @@ export function parseResolverVerdict(stdout: string): { verdict: ResolverVerdict
 export function ackForResolution(stdout: string, decision: string): string {
   const { verdict, line } = parseResolverVerdict(stdout);
   if (verdict === "ok") {
-    const decLower = decision.toLowerCase();
-    if (decLower === "skip") return "⏸ Plus tard";
-    if (decLower === "reject" || decLower === "cancel") return "❌ Rejeté";
-    return "✅ Approuvé";
+    switch (classifyDecision(decision)) {
+      case "postponed":
+        return "⏸ Plus tard";
+      case "rejected":
+        return "❌ Rejeté";
+      case "discussed":
+        // Routes to the discussion handler, which opens a thread on the proposal
+        // instead of applying it. The ack names no agent: which assistant it went
+        // to comes from the operator's own config, not from this string.
+        return "💬 Envoyé en discussion — réponds pour continuer";
+      case "informational":
+        return "👀 Consulté";
+      case "approved":
+        return "✅ Approuvé";
+      default:
+        return `↩︎ Décision enregistrée — ${normalizeDecision(decision)}`;
+    }
   }
   if (verdict === "already") return ackForAlready(line);
   if (verdict === "not_found") return "⚠️ Action introuvable";


### PR DESCRIPTION
Fixes #374.

A `discuss` tap on a pending action was acked as **approved**. The two
acknowledgement paths had drifted: `discuss` was handled in one and left lying
in the other, and an unrecognised decision fell through to the approval branch —
so the user was told their choice had been approved when it had not.

## What changed

Both paths now answer one rule, `classifyDecision`, instead of two deny-lists
that could disagree. An unrecognised decision is **reported** rather than
interpreted as an approval.

`normalizeDecision` is used both to classify and to echo, so the two paths also
render the same string: `ackForAlready` lower-cased while parsing while
`ackForResolution` echoed the raw callback value, which meant `Done` and `done`
came back differently. A mixed-case test pins that.

One existing assertion was deliberately reversed: an unknown decision used to
ack as approved, and that was the defect, not the contract.

## Verification

- `bun test src/commands/__tests__/telegram-pending-ack.test.ts` — 22 pass.
- Repo suite compared against the merge base: no failure the base did not have.
- Reviewed at the current head by two independent passes. The first found a real
  defect (the two unknown branches echoed differently-normalized values); it is
  fixed here and covered by a test. The re-review at this head found no defects.
- Live: the fix was deployed to a running daemon and a real `discuss` tap was
  acked as *sent to discussion*, not as approved.

Every decision value reaching these functions was enumerated from the code that
produces them, not from the ones the original report mentioned.
