### PR TITLE
fix(bus): confirm prompt delivery from the transcript, not the repaint

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.239",
+      "version": "2.2.240",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.239",
+  "version": "2.2.240",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/jsonl-tailer.test.ts
+++ b/src/bus/__tests__/jsonl-tailer.test.ts
@@ -22,6 +22,7 @@ import { join } from "node:path";
 import type { BusCore, SendPromptRequest } from "../core";
 import { encodeCwdForProjectsDir } from "../jsonl-line-types";
 import { JsonlTailer, SCHEMA_VERSION } from "../jsonl-tailer";
+import type { PromptIngestion } from "../jsonl-line-types";
 import type { BusEvent, BusEventTopic } from "../types";
 
 /* ───────────────────────────────────────────────────────────────────── */
@@ -854,5 +855,177 @@ describe("startAt: 'end' (issue #215 runtime wiring)", () => {
     await waitFor(events, (e) => e.some((x) => x.topic === "response.turn_end"));
     const te = events.find((e) => e.topic === "response.turn_end");
     expect((te?.payload as { text: string }).text).toBe("first turn of a brand new session");
+  });
+});
+
+/* ───────────────────────────────────────────────────────────────────── */
+/* Prompt-ingestion callbacks (issue #363)                               */
+/*                                                                       */
+/* Added after the adversarial pass found this half of the change        */
+/* covered by nothing: deleting the `operation === "enqueue"` filter AND  */
+/* the sidechain/isMeta exclusion left the whole suite green. The tests   */
+/* that existed called `notePromptIngested` directly, bypassing the code  */
+/* that decides which transcript records qualify in the first place.      */
+/* ───────────────────────────────────────────────────────────────────── */
+
+describe("prompt ingestion callbacks", () => {
+  /** A tailer wired to capture what it reports, rather than only bus events. */
+  function makeIngestTailer(bus: BusCore) {
+    const ingested: PromptIngestion[] = [];
+    let aliveCalls = 0;
+    const t = new JsonlTailer({
+      bus,
+      agent_id: AGENT_ID,
+      session_id: SESSION_ID,
+      cwd,
+      projectsDir,
+      onError: () => undefined,
+      onPromptIngested: (i) => ingested.push(i),
+      onTranscriptAlive: () => {
+        aliveCalls += 1;
+      },
+    });
+    return { t, ingested, alive: () => aliveCalls };
+  }
+
+  it("reports an enqueue record as an ingestion", async () => {
+    const { bus, events } = createMockBus();
+    const h = makeIngestTailer(bus);
+    tailer = h.t;
+    await writeFile(
+      sessionPath,
+      jsonl({
+        type: "queue-operation",
+        operation: "enqueue",
+        content: "run the nightly sync",
+        timestamp: "2026-09-07T15:00:00.000Z",
+      }),
+    );
+    await h.t.start();
+    await waitFor(events, (e) => e.some((x) => x.topic === "session.queue"));
+
+    expect(h.ingested).toHaveLength(1);
+    expect(h.ingested[0]?.source).toBe("enqueue");
+    expect(h.ingested[0]?.text).toBe("run the nightly sync");
+    expect(h.ingested[0]?.ingestedAtMs).toBe(Date.parse("2026-09-07T15:00:00.000Z"));
+  });
+
+  /**
+   * A `dequeue` is the queue handing the prompt to the RUNNER, not handing it
+   * back. `docs/spikes/fixtures/jsonl/01-headless-text-only.jsonl` shows it
+   * 1 ms after the enqueue and 2 s before the `user` line of a normal
+   * delivery, and it carries no `content`. Two rounds of review read it as a
+   * cancellation; a test asserted that reading, against a record shape the CLI
+   * does not write.
+   */
+  it("does not report a dequeue as an ingestion", async () => {
+    const { bus, events } = createMockBus();
+    const h = makeIngestTailer(bus);
+    tailer = h.t;
+    await writeFile(
+      sessionPath,
+      jsonl(
+        {
+          type: "queue-operation",
+          operation: "enqueue",
+          content: "the prompt",
+          timestamp: "2026-09-07T15:00:00.000Z",
+        },
+        // The fixture's own shape: 1 ms later, no `content`.
+        {
+          type: "queue-operation",
+          operation: "dequeue",
+          timestamp: "2026-09-07T15:00:00.001Z",
+        },
+        // And the shape that would actually reach the consumer if a future CLI
+        // started writing `content` on this line. Without the operation filter
+        // this one IS forwarded, and the delivery it names gets un-confirmed —
+        // so this is the assertion that holds the guard in place, not the one
+        // above (which the missing `content` would drop anyway).
+        {
+          type: "queue-operation",
+          operation: "dequeue",
+          content: "the prompt",
+          timestamp: "2026-09-07T15:00:00.002Z",
+        },
+      ),
+    );
+    await h.t.start();
+    await waitFor(events, (e) => e.filter((x) => x.topic === "session.queue").length >= 3);
+
+    expect(h.ingested).toHaveLength(1);
+    expect(h.ingested[0]?.source).toBe("enqueue");
+  });
+
+  it("ignores a queue operation that is not an acceptance", async () => {
+    const { bus, events } = createMockBus();
+    const h = makeIngestTailer(bus);
+    tailer = h.t;
+    await writeFile(
+      sessionPath,
+      jsonl({
+        type: "queue-operation",
+        operation: "reorder",
+        content: "still queued",
+        timestamp: "2026-09-07T15:00:00.000Z",
+      }),
+    );
+    await h.t.start();
+    await waitFor(events, (e) => e.some((x) => x.topic === "session.queue"));
+
+    expect(h.ingested).toHaveLength(0);
+  });
+
+  it("does not report a sub-agent prompt as this process's delivery", async () => {
+    const { bus, events } = createMockBus();
+    const h = makeIngestTailer(bus);
+    tailer = h.t;
+    await writeFile(
+      sessionPath,
+      jsonl(
+        {
+          type: "user",
+          isSidechain: true,
+          message: { content: "a sub-agent's prompt" },
+          timestamp: "2026-09-07T15:00:00.000Z",
+        },
+        {
+          type: "user",
+          isMeta: true,
+          message: { content: "<command-name>/compact</command-name>" },
+          timestamp: "2026-09-07T15:00:01.000Z",
+        },
+        {
+          type: "user",
+          message: { content: "the real prompt" },
+          promptId: "pid-real",
+          timestamp: "2026-09-07T15:00:02.000Z",
+        },
+      ),
+    );
+    await h.t.start();
+    await waitFor(events, (e) => e.filter((x) => x.topic === "prompt").length >= 3);
+
+    // All three publish `prompt`; only the last is OUR delivery.
+    expect(h.ingested).toHaveLength(1);
+    expect(h.ingested[0]?.text).toBe("the real prompt");
+    expect(h.ingested[0]?.promptId).toBe("pid-real");
+  });
+
+  it("signals the transcript is alive exactly once, on the first line", async () => {
+    const { bus, events } = createMockBus();
+    const h = makeIngestTailer(bus);
+    tailer = h.t;
+    await writeFile(
+      sessionPath,
+      jsonl(
+        { type: "ai-title", aiTitle: "first", timestamp: "2026-09-07T15:00:00.000Z" },
+        { type: "ai-title", aiTitle: "second", timestamp: "2026-09-07T15:00:01.000Z" },
+      ),
+    );
+    await h.t.start();
+    await waitFor(events, (e) => e.filter((x) => x.topic === "session.title").length >= 2);
+
+    expect(h.alive()).toBe(1);
   });
 });

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -7,7 +7,7 @@
  *     REPL-ready marker, not on first prompt (issue #193 / Codex P2 on #195).
  */
 import { describe, expect, it } from "bun:test";
-import { PtyAgentProcess, type PtyHandle } from "../session-agent-process";
+import { PtyAgentProcess, type PromptIngestion, type PtyHandle } from "../session-agent-process";
 
 describe("PtyAgentProcess.send_prompt_stream", () => {
   it("serialises concurrent prompts so their bytes don't interleave", async () => {
@@ -712,5 +712,752 @@ describe("PtyAgentProcess compaction latch", () => {
     // Footer preserved ⇒ the REPL is correctly seen as idle ⇒ the loop nudges
     // instead of declaring a turn. 1 initial submit + 2 nudges.
     expect(writes.filter((w) => w === "\r").length).toBe(3);
+  });
+});
+
+describe("PtyAgentProcess transcript-confirmed delivery (issue #362)", () => {
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+  const ingestion = (text: string, over: Partial<PromptIngestion> = {}): PromptIngestion => ({
+    text,
+    source: "user",
+    promptId: `pid-${Math.random().toString(36).slice(2)}`,
+    ingestedAtMs: Date.now(),
+    ...over,
+  });
+
+  /**
+   * A compaction that STARTS AND ENDS BEFORE the prompt is written, then keeps
+   * repainting the restored transcript. This is the production ordering of the
+   * 2026-08-27 wedge (compaction ends 14:04:43, prompt written 14:04:47) and
+   * the one no screen-derived signal can see: the epoch was bumped before the
+   * snapshot, the latch is already cleared, `markerTail` is wiped at write, and
+   * `Compacted (` never appears in a confirm window.
+   */
+  async function compactionEndsThenWrite(
+    proc: PtyAgentProcess,
+    emit: (d: string) => void,
+    prompt: string,
+  ) {
+    emit("Compacting conversation…");
+    await sleep(20);
+    emit("Compacted (ctrl+o to see full summary)");
+    await sleep(30);
+    const iv = setInterval(() => emit("earlier turn text being repainted\n"), 5);
+    const done = proc.send_prompt_stream(prompt);
+    return { done, stop: () => clearInterval(iv) };
+  }
+
+  it("does not confirm a turn from a repaint when the compaction ended BEFORE the write", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("f1", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+
+    const { done, stop } = await compactionEndsThenWrite(proc, emit, "please summarise");
+    await done;
+    stop();
+
+    // The prompt was never ingested: reporting a started turn here is the wedge.
+    expect(writes).toContain("\x15");
+  });
+
+  it("keeps the old screen behaviour for that same ordering when no transcript is live", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("f1b", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    // No enableTranscriptConfirmation: also the blind-tailer case, where a
+    // path mismatch means no line is ever read. Such an agent must degrade to
+    // the previous behaviour, never stall waiting on a transcript that cannot
+    // speak. Identical config to the test above — only the transcript differs.
+
+    const { done, stop } = await compactionEndsThenWrite(proc, emit, "please summarise");
+    await done;
+    stop();
+
+    expect(writes).not.toContain("\x15");
+  });
+
+  it("confirms as soon as the transcript records the prompt, whatever the screen shows", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("ok", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 3,
+      transcriptGraceMs: 5000,
+    });
+    proc.enableTranscriptConfirmation();
+
+    const { done, stop } = await compactionEndsThenWrite(proc, emit, "hello there");
+    setTimeout(() => proc.notePromptIngested(ingestion("hello there")), 30);
+    await done;
+    stop();
+
+    expect(writes).not.toContain("\x15");
+    expect(writes.filter((w) => w === "\r").length).toBe(1);
+  });
+
+  it("reports unconfirmed rather than a turn when a live transcript stays silent", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("f2", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+
+    // Genuine streaming output the whole way, but the transcript never speaks.
+    const p = proc.send_prompt_stream("hi");
+    const iv = setInterval(() => emit("assistant is streaming a response\n"), 5);
+    await p;
+    clearInterval(iv);
+
+    // Held for the grace period without spending a nudge, then answered
+    // "unknown" — exactly one submit CR, never re-nudged or re-typed.
+    expect(writes.filter((w) => w === "\r").length).toBe(1);
+    // A single \r holds identically for `turn-started`, so it does not name the
+    // outcome this test is about: deleting the whole transcript branch left it
+    // green (adversarial pass, finding 6). `\x15` is the discriminator — the
+    // loop clears the input box only when it refuses to call the delivery
+    // confirmed.
+    expect(writes).toContain("\x15");
+  });
+
+  /**
+   * Staleness-by-timestamp applies to `enqueue` only. Its stamp tracks
+   * acceptance within ~0.2s, whereas the CLI backdates `user` lines — observed
+   * by up to 148s — so a `user` record cannot be judged stale that way. What
+   * protects the `user` path is the consumed-id set, covered separately.
+   */
+  it("ignores an enqueue recorded before this prompt was armed (late event, earlier delivery)", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("f4a", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+
+    const { done, stop } = await compactionEndsThenWrite(
+      proc,
+      emit,
+      "heartbeat: any new messages?",
+    );
+    // The bus re-delivers verbatim; this is the FIRST delivery's transcript
+    // line arriving late. Same text, but stamped well before this arming.
+    setTimeout(
+      () =>
+        proc.notePromptIngested({
+          text: "heartbeat: any new messages?",
+          source: "enqueue",
+          ingestedAtMs: Date.now() - 60_000,
+        }),
+      30,
+    );
+    await done;
+    stop();
+
+    expect(writes).toContain("\x15");
+  });
+
+  it("refuses to reuse a promptId that already confirmed a delivery", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("f4b", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+    const shared = "identical prompt text";
+    const pid = "pid-reused";
+
+    // First delivery, confirmed by the transcript.
+    const first = proc.send_prompt_stream(shared);
+    setTimeout(
+      () =>
+        proc.notePromptIngested({
+          text: shared,
+          source: "user",
+          promptId: pid,
+          ingestedAtMs: Date.now(),
+        }),
+      25,
+    );
+    await first;
+    const afterFirst = writes.length;
+
+    // Second, verbatim re-delivery. The same promptId must not confirm it.
+    const { done, stop } = await compactionEndsThenWrite(proc, emit, shared);
+    setTimeout(
+      () =>
+        proc.notePromptIngested({
+          text: shared,
+          source: "user",
+          promptId: pid,
+          ingestedAtMs: Date.now(),
+        }),
+      25,
+    );
+    await done;
+    stop();
+
+    expect(writes.slice(afterFirst)).toContain("\x15");
+  });
+
+  it("ignores a transcript prompt that is not the one in flight", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("other", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+
+    const { done, stop } = await compactionEndsThenWrite(proc, emit, "the real prompt");
+    setTimeout(() => proc.notePromptIngested(ingestion("Continue from where you left off")), 30);
+    await done;
+    stop();
+
+    expect(writes).toContain("\x15");
+  });
+
+  it("matches a prompt containing a tab, which the transcript cannot carry", async () => {
+    const { handle, writes } = bootPty();
+    const proc = new PtyAgentProcess("tab", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 3,
+      transcriptGraceMs: 5000,
+    });
+    proc.enableTranscriptConfirmation();
+
+    // sanitizePtyPromptText preserves TAB, but a raw 0x09 typed into the TUI is
+    // a completion key and never reaches the transcript.
+    const p = proc.send_prompt_stream("col a\tcol b");
+    setTimeout(() => proc.notePromptIngested(ingestion("col acol b")), 40);
+    await p;
+
+    expect(writes).not.toContain("\x15");
+  });
+});
+
+describe("PtyAgentProcess enqueue-confirmed delivery (issue #363)", () => {
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+  const enqueued = (text: string, over: Partial<PromptIngestion> = {}): PromptIngestion => ({
+    text,
+    source: "enqueue",
+    ingestedAtMs: Date.now(),
+    ...over,
+  });
+
+  /**
+   * The case that refuted the `user`-only design. The bus delivers into an
+   * active turn: the CLI queues the keystrokes and does not write the `user`
+   * line until the neighbouring turn ends — measured past 8s for 12 of 56
+   * deliveries, with a 443s maximum. Meanwhile the screen is non-empty,
+   * footer-free streaming output, so requiring `user` turned a rare false
+   * "delivered" into a frequent false "lost".
+   *
+   * `enqueue` is written ~0.2s after the keystrokes land, precisely BECAUSE
+   * the prompt was queued. Every one of those 12 slow deliveries has one.
+   */
+  it("confirms a prompt queued behind a live turn from its enqueue record", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("q1", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 200,
+    });
+    proc.enableTranscriptConfirmation();
+
+    const p = proc.send_prompt_stream("new inbound message");
+    // A neighbour turn streams the whole time; the `user` line never arrives.
+    const iv = setInterval(() => emit("neighbour turn is streaming its answer\n"), 5);
+    setTimeout(() => proc.notePromptIngested(enqueued("new inbound message")), 40);
+    await p;
+    clearInterval(iv);
+
+    // Confirmed, so no stranded-line clear and exactly one submit CR.
+    expect(writes).not.toContain("\x15");
+    expect(writes.filter((w) => w === "\r").length).toBe(1);
+  });
+
+  /**
+   * An auto-compaction emits a cluster of `user` lines sharing ONE promptId —
+   * the continuation summary first, the real prompt after. Keying the consumed
+   * set on the id alone let the summary burn it, so the prompt that followed
+   * could never confirm: the failure landed in exactly the case this mechanism
+   * exists for, and `enqueue` does not cover it (a prompt that TRIGGERS a
+   * compaction is not queued behind a running turn).
+   */
+  it("still confirms when a compaction cluster shares one promptId with earlier lines", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("cluster", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 3,
+      transcriptGraceMs: 400,
+    });
+    proc.enableTranscriptConfirmation();
+    const sharedId = "pid-compaction-cluster";
+
+    const p = proc.send_prompt_stream("summarise the thread");
+    const iv = setInterval(() => emit("restored transcript repaint\n"), 5);
+    // The cluster's earlier lines arrive first, under the same promptId.
+    setTimeout(() => {
+      proc.notePromptIngested({
+        text: "This session is being continued from a previous conversation…",
+        source: "user",
+        promptId: sharedId,
+        ingestedAtMs: Date.now(),
+      });
+      proc.notePromptIngested({
+        text: "<command-name>/compact</command-name>",
+        source: "user",
+        promptId: sharedId,
+        ingestedAtMs: Date.now(),
+      });
+      // Then the real prompt, same id.
+      proc.notePromptIngested({
+        text: "summarise the thread",
+        source: "user",
+        promptId: sharedId,
+        ingestedAtMs: Date.now(),
+      });
+    }, 40);
+    await p;
+    clearInterval(iv);
+
+    expect(writes).not.toContain("\x15");
+  });
+
+  it("refuses to confirm from the screen when the transcript says nothing at all", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("q2", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+
+    const p = proc.send_prompt_stream("dropped prompt");
+    const iv = setInterval(() => emit("repaint noise\n"), 5);
+    // Nothing is injected: this is the transcript-silent case, and the point is
+    // that the screen alone never confirms.
+    //
+    // Renamed. It used to be called "ignores a de-queue: only operation=enqueue
+    // is an ingestion" and its comment said a `remove` record was filtered at
+    // the tailer — both false since withdrawals became a forwarded signal, and
+    // neither was ever true of this body, which injects no record at all. The
+    // withdrawal paths are covered by their own tests above.
+    await p;
+    clearInterval(iv);
+
+    expect(writes).toContain("\x15");
+  });
+
+  /**
+   * The screen claimed a turn, the transcript spoke only afterwards. This is
+   * the path the grace period exists for, and the previous attempt never
+   * exercised it: its ingestions all fired inside the 200ms paste settle, so
+   * deleting the grace entirely left every test passing.
+   */
+  it("holds the screen's claim and confirms when the transcript speaks during the grace", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("grace", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 400,
+    });
+    proc.enableTranscriptConfirmation();
+
+    const p = proc.send_prompt_stream("held then confirmed");
+    const iv = setInterval(() => emit("output with no footer\n"), 5);
+    // Well after the settle, so the loop must reach the claim branch and hold.
+    setTimeout(() => proc.notePromptIngested(enqueued("held then confirmed")), 260);
+    await p;
+    clearInterval(iv);
+
+    expect(writes).not.toContain("\x15");
+    expect(writes.filter((w) => w === "\r").length).toBe(1);
+  });
+
+  /**
+   * An ingestion arriving while nothing is armed must still be recorded as
+   * consumed. Deliveries routinely end with the transcript silent, so this is
+   * the common case — and leaving the id unrecorded let it confirm the next
+   * verbatim re-delivery, which the bus produces on flush-verify.
+   */
+  /**
+   * Adversarial pass, finding 1 — the phantom this whole mechanism exists to
+   * remove, still open until this test.
+   *
+   * `enqueue` confirms delivery #1 the moment the CLI takes the keystrokes.
+   * The matching `user` line is written later, when the prompt actually runs.
+   * `flushVerify` re-delivers the SAME text verbatim in between, so that late
+   * `user` line lands while delivery #2 is armed. It is a first sighting, so
+   * the consumed-ids set does not know it, and `user` records are exempt from
+   * the timestamp check because the CLI backdates them by up to 148 s.
+   * Nothing rejected it: delivery #2 was reported delivered while still
+   * sitting un-submitted in the input box.
+   */
+  it("does not let a late user record from an enqueue-confirmed delivery confirm the next one", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("late-user", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+    const text = "heartbeat: any new messages?";
+
+    // Delivery #1 — confirmed by its enqueue. Its `user` line has not landed.
+    const first = proc.send_prompt_stream(text);
+    const iv1 = setInterval(() => emit("streaming\n"), 5);
+    setTimeout(() => proc.notePromptIngested(enqueued(text)), 25);
+    await first;
+    clearInterval(iv1);
+
+    // Delivery #2 — same bytes, as flushVerify re-delivers them.
+    const before = writes.length;
+    const second = proc.send_prompt_stream(text);
+    const iv2 = setInterval(() => emit("streaming\n"), 5);
+    // Delivery #1's `user` line, arriving for the FIRST time, mid-delivery #2.
+    setTimeout(
+      () =>
+        proc.notePromptIngested({
+          text,
+          source: "user",
+          promptId: "pid-of-first",
+          ingestedAtMs: Date.now(),
+        }),
+      30,
+    );
+    await second;
+    clearInterval(iv2);
+
+    // Un-submitted: the loop must have given up on the transcript, not been
+    // satisfied by a record that belonged to the delivery before it.
+    expect(writes.slice(before)).toContain("\x15");
+  });
+
+  /**
+   * Adversarial pass, finding 2 — an unusable timestamp used to wave the
+   * record through. The enqueue path carries no `promptId`, so the timestamp
+   * is the ONLY thing deciding which delivery a record belongs to; treating a
+   * missing stamp as "recent enough" let a stale enqueue confirm whatever
+   * happened to be armed.
+   */
+  it("refuses an enqueue whose timestamp is unusable instead of trusting it", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("no-stamp", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+    const text = "deploy the thing";
+
+    const p = proc.send_prompt_stream(text);
+    const iv = setInterval(() => emit("streaming\n"), 5);
+    setTimeout(() => proc.notePromptIngested(enqueued(text, { ingestedAtMs: 0 })), 30);
+    await p;
+    clearInterval(iv);
+
+    expect(writes).toContain("\x15");
+  });
+
+  /**
+   * Adversarial pass, finding 2 (the other half) — an enqueue stamped before
+   * this prompt was armed belongs to an earlier delivery.
+   */
+  it("refuses an enqueue stamped before the prompt was armed", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("stale-enqueue", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+    const text = "deploy the other thing";
+
+    const p = proc.send_prompt_stream(text);
+    const iv = setInterval(() => emit("streaming\n"), 5);
+    setTimeout(
+      () => proc.notePromptIngested(enqueued(text, { ingestedAtMs: Date.now() - 60_000 })),
+      30,
+    );
+    await p;
+    clearInterval(iv);
+
+    expect(writes).toContain("\x15");
+  });
+
+  /**
+   * Adversarial pass, finding 4 — a whitespace-only prompt normalises to the
+   * empty string, which then matched ANY whitespace-only record in the
+   * transcript. Nothing to compare on means nothing to confirm on.
+   */
+  it("does not arm on a prompt that normalises to nothing", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("blank", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+
+    const p = proc.send_prompt_stream("   ");
+    const iv = setInterval(() => emit("streaming\n"), 5);
+    // A different whitespace-only record — normalises to "" just the same.
+    setTimeout(
+      () =>
+        proc.notePromptIngested({
+          text: "\t\n",
+          source: "user",
+          promptId: "pid-blank",
+          ingestedAtMs: Date.now(),
+        }),
+      30,
+    );
+    await p;
+    clearInterval(iv);
+
+    expect(writes).toContain("\x15");
+  });
+
+  /**
+   * Second adversarial pass, finding 1 — the headline. The first cut booked the
+   * queue entry only where an `enqueue` actually CONFIRMED a delivery, so an
+   * enqueue seen while nothing was armed (the common case: it lands after the
+   * confirm loop has already resolved) booked nothing. The CLI still had the
+   * prompt queued and still wrote its `user` line later, which then confirmed
+   * the next delivery of the same text — the original phantom, untouched.
+   */
+  it("counts an enqueue seen while unarmed, so its later user line cannot confirm the next delivery", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("unarmed-enqueue", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+    const text = "heartbeat: any new messages?";
+
+    // The CLI accepted a submission of this text while nothing was armed.
+    proc.notePromptIngested(enqueued(text));
+
+    // A later delivery of the same bytes. Its `user` line is the one owed to
+    // the submission above, not evidence about this delivery.
+    const p = proc.send_prompt_stream(text);
+    const iv = setInterval(() => emit("streaming\n"), 5);
+    setTimeout(
+      () =>
+        proc.notePromptIngested({
+          text,
+          source: "user",
+          promptId: "pid-of-the-queued-one",
+          ingestedAtMs: Date.now(),
+        }),
+      30,
+    );
+    await p;
+    clearInterval(iv);
+
+    expect(writes).toContain("\x15");
+  });
+
+  /**
+   * Second adversarial pass, finding 1, second shape — a refused enqueue must
+   * still be counted. Refusing an unusable timestamp is a statement about which
+   * DELIVERY the record belongs to; it says nothing about whether the CLI
+   * queued the prompt. Skipping the booking made that guard manufacture the
+   * phantom it exists to prevent.
+   */
+  it("counts an enqueue even when its timestamp makes it unusable as a confirmation", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("refused-enqueue", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+    const text = "run the nightly sync";
+
+    // Delivery #1: the enqueue is refused as a confirmation (no usable stamp),
+    // but the prompt IS queued.
+    const first = proc.send_prompt_stream(text);
+    const iv1 = setInterval(() => emit("streaming\n"), 5);
+    setTimeout(() => proc.notePromptIngested(enqueued(text, { ingestedAtMs: 0 })), 25);
+    await first;
+    clearInterval(iv1);
+
+    // Delivery #2, same bytes. Delivery #1's `user` line must not confirm it.
+    const before = writes.length;
+    const second = proc.send_prompt_stream(text);
+    const iv2 = setInterval(() => emit("streaming\n"), 5);
+    setTimeout(
+      () =>
+        proc.notePromptIngested({
+          text,
+          source: "user",
+          promptId: "pid-of-first",
+          ingestedAtMs: Date.now(),
+        }),
+      30,
+    );
+    await second;
+    clearInterval(iv2);
+
+    expect(writes.slice(before)).toContain("\x15");
+  });
+
+  /**
+   * A `dequeue` record is NOT a cancellation, and nothing here treats it as one.
+   *
+   * Two rounds of review built a withdrawal path on the opposite reading. The
+   * repo's own fixtures settle it: in
+   * `docs/spikes/fixtures/jsonl/01-headless-text-only.jsonl` the `dequeue`
+   * fires 1 ms after the `enqueue` and 2 s before the `user` line, in a normal
+   * successful delivery — the queue handing the prompt to the runner. It also
+   * carries no `content`. The tests that covered the withdrawal synthesised a
+   * record the CLI does not write, and the code they covered would have
+   * un-confirmed every delivery the day the CLI started writing it.
+   */
+
+  /**
+   * Second adversarial pass, fix 2 — `NaN` fails every comparison it appears
+   * in, so a bare `< armed` test let it through, and a stamp in the future
+   * passed both bounds while also poisoning the dedupe key built from it.
+   */
+  it("refuses an enqueue whose timestamp is not a usable instant", async () => {
+    for (const stamp of [Number.NaN, Date.parse("2099-01-01T00:00:00.000Z")]) {
+      const { handle, writes, emit } = bootPty();
+      const proc = new PtyAgentProcess(`bad-stamp-${stamp}`, handle, {
+        submitConfirmMs: 20,
+        maxSubmitNudges: 2,
+        transcriptGraceMs: 60,
+      });
+      proc.enableTranscriptConfirmation();
+      const text = "deploy with a broken clock";
+
+      const p = proc.send_prompt_stream(text);
+      const iv = setInterval(() => emit("streaming\n"), 5);
+      setTimeout(() => proc.notePromptIngested(enqueued(text, { ingestedAtMs: stamp })), 30);
+      await p;
+      clearInterval(iv);
+
+      expect(writes).toContain("\x15");
+    }
+  });
+
+  /**
+   * Second adversarial pass — the enqueue identity key had no test at all:
+   * reverting it to `null` left the whole suite green. It is load-bearing
+   * because the queue count is a ledger: the same enqueue record presented
+   * twice must not book two outstanding submissions, or the second one absorbs
+   * a legitimate confirmation later.
+   */
+  it("counts a repeated enqueue record once, not twice", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("dup-enqueue", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+    const text = "a prompt whose enqueue is read twice";
+
+    // The identical record, twice — same text, same stamp, so same identity.
+    const stamped = enqueued(text, { ingestedAtMs: Date.now() });
+    proc.notePromptIngested({ ...stamped });
+    proc.notePromptIngested({ ...stamped });
+
+    // One outstanding submission, so one `user` line pays it off. The delivery
+    // below must then be confirmed by its OWN record, not starved by a phantom
+    // second entry.
+    proc.notePromptIngested({
+      text,
+      source: "user",
+      promptId: "pid-the-queued-one",
+      ingestedAtMs: Date.now(),
+    });
+
+    const p = proc.send_prompt_stream(text);
+    const iv = setInterval(() => emit("streaming\n"), 5);
+    setTimeout(
+      () =>
+        proc.notePromptIngested({
+          text,
+          source: "user",
+          promptId: "pid-this-delivery",
+          ingestedAtMs: Date.now(),
+        }),
+      30,
+    );
+    await p;
+    clearInterval(iv);
+
+    expect(writes).not.toContain("\x15");
+  });
+
+  it("consumes an id seen while unarmed, so it cannot confirm a later delivery", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("unarmed", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      transcriptGraceMs: 60,
+    });
+    proc.enableTranscriptConfirmation();
+    const text = "heartbeat: any new messages?";
+    const pid = "pid-late";
+
+    // Nothing armed: the tail hands over a record between deliveries.
+    proc.notePromptIngested({ text, source: "user", promptId: pid, ingestedAtMs: Date.now() });
+
+    const p = proc.send_prompt_stream(text);
+    const iv = setInterval(() => emit("repaint noise\n"), 5);
+    // The same record arrives again mid-delivery. Already consumed.
+    setTimeout(
+      () =>
+        proc.notePromptIngested({ text, source: "user", promptId: pid, ingestedAtMs: Date.now() }),
+      30,
+    );
+    await p;
+    clearInterval(iv);
+
+    expect(writes).toContain("\x15");
+  });
+
+  /**
+   * The claim clock must restart when the screen stops claiming. Otherwise a
+   * repaint window before a compaction spends the whole grace, and the
+   * post-compaction turn gets none of it.
+   */
+  it("restarts the grace after the screen withdraws its claim", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("reset", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 4,
+      transcriptGraceMs: 150,
+    });
+    proc.enableTranscriptConfirmation();
+
+    const p = proc.send_prompt_stream("do the thing");
+    // Claim, then withdraw it (idle footer), then a real turn whose transcript
+    // record lands shortly after it starts.
+    emit("a repaint with no footer\n");
+    await sleep(60);
+    const idle = setInterval(() => emit("\n> accept edits on (shift+tab to cycle)"), 5);
+    await sleep(60);
+    clearInterval(idle);
+    const turn = setInterval(() => emit("the real turn is streaming\n"), 5);
+    setTimeout(() => proc.notePromptIngested(enqueued("do the thing")), 60);
+    await p;
+    clearInterval(turn);
+
+    expect(writes).not.toContain("\x15");
   });
 });

