### PR TITLE
docs(bus): correct the dequeue-timing figure cited from the fixture

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.242",
+      "version": "2.2.243",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.242",
+  "version": "2.2.243",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/jsonl-tailer.test.ts
+++ b/src/bus/__tests__/jsonl-tailer.test.ts
@@ -913,7 +913,7 @@ describe("prompt ingestion callbacks", () => {
   /**
    * A `dequeue` is the queue handing the prompt to the RUNNER, not handing it
    * back. `docs/spikes/fixtures/jsonl/01-headless-text-only.jsonl` shows it
-   * 1 ms after the enqueue and 2 s before the `user` line of a normal
+   * 1 ms after the enqueue and 13 ms before the `user` line of a normal
    * delivery, and it carries no `content`. Two rounds of review read it as a
    * cancellation; a test asserted that reading, against a record shape the CLI
    * does not write.

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -1320,7 +1320,7 @@ describe("PtyAgentProcess enqueue-confirmed delivery (issue #363)", () => {
    * Two rounds of review built a withdrawal path on the opposite reading. The
    * repo's own fixtures settle it: in
    * `docs/spikes/fixtures/jsonl/01-headless-text-only.jsonl` the `dequeue`
-   * fires 1 ms after the `enqueue` and 2 s before the `user` line, in a normal
+   * fires 1 ms after the `enqueue` and 13 ms before the `user` line, in a normal
    * successful delivery — the queue handing the prompt to the runner. It also
    * carries no `content`. The tests that covered the withdrawal synthesised a
    * record the CLI does not write, and the code they covered would have

--- a/src/bus/jsonl-line-types.ts
+++ b/src/bus/jsonl-line-types.ts
@@ -309,7 +309,7 @@ export interface PromptIngestion {
    * the queue handing the prompt BACK and built a withdrawal path on that. The
    * repo's own fixtures say otherwise: in
    * `docs/spikes/fixtures/jsonl/01-headless-text-only.jsonl` a `dequeue` fires
-   * 1 ms after the `enqueue` and 2 s before the `user` line, in a normal
+   * 1 ms after the `enqueue` and 13 ms before the `user` line, in a normal
    * successful single-prompt delivery. It means the queue handed the prompt to
    * the RUNNER. Treating it as a cancellation un-confirms every delivery it
    * touches. It also carries no `content`, so it cannot be attributed to a

--- a/src/bus/jsonl-tailer.ts
+++ b/src/bus/jsonl-tailer.ts
@@ -417,7 +417,7 @@ export class JsonlTailer {
     if (!this.onPromptIngested) return;
     // Only `enqueue`. A `dequeue` is NOT the queue giving the prompt back — the
     // fixtures in `docs/spikes/fixtures/jsonl/` show it firing 1 ms after the
-    // enqueue and 2 s before the `user` line of a normal delivery, i.e. the
+    // enqueue and 13 ms before the `user` line of a normal delivery, i.e. the
     // queue handing the prompt to the runner. A round of review read it as a
     // cancellation and this forwarded it as one; every delivery it touched
     // would have been un-confirmed. Positive test, so any other operation a


### PR DESCRIPTION
## Problem

Four comments state that in `docs/spikes/fixtures/jsonl/01-headless-text-only.jsonl` a `dequeue` fires *"1 ms after the enqueue and **2 s** before the `user` line"*.

## Root cause

Reading the fixture:

```
enqueue  2026-05-17T14:16:51.702Z
dequeue  2026-05-17T14:16:51.703Z   (+1 ms)
user     2026-05-17T14:16:51.716Z   (+13 ms)
```

**Thirteen milliseconds, not two seconds.** The "+1 ms after the enqueue" half is correct.

## Why it matters even though no code reads it

That figure carries the argument that a `dequeue` means *"the queue handed the prompt to the runner"* rather than *"the queue handed it back"* — and that argument is what keeps a `dequeue` from un-confirming every delivery it touches.

The conclusion still holds. A `dequeue` 13 ms from its enqueue supports it **more** strongly than one 2 s away. It simply did not hold for the number written beside it, and a wrong figure in a comment reads as a measurement to the next person who opens the file.

## Fix

The claim appears in four places — the `PromptIngestion` docstring, the `notifyEnqueue` comment, and the two test files that quote them. All four now agree.

Four copies that disagree would be worse than four that are wrong: the next reader would not know which to trust.

## Test plan

- `bun run lint` — clean (exit 0)
- `bun test src/bus/__tests__/jsonl-tailer.test.ts src/bus/__tests__/session-agent-process.test.ts` — 86 pass, 0 fail
- Fixture re-read directly to confirm the three timestamps above
- `grep -rn "2 s before" src/ docs/` → 0 remaining

Comment-only diff: no code path is touched, so there is no behavioural surface to exercise. Version bumped because the guard covers `src/`.

## Refs

Refs #381