--- a/src/bus/jsonl-line-types.ts
+++ b/src/bus/jsonl-line-types.ts
@@ -277,6 +277,52 @@ export function encodeCwdForProjectsDir(
   return `${encoded.slice(0, PROJECTS_DIR_MAX_LEN)}-${hashCwdForProjectsDir(cwd)}`;
 }
 
+/**
+ * A transcript-confirmed prompt ingestion (issue #362).
+ *
+ * `promptId` and `ingestedAtMs` are what make this safe to act on: text alone
+ * cannot tell a fresh ingestion from a late event for an earlier delivery of
+ * the identical string, and the bus re-delivers verbatim on flush-verify.
+ */
+export interface PromptIngestion {
+  text: string;
+  /**
+   * Which record carried the fact. The two are complementary, not redundant:
+   *
+   * - `"enqueue"` is written the moment the CLI ACCEPTS the keystrokes. It is
+   *   not emitted for every prompt (14 of 56 in the sample), but the repo's own
+   *   fixtures show it for unqueued prompts too, so "it exists iff the prompt
+   *   was queued" is too strong a claim — treat it as an early record that is
+   *   often but not always present.
+   * - `"user"` is written when the CLI EXECUTES the turn — immediate when
+   *   nothing was queued, and arbitrarily late when something was.
+   *
+   * Measured over 56 deliveries on a long-running session: `user` alone has a
+   * p95 of 236 s (12 deliveries past 8 s, max 443 s); every one of those slow
+   * deliveries has an `enqueue`. That is the property the loop relies on — the
+   * slow cases are covered — and it holds regardless of whether `enqueue` is
+   * also emitted in fast ones. Taking whichever lands first gives p95 0.25 s
+   * and a 0.27 s maximum. Neither record alone is sufficient: `enqueue` covers
+   * only a quarter of prompts, and `user` has the 443 s tail.
+   *
+   * `"dequeue"` is deliberately NOT one of these. A round of review read it as
+   * the queue handing the prompt BACK and built a withdrawal path on that. The
+   * repo's own fixtures say otherwise: in
+   * `docs/spikes/fixtures/jsonl/01-headless-text-only.jsonl` a `dequeue` fires
+   * 1 ms after the `enqueue` and 2 s before the `user` line, in a normal
+   * successful single-prompt delivery. It means the queue handed the prompt to
+   * the RUNNER. Treating it as a cancellation un-confirms every delivery it
+   * touches. It also carries no `content`, so it cannot be attributed to a
+   * text even if one wanted to.
+   */
+  source: "user" | "enqueue";
+  /** CLI-assigned id. Present on `user` lines only, and it identifies a
+   *  submission rather than a record — a compaction cluster shares one. */
+  promptId?: string;
+  /** Transcript `timestamp`, epoch ms. `0` when unparseable. */
+  ingestedAtMs: number;
+}
+
 /* ───────────────────────────────────────────────────────────────────── */
 /* Extraction helpers                                                    */
 /* ───────────────────────────────────────────────────────────────────── */

--- a/src/bus/jsonl-tailer.ts
+++ b/src/bus/jsonl-tailer.ts
@@ -31,6 +31,7 @@ import type { BusCore } from "./core";
 import {
   BUS_CRITICAL_ATTACHMENT_SUBTYPES,
   encodeCwdForProjectsDir,
+  type PromptIngestion,
   extractToolResults,
   type AssistantLine,
   type AttachmentLine,
@@ -92,6 +93,8 @@ const SIMPLE_DISPATCH: Record<
   },
 };
 
+export type { PromptIngestion };
+
 export interface JsonlTailerOptions {
   bus: BusCore;
   agent_id: string;
@@ -116,6 +119,26 @@ export interface JsonlTailerOptions {
   startAt?: "begin" | "end";
   /** Error sink. Defaults to console.error. */
   onError?: (err: unknown, ctx?: Record<string, unknown>) => void;
+  /**
+   * Called when the transcript records that the CLI actually ingested a
+   * top-level user prompt (issue #362). This is the only delivery signal that
+   * originates outside the terminal rendering: on the PTY surface "the CLI
+   * submitted my text" and "the CLI repainted something" are the same bytes,
+   * so every screen heuristic can be fooled by a post-compaction repaint.
+   * The session manager wires this to the agent's `notePromptIngested`.
+   */
+  onPromptIngested?: (ingestion: PromptIngestion) => void;
+  /**
+   * Called once, on the first line this tailer actually reads (issue #362).
+   *
+   * Being constructed is NOT evidence that a transcript is readable: the path
+   * is derived from the cwd encoding, and a mismatch there leaves the tailer
+   * pointed at a file that never appears — silently, since a missing session
+   * file is a normal startup state. Anything that hardens behaviour on the
+   * assumption that the transcript will speak must key off this, not off the
+   * wiring, or it degrades every agent whose transcript is unreachable.
+   */
+  onTranscriptAlive?: () => void;
 }
 
 export class JsonlTailer {
@@ -126,6 +149,9 @@ export class JsonlTailer {
   private readonly projectsDir: string;
   private readonly schemaVersion: string;
   private readonly onError: (err: unknown, ctx?: Record<string, unknown>) => void;
+  private readonly onPromptIngested?: (ingestion: PromptIngestion) => void;
+  private readonly onTranscriptAlive?: () => void;
+  private sawAnyLine = false;
   private readonly filePath: string;
   private readonly startAt: "begin" | "end";
 
@@ -162,6 +188,8 @@ export class JsonlTailer {
     this.schemaVersion = opts.schemaVersion ?? SCHEMA_VERSION;
     this.onError = opts.onError ?? ((err, ctx) => console.error("[jsonl-tailer]", err, ctx));
     this.startAt = opts.startAt ?? "begin";
+    this.onPromptIngested = opts.onPromptIngested;
+    this.onTranscriptAlive = opts.onTranscriptAlive;
     this.filePath = join(
       this.projectsDir,
       encodeCwdForProjectsDir(this.cwd),
@@ -376,7 +404,48 @@ export class JsonlTailer {
    * "simple" types (single field extraction) are handled via the
    * `SIMPLE_DISPATCH` table to keep this method small.
    */
+  /**
+   * Issue #363 — a queued prompt's acceptance, reported the moment the CLI
+   * takes the keystrokes rather than when it gets round to running them. The
+   * line is already dispatched to `session.queue` via SIMPLE_DISPATCH; this is
+   * an additional consumer of the same record, not new parsing.
+   *
+   * `operation` takes other values too (`"dequeue"` / `"remove"` depending on
+   * CLI version), so the test is positive rather than a blocklist.
+   */
+  private notifyEnqueue(line: Record<string, unknown>): void {
+    if (!this.onPromptIngested) return;
+    // Only `enqueue`. A `dequeue` is NOT the queue giving the prompt back — the
+    // fixtures in `docs/spikes/fixtures/jsonl/` show it firing 1 ms after the
+    // enqueue and 2 s before the `user` line of a normal delivery, i.e. the
+    // queue handing the prompt to the runner. A round of review read it as a
+    // cancellation and this forwarded it as one; every delivery it touched
+    // would have been un-confirmed. Positive test, so any other operation a
+    // future CLI adds is ignored rather than guessed at.
+    if (line.operation !== "enqueue") return;
+    const content = line.content;
+    if (typeof content !== "string") return;
+    const ts = typeof line.timestamp === "string" ? Date.parse(line.timestamp) : Number.NaN;
+    try {
+      this.onPromptIngested({
+        text: content,
+        source: "enqueue",
+        ingestedAtMs: Number.isFinite(ts) ? ts : 0,
+      });
+    } catch (err) {
+      this.onError(err, { where: "onPromptIngested(enqueue)", agent_id: this.agent_id });
+    }
+  }
+
   private dispatch(line: JsonlLine, raw: string): void {
+    if (!this.sawAnyLine) {
+      this.sawAnyLine = true;
+      try {
+        this.onTranscriptAlive?.();
+      } catch (err) {
+        this.onError(err, { where: "onTranscriptAlive", agent_id: this.agent_id });
+      }
+    }
     switch (line.type) {
       case "user":
         this.dispatchUser(line as UserLine, raw);
@@ -391,6 +460,9 @@ export class JsonlTailer {
         this.dispatchSystem(line as SystemLine);
         return;
       default: {
+        if (line.type === "queue-operation") {
+          this.notifyEnqueue(line as unknown as Record<string, unknown>);
+        }
         const simple = SIMPLE_DISPATCH[line.type];
         if (simple) {
           this.publish(simple.topic, simple.extract(line as Record<string, unknown>), line);
@@ -418,6 +490,31 @@ export class JsonlTailer {
         },
         line,
       );
+      // Issue #362: the transcript writing this line IS the CLI acknowledging
+      // it ingested the prompt, which is what the PTY delivery-confirm loop
+      // has no way to observe. Notify out-of-band so a failure in a consumer
+      // cannot take down the tail — the publish above is the contract, this is
+      // a side-channel.
+      // Sub-agent prompts and harness meta lines are recorded the same way but
+      // are not this process's delivery. Excluded at the source so no consumer
+      // has to know the distinction.
+      if (
+        this.onPromptIngested &&
+        line.isSidechain !== true &&
+        !(line as { isMeta?: boolean }).isMeta
+      ) {
+        const ts = line.timestamp ? Date.parse(line.timestamp) : Number.NaN;
+        try {
+          this.onPromptIngested({
+            text: content,
+            source: "user",
+            promptId: line.promptId,
+            ingestedAtMs: Number.isFinite(ts) ? ts : 0,
+          });
+        } catch (err) {
+          this.onError(err, { where: "onPromptIngested", agent_id: this.agent_id });
+        }
+      }
       return;
     }
     if (Array.isArray(content)) {

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -41,6 +41,33 @@ import type { SupervisionMode } from "./types";
  *  confirm")` / `includes("Yes, I accept")` dialog gates — leaving a spawned
  *  agent stuck at the boot dialog. This is the bus-path analogue of the #345
  *  pty-supervisor footer hang. */
+/**
+ * Normalise a prompt for cross-surface comparison (issue #362). The PTY is fed
+ * `sanitizePtyPromptText` output while the transcript stores what the CLI
+ * parsed, so the two can differ in trailing whitespace and in how a run of
+ * spaces survives the input box. Compare on the shape both surfaces agree on.
+ */
+function normalizePromptForMatch(text: string): string {
+  // Whitespace is dropped entirely rather than collapsed. The two surfaces
+  // disagree on more than runs of spaces: `sanitizePtyPromptText` preserves a
+  // TAB, but a raw 0x09 typed into the TUI is a completion KEY, so it never
+  // reaches the transcript at all. Collapsing would leave `"a\tb"` arming
+  // `"a b"` against a recorded `"ab"` — a permanent non-match.
+  //
+  // This is only safe because identity no longer rests on the text: `promptId`
+  // and the transcript timestamp are what decide which delivery an ingestion
+  // belongs to. The text is a sanity check, not the key.
+  return text.replace(/\s+/g, "");
+}
+
+/** Tolerance for CLI-vs-daemon clock skew when ordering an ingestion against
+ *  the moment its prompt was armed. Same host, so this is generous. */
+const INGESTION_CLOCK_SKEW_MS = 2000;
+
+import type { PromptIngestion } from "./jsonl-line-types";
+
+export type { PromptIngestion };
+
 function stripAnsiEscapes(text: string): string {
   return (
     expandCursorForwardToSpaces(text)
@@ -71,6 +98,18 @@ export interface AgentProcess {
   send_slash(cmd: string): Promise<void>;
   /** Send a stream-json line. Only valid in `process-stream-json` mode. */
   send_prompt_stream(line: string): Promise<void>;
+  /**
+   * Optional: report that the session transcript recorded the CLI ingesting
+   * `text` as a top-level user prompt (issue #362). Implementations that have
+   * no transcript simply omit this and keep the screen heuristics.
+   */
+  notePromptIngested?(ingestion: PromptIngestion): void;
+  /**
+   * Optional: declare that a session transcript is being tailed for this
+   * process, so the confirm loop can require its word instead of trusting the
+   * rendered terminal in the one window where the terminal is known to lie.
+   */
+  enableTranscriptConfirmation?(): void;
   onExit(handler: ExitHandler): void;
   /**
    * Crash-signal observer ONLY. The Bus must NEVER parse model output from
@@ -241,6 +280,68 @@ export class PtyAgentProcess implements AgentProcess {
   /** One-shot guard so an unconfirmed delivery is surfaced once per process
    *  (see the delivery-confirm loop) instead of spamming the log. */
   private warnedUnconfirmedDelivery = false;
+  /**
+   * Issue #362 — authoritative delivery signal.
+   *
+   * `pendingPromptMatch` is the normalised text of the prompt currently being
+   * delivered; `promptIngested` flips when the session transcript records the
+   * CLI ingesting exactly that text. Only `send_prompt_stream` arms and
+   * disarms them, and the write chain serialises prompts, so at most one is
+   * ever in flight.
+   *
+   * This exists because every other probe in the confirm loop reads the
+   * rendered terminal, where a post-compaction repaint is byte-identical to a
+   * streaming turn. The transcript is written by the CLI when it actually
+   * ingests the prompt — a fact, not an inference from pixels.
+   */
+  private pendingPromptMatch: string | null = null;
+  private pendingArmedAtMs = 0;
+  private promptIngested = false;
+  /**
+   * Records already accepted, keyed by `promptId` + normalised text. The bus re-delivers a prompt verbatim on
+   * flush-verify, so the same text can be armed twice; without this a late
+   * event for the FIRST delivery would confirm the second — a phantom success
+   * of exactly the kind this whole mechanism exists to remove. Bounded: only
+   * the recent past can plausibly arrive late.
+   */
+  private readonly consumedPromptIds = new Set<string>();
+  private static readonly CONSUMED_PROMPT_IDS_MAX = 64;
+  /**
+   * How many `user` records we still owe to ALREADY-CONFIRMED deliveries,
+   * keyed by normalised text (issue #363 adversarial pass, finding 1).
+   *
+   * An `enqueue` record says the CLI took the keystrokes; the matching `user`
+   * line is written later, when it actually runs the prompt. If the bus
+   * re-delivers the same text in between — which `flushVerify` does verbatim,
+   * on a timer — that late `user` line is a FIRST sighting, so `consumedPromptIds`
+   * does not know it, and `user` records are deliberately exempt from the
+   * timestamp check because the CLI backdates them. Nothing else rejected it,
+   * so it confirmed the delivery still sitting un-submitted in the input box.
+   *
+   * Identity cannot separate the two: two submissions of byte-identical text
+   * carry different `promptId`s, and we never learn which one is ours. So we
+   * count instead. Confirming by `enqueue` owes one `user` record; the next
+   * matching `user` record pays that debt and is absorbed rather than credited.
+   */
+  private readonly outstandingEnqueues = new Map<string, { count: number; lastSeenMs: number }>();
+  private static readonly OUTSTANDING_ENQUEUE_MAX = 256;
+  /**
+   * How long an accepted-but-unrun submission stays outstanding. The measured
+   * `user`-line tail on a busy session is 443 s; this is that with room to
+   * spare. Past it, the queue entry is assumed gone — a session file rotated,
+   * a CLI that dropped the queue without writing a withdrawal — because an
+   * entry that never expires eventually absorbs a legitimate confirmation and
+   * makes the bus re-deliver a prompt the agent already ran (second
+   * adversarial pass, finding 4).
+   */
+  private static readonly OUTSTANDING_ENQUEUE_TTL_MS = 15 * 60_000;
+  /**
+   * True once a JSONL tailer is feeding `notePromptIngested`. Gates the
+   * stricter post-compaction rule below: without a transcript there is nothing
+   * better than the screen, so the original heuristics must stay in force.
+   */
+  private transcriptAvailable = false;
+  private readonly transcriptGraceMs: number;
   /** Hard cap on the boot-dialog watch window (issue #193 / Codex P2). If no
    *  REPL-ready marker is observed within this window (e.g. a future CLI
    *  changes the footer text), the watcher disengages anyway so it never
@@ -259,12 +360,18 @@ export class PtyAgentProcess implements AgentProcess {
       /** Upper bound to wait out an in-progress auto-compaction before the
        *  submit is abandoned to the watchdog (compaction can run ~100s). */
       maxCompactionWaitMs?: number;
+      /** How long to keep waiting for the transcript once the screen alone
+       *  would have declared a turn. The union of the two transcript records
+       *  has a measured p95 of 0.25s and a 0.27s maximum across 56 deliveries,
+       *  so this default is roughly 10x the observed worst case. */
+      transcriptGraceMs?: number;
     } = {},
   ) {
     this.agent_id = agent_id;
     this.pty = pty;
     this.pid = pty.pid;
     this.submitConfirmMs = opts.submitConfirmMs ?? 1500;
+    this.transcriptGraceMs = opts.transcriptGraceMs ?? 3000;
     this.maxSubmitNudges = opts.maxSubmitNudges ?? 2;
     this.maxCompactionWaitMs = opts.maxCompactionWaitMs ?? 240_000;
     this.bootDialogTimer = setTimeout(
@@ -381,6 +488,18 @@ export class PtyAgentProcess implements AgentProcess {
       // cost O(prompt x lines) for the life of the process. The input box only
       // ever echoes a screenful, so the head is the part that can come back.
       this.lastWritten = text.slice(0, PtyAgentProcess.ECHO_MATCH_MAX);
+      // Issue #362: arm the transcript watcher BEFORE the write. The CLI can
+      // ingest the prompt during the 200ms settle below — arming afterwards
+      // would miss exactly the fast case and fall back to reading pixels.
+      // A prompt that normalises to nothing — whitespace only — would arm the
+      // empty string and then match ANY whitespace-only record in the
+      // transcript, confirming a delivery it has no evidence for. Nothing to
+      // compare on means nothing to confirm on: stay disarmed and let the
+      // screen heuristic decide (adversarial pass, finding 4).
+      const armed = normalizePromptForMatch(text);
+      this.pendingPromptMatch = armed === "" ? null : armed;
+      this.pendingArmedAtMs = Date.now();
+      this.promptIngested = false;
       const compactingAtWrite = this.compacting;
       const compactionEpochAtWrite = this.compactionEpoch;
       this.pty.write(text);
@@ -414,7 +533,11 @@ export class PtyAgentProcess implements AgentProcess {
       // NEVER silently -- the stranded input line is cleared and a diagnostic is
       // surfaced, since a silently-dropped prompt is the failure this loop fixes.
       const compactionDeadline = Date.now() + this.maxCompactionWaitMs;
-      let outcome: "turn-started" | "stuck-compaction" | "unconfirmed-idle" = "unconfirmed-idle";
+      let outcome: "turn-started" | "stuck-compaction" | "unconfirmed-idle" | "unconfirmed-live" =
+        "unconfirmed-idle";
+      // When the screen first claimed a turn while a live transcript had not
+      // yet spoken. Bounds how long that claim is held unresolved.
+      let screenClaimedTurnAtMs = 0;
       let sawCompaction = compactingAtWrite || this.compactionEpoch !== compactionEpochAtWrite;
       let retypedAfterCompaction = false;
       // Latched as soon as any window shows real output that is neither the idle
@@ -433,6 +556,21 @@ export class PtyAgentProcess implements AgentProcess {
         // so resolving here would report a phantom success for a prompt whose
         // target just died -- suppressing re-queue and masking the wedge.
         if (this._exited) throw new Error(`agent ${this.agent_id} has exited`);
+        // Issue #362 — the transcript settles this window before any screen
+        // heuristic gets a say. The CLI wrote a `user` entry for this exact
+        // prompt, which it only does once it has actually ingested it. That
+        // outranks every probe below, all of which infer delivery from the
+        // rendered terminal and therefore cannot tell a submitted prompt from
+        // a post-compaction repaint (the 2026-08-27 false positive).
+        //
+        // Checking here also removes the retype's remaining double-submit
+        // risk: a confirmed ingestion exits the loop before the retype branch
+        // can fire on a stale idle footer.
+        if (this.promptIngested) {
+          outcome = "turn-started";
+          this.warnedUnconfirmedDelivery = false;
+          break;
+        }
         // Anchor the compaction probe to the CLI status line ("Compacting
         // conversation" / "Compacting at auto window") rather than the bare word
         // "Compacting", which also occurs in ordinary model output: a live turn
@@ -471,6 +609,7 @@ export class PtyAgentProcess implements AgentProcess {
           visible.includes("Compacting at auto")
         ) {
           sawCompaction = true;
+          screenClaimedTurnAtMs = 0; // the screen is not claiming a turn here
           // Evidence of a running turn only means anything AFTER the compaction:
           // before it, the echoed input line (the prompt sitting un-submitted in
           // the box) is itself non-footer output and would gate the retype off.
@@ -482,6 +621,9 @@ export class PtyAgentProcess implements AgentProcess {
           continue; // compaction in progress -> wait, do not spend a nudge
         }
         const footerVisible = /to\s*cycle/.test(visible);
+        // The idle footer is positive evidence that no turn is running, so any
+        // earlier screen claim is withdrawn and its clock restarts.
+        if (footerVisible) screenClaimedTurnAtMs = 0;
         // Everything in this window that is not a footer repaint and not a
         // spinner glyph. Printable ASCII only, so box-drawing and braille
         // spinner frames do not register as output.
@@ -527,6 +669,37 @@ export class PtyAgentProcess implements AgentProcess {
         // footer's absence; an empty/whitespace window stays inconclusive and
         // spends a nudge instead of claiming a phantom success.
         if (visible.trim().length > 0 && !footerVisible) {
+          // Issue #362 — the 2026-08-27 false positive lands exactly here.
+          // After a compaction the CLI repaints the restored transcript for
+          // seconds; those repaints are non-empty, carry no idle footer, and
+          // `Compacted (` has already scrolled out of this rolling window.
+          // Byte for byte, that is a streaming turn.
+          //
+          // This deliberately does NOT test whether a compaction was seen.
+          // `sawCompaction` is itself derived from the screen, and it is blind
+          // to the production ordering: a compaction that STARTED BEFORE this
+          // prompt was written and ENDED BEFORE it too bumps the epoch ahead of
+          // the snapshot, clears the latch, and shows no start banner — which
+          // is precisely the 2026-08-27 timeline (compaction ends 14:04:43,
+          // prompt written 14:04:47). Gating on it would leave the reported
+          // failure untouched.
+          //
+          // So: whenever a transcript is proven live, it is the only thing that
+          // may CONFIRM a turn. The screen's claim is held, unresolved and
+          // without spending a nudge, for a bounded grace period. If the
+          // transcript still has not spoken, the honest answer is "unknown" —
+          // not "yes" (the wedge) and not "no" (which would strand a turn that
+          // really is running).
+          if (this.transcriptAvailable) {
+            // Reset whenever the screen stops claiming (see the idle/compaction
+            // branches): otherwise one repaint window before a compaction burns
+            // the whole grace, and the post-compaction turn — the case this
+            // machinery exists for — gets none of it.
+            if (screenClaimedTurnAtMs === 0) screenClaimedTurnAtMs = Date.now();
+            if (Date.now() - screenClaimedTurnAtMs < this.transcriptGraceMs) continue;
+            outcome = "unconfirmed-live";
+            break;
+          }
           outcome = "turn-started";
           // A turn confirmed → re-arm the one-shot wedge warning, so a LATER
           // genuine wedge on this long-lived process still surfaces a diagnostic
@@ -570,7 +743,23 @@ export class PtyAgentProcess implements AgentProcess {
       // filter has nothing left to match. Clearing it keeps the filter from
       // running against unrelated output for the whole idle period after a turn.
       this.lastWritten = "";
-      if (outcome !== "turn-started" && !this.warnedUnconfirmedDelivery) {
+      // Disarm alongside the echo filter: a late transcript event for a prompt
+      // this loop already resolved must not confirm the NEXT one. The arm
+      // above resets both fields anyway, so an early throw cannot strand them.
+      this.pendingPromptMatch = null;
+      this.promptIngested = false;
+      if (outcome === "unconfirmed-live") {
+        // Distinct from the wedge warnings, and deliberately NOT one-shot-
+        // silenced: this says the screen looked like a turn while the
+        // transcript stayed quiet past the grace period. It is a real
+        // ambiguity worth seeing every time, and burning the one-shot flag
+        // here would mute a genuine wedge later in this process's life.
+        console.warn(
+          `[delivery-confirm] agent=${this.agent_id}: screen showed turn output but ` +
+            `the session transcript did not record the prompt within ` +
+            `${this.transcriptGraceMs}ms; reporting unconfirmed rather than guessing.`,
+        );
+      } else if (outcome !== "turn-started" && !this.warnedUnconfirmedDelivery) {
         this.warnedUnconfirmedDelivery = true;
         console.warn(
           `[delivery-confirm] agent=${this.agent_id}: submit not confirmed ` +
@@ -711,6 +900,193 @@ export class PtyAgentProcess implements AgentProcess {
 
   onExit(handler: ExitHandler): void {
     this.exitHandlers.push(handler);
+  }
+
+  /**
+   * Issue #362 — called by the session JSONL tailer when the transcript shows
+   * the CLI ingested a top-level user prompt. Ignored unless it matches the
+   * prompt currently in flight: the transcript also carries prompts this
+   * process never typed (a resumed session's harness nudge, for one), and
+   * treating those as confirmation would report delivery for a prompt still
+   * sitting un-submitted in the input box.
+   */
+  /** Issue #362 — see `transcriptAvailable`. Called by the session manager
+   *  when it binds a JSONL tailer to this process. */
+  enableTranscriptConfirmation(): void {
+    this.transcriptAvailable = true;
+  }
+
+  notePromptIngested(ingestion: PromptIngestion): void {
+    // Key on promptId AND the text, never on promptId alone.
+    //
+    // A `promptId` identifies a submission, not a record: an auto-compaction
+    // emits a cluster of `user` lines under one id — the continuation summary,
+    // the `/compact` command echo, its stdout — and the summary is written
+    // BEFORE the real prompt. Keying on the id alone let the summary consume
+    // it, so the actual prompt's record was dismissed as already seen and could
+    // never confirm. That failed in precisely the auto-compaction case this
+    // mechanism exists for, and `enqueue` does not cover it: a prompt that
+    // TRIGGERS a compaction is not queued behind a running turn.
+    // An `enqueue` record carries no `promptId`, so keying on the id alone left
+    // it with no identity at all: never recorded, never deduped, and free to
+    // confirm again on any re-read of the same line (adversarial pass,
+    // finding 3). Its transcript timestamp is written once, at acceptance, so
+    // timestamp + text identifies the record even though it identifies no
+    // submission. A stamp we cannot read yields no key — and the timestamp
+    // check below refuses that record anyway.
+    const key = ingestion.promptId
+      ? `${ingestion.promptId}\u0000${normalizePromptForMatch(ingestion.text)}`
+      : ingestion.source === "enqueue" && ingestion.ingestedAtMs > 0
+        ? `enqueue\u0000${ingestion.ingestedAtMs}\u0000${normalizePromptForMatch(ingestion.text)}`
+        : null;
+    const alreadySeen = key ? this.consumedPromptIds.has(key) : false;
+    // Record the id FIRST, before any early return.
+    //
+    // A delivery routinely ends with the transcript still silent, so its record
+    // arrives while nothing is armed. Returning early without recording it left
+    // that record eligible to confirm the NEXT arming of the same text — and
+    // the bus re-delivers verbatim on flush-verify, so "the same text again" is
+    // a coded path, not a coincidence. That phantom confirmation is the exact
+    // failure this mechanism exists to remove.
+    if (key && !alreadySeen) {
+      if (this.consumedPromptIds.size >= PtyAgentProcess.CONSUMED_PROMPT_IDS_MAX) {
+        // Set iteration is insertion-ordered, so this is genuinely the oldest.
+        const oldest = this.consumedPromptIds.values().next().value;
+        if (oldest !== undefined) this.consumedPromptIds.delete(oldest);
+      }
+      this.consumedPromptIds.add(key);
+    }
+
+    const normalised = normalizePromptForMatch(ingestion.text);
+
+    // ── The queue is a conservation law, not a side effect of confirming ──
+    //
+    // First cut booked the debt only where an `enqueue` actually confirmed a
+    // delivery. Every enqueue refused for any other reason booked nothing —
+    // yet the CLI still had the prompt queued and still wrote its `user` line
+    // later, which then confirmed the NEXT delivery of the same text. The
+    // original phantom, untouched. Worse, refusing an unusable timestamp is
+    // what SKIPPED the booking, so that guard manufactured the very failure it
+    // was added to prevent (second adversarial pass, finding 1).
+    //
+    // What the transcript actually tells us is a count: how many submissions
+    // of this text the CLI has accepted but not yet run. `enqueue` increments
+    // it, `user` and a withdrawal decrement it. Whether any of them confirms
+    // one of OUR deliveries is a separate question, asked afterwards.
+    // Gated on `alreadySeen`: the count is a ledger, and a record presented
+    // twice must not be counted twice in either direction. This is what makes
+    // the identity key above load-bearing rather than decorative — without the
+    // gate, a re-read enqueue books a phantom queue entry that later absorbs a
+    // legitimate confirmation, and a re-read `user` line pays down two.
+    if (!alreadySeen && ingestion.source === "enqueue") this.noteEnqueueObserved(normalised);
+    if (!alreadySeen && ingestion.source === "user" && this.consumeOutstandingEnqueue(normalised)) {
+      // This `user` line belongs to a submission accepted earlier and only now
+      // running. It is evidence about that one, not about whatever is armed.
+      return;
+    }
+
+    if (this.pendingPromptMatch === null) return;
+    if (alreadySeen) return;
+    // Staleness by timestamp applies to `enqueue` ONLY. Its timestamp tracks
+    // acceptance within ~0.2s, whereas the CLI backdates `user` lines — observed
+    // by up to 148s (a line written at 14:04:43 stamped 14:02:15). Judging a
+    // `user` record stale on its own timestamp would discard live confirmations.
+    //
+    // An unusable timestamp REFUSES the record instead of waving it through.
+    // The enqueue path carries no `promptId`, so this check is the only thing
+    // deciding which delivery it belongs to; treating a missing stamp as
+    // "recent enough" made a 60s-stale enqueue confirm whatever was armed
+    // (adversarial pass, finding 2). Refusing costs a fall back to the screen
+    // heuristic and its grace; accepting reports a delivery that never
+    // happened, which is the failure this whole mechanism exists to remove.
+    if (ingestion.source === "enqueue" && !this.enqueueStampBelongsToThisDelivery(ingestion)) {
+      return;
+    }
+    if (normalised !== this.pendingPromptMatch) return;
+    this.promptIngested = true;
+  }
+
+  /**
+   * Whether an `enqueue` record's timestamp places it inside the delivery
+   * currently in flight. Every way a stamp can be unusable is refused rather
+   * than waved through: the enqueue path carries no `promptId`, so this is the
+   * only thing deciding which delivery the record belongs to.
+   *
+   * A stamp in the future is unusable too — a forward clock skew on the CLI is
+   * not hypothetical, and an absurd one also poisons the dedupe key built from
+   * it.
+   *
+   * There is deliberately no `Number.isFinite` guard. A previous round added
+   * one and justified it with "a bare `< armed` test let NaN through" — but
+   * the comparison below is `>=` inside a `return`, and `NaN >= x` is false,
+   * so NaN was already refused. Deleting the guard left every test green: it
+   * was dead code dressed as a fix, the exact thing the round before it was
+   * criticised for. The tailer also maps non-finite stamps to `0`
+   * (`jsonl-tailer.ts`), which `ts <= 0` catches.
+   *
+   * Refusing costs a fall back to the screen heuristic and its grace period.
+   * Accepting reports a delivery that never happened — the failure this whole
+   * mechanism exists to remove — so the asymmetry is deliberate.
+   */
+  private enqueueStampBelongsToThisDelivery(ingestion: PromptIngestion): boolean {
+    const ts = ingestion.ingestedAtMs;
+    if (ts <= 0) return false;
+    if (ts > Date.now() + INGESTION_CLOCK_SKEW_MS) return false;
+    return ts >= this.pendingArmedAtMs - INGESTION_CLOCK_SKEW_MS;
+  }
+
+  /**
+   * Record that the CLI accepted one more submission of this text. Called for
+   * EVERY `enqueue` record seen, whatever it goes on to confirm — the count is
+   * a fact about the CLI's queue, not about our confirmation logic.
+   */
+  private noteEnqueueObserved(normalised: string): void {
+    this.expireOutstandingEnqueues();
+    const entry = this.outstandingEnqueues.get(normalised);
+    if (entry) {
+      entry.count += 1;
+      entry.lastSeenMs = Date.now();
+      return;
+    }
+    if (this.outstandingEnqueues.size >= PtyAgentProcess.OUTSTANDING_ENQUEUE_MAX) {
+      // Only reachable when 256 distinct texts are queued and unrun inside the
+      // TTL. Dropping the oldest restores the phantom for that one text, which
+      // is worse than the memory — but unbounded growth in a daemon that runs
+      // for weeks is not acceptable either, so bound generously and evict only
+      // after the TTL sweep above has already failed to free anything.
+      const oldest = this.outstandingEnqueues.keys().next().value;
+      if (oldest !== undefined) this.outstandingEnqueues.delete(oldest);
+    }
+    this.outstandingEnqueues.set(normalised, { count: 1, lastSeenMs: Date.now() });
+  }
+
+  /**
+   * Account one outstanding submission of this text as run (or withdrawn).
+   * Returns true when there WAS one — meaning the record just seen belongs to
+   * that earlier submission and must not be credited to whatever is armed now.
+   *
+   * Decrements by one. The first cut deleted the whole entry, so a single
+   * withdrawal wiped every outstanding copy of a text the bus had queued twice
+   * — and the survivor's `user` line then confirmed the next delivery (second
+   * adversarial pass, finding 2).
+   */
+  private consumeOutstandingEnqueue(normalised: string): boolean {
+    this.expireOutstandingEnqueues();
+    const entry = this.outstandingEnqueues.get(normalised);
+    if (!entry || entry.count <= 0) return false;
+    entry.count -= 1;
+    entry.lastSeenMs = Date.now();
+    if (entry.count === 0) this.outstandingEnqueues.delete(normalised);
+    return true;
+  }
+
+  /** Drop queue entries old enough that their `user` line is never coming. */
+  private expireOutstandingEnqueues(): void {
+    if (this.outstandingEnqueues.size === 0) return;
+    const cutoff = Date.now() - PtyAgentProcess.OUTSTANDING_ENQUEUE_TTL_MS;
+    for (const [text, entry] of this.outstandingEnqueues) {
+      if (entry.lastSeenMs < cutoff) this.outstandingEnqueues.delete(text);
+    }
   }
 
   onData(handler: DataHandler): void {

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -848,6 +848,12 @@ export class SessionManager {
     // fire-and-forget: it must not block returning the proc, and a tail
     // failure must never fail the spawn.
     if (this.options.bus) {
+      // Widen to the interface: `proc` is the concrete union
+      // `PtyAgentProcess | ChildAgentProcess`, and an optional member on the
+      // interface is not visible through a union of the classes implementing
+      // it. Both implement `AgentProcess`, so the transcript hooks are reached
+      // through it — and a runtime without them stays a no-op via `?.`.
+      const confirmable: AgentProcess = proc;
       const tailer = new JsonlTailer({
         bus: this.options.bus,
         agent_id: agent.id,
@@ -855,7 +861,20 @@ export class SessionManager {
         cwd: realCwd,
         startAt: "end",
         projectsDir: this.options.projectsDir,
+        // Issue #362: feed the transcript's prompt-ingestion fact back to the
+        // PTY delivery-confirm loop, which otherwise has only the rendered
+        // terminal to judge by and cannot distinguish a submitted prompt from
+        // a repaint. `startAt: "end"` above is what makes this safe on a
+        // resumed session: historical prompts are never replayed, so this can
+        // only ever fire for a prompt typed by this process.
+        onPromptIngested: (ingestion) => confirmable.notePromptIngested?.(ingestion),
+        // Only once a line has actually been read does the process stop
+        // trusting a post-compaction repaint. Enabling it at wiring time would
+        // strand any agent whose transcript path does not resolve: the strict
+        // branch would wait for a signal that can never arrive.
+        onTranscriptAlive: () => confirmable.enableTranscriptConfirmation?.(),
       });
+
       record.tailer = tailer;
       void tailer
         .start()


### PR DESCRIPTION
## Problem

Delivery confirmation currently reads the PTY surface. On that surface *"the CLI
submitted my text"* and *"the CLI repainted something"* are the same bytes, so any
screen heuristic can be fooled by a post-compaction repaint: the delivery is
reported as confirmed while the prompt was never taken.

## Change

Take the confirmation from the session transcript instead — from whichever record
lands first:

| Record | Meaning |
|---|---|
| `queue-operation` / `operation: "enqueue"` | the CLI **accepted** the keystrokes |
| the `user` line | the CLI **started** the turn |

Both are facts the CLI writes about itself, independent of rendering.

### Why both, and not the `user` line alone

`core.ts` delivers a prompt even when a turn is active; the CLI then queues the
keystrokes and writes the `user` line only when it gets round to running them.

Measured by pairing `enqueue` → `user` on a production transcript set:

| Sample | Pairs | Median | Max | Beyond 8 s |
|---|---|---|---|---|
| Agent sessions (bus-driven) | 292 | 0.09 s | 243.8 s | **12 (4 %)** |
| All sessions | 915 | 0.10 s | 243.8 s | 5 (1 %) |

The median is not the story — the distribution has a second mode. Confirming on
the `user` line alone reports those 12 deliveries as lost.

### Design notes

- **The `operation` test is positive** (`=== "enqueue"`), not a blocklist. A
  `dequeue` is the queue handing the prompt to the runner, not a cancellation —
  the fixtures show it firing ~1 ms after the enqueue and ~2 s before the `user`
  line of a normal delivery. An earlier round read it as a cancellation and
  un-confirmed every delivery it touched. Any operation a future CLI adds is now
  ignored rather than guessed at.
- **`onTranscriptAlive` fires once**, on the first line actually read. Being
  constructed is not evidence a transcript is readable: the path is derived from
  the cwd encoding, and a mismatch leaves the tailer pointed at a file that never
  appears — silently, since a missing session file is a normal startup state.
  Hardening keyed off the wiring instead would degrade every agent whose
  transcript is unreachable.
- **`startAt: "end"` on resumed sessions**, so historical prompts are never
  replayed as fresh deliveries.
- **Both hooks are optional** (`?.`) — a runtime without them is a no-op.

### Known bounds, all failing safe

An outstanding enqueue whose `user` line carries an array `content` (attachments),
or whose `enqueue` is written *after* its `user` line, is never paid off and
expires on the 15 min TTL. The consequence is a false *"unconfirmed"*, never a
phantom confirm.

`unconfirmed-live` does not propagate to the caller: `send_prompt_stream` still
resolves, matching the existing `unconfirmed-idle` behaviour. The 3 s default
grace is the parameter worth watching in logs after deploy.

## Verification

- `bun run lint` — no errors
- CI test suites — **1610 pass / 0 fail** (753 + 857, each stable across repeat runs)
- `bun run typecheck` — 153 errors, baseline 153, no regression
- **Live check against real transcripts**, read-only: the tailer was instantiated
  against a production session file. `onTranscriptAlive` fired exactly once,
  `onPromptIngested` fired 48 times (`enqueue` 9, `user` 39), zero malformed
  entries — both paths exercised on real data.
- Contract re-checked against the current CLI: `operation: "enqueue"` carries a
  **string** `content`; `operation: "dequeue"` carries `null`, so the type guard
  catches a dequeue even if the positive test were removed.

Plugin and marketplace manifests are both bumped.
