### PR TITLE
fix(pty): bound the waits that run before runOnPty's timeout arms

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.240",
+      "version": "2.2.241",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.241",
+      "version": "2.2.242",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.240",
+  "version": "2.2.241",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.241",
+  "version": "2.2.242",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,5 +75,10 @@ jobs:
       # analogue of the #345 pty-supervisor footer hang) — slipped past CI.
       # Fast (~0.5s), pure fake-PTY, no infra; verified 0 fail in the shared
       # process (1443 pass across the clean suites) and stable across repeat runs.
+      # `src/__tests__/pty-supervisor.test.ts` added #369: 47 pre-existing tests
+      # plus the two bounded-admission ones, 49 pass / 0 fail, verified stable
+      # 5/5 across repeat runs in 0.7s. It is the suite that covers the spawn and
+      # per-entry-lock paths this change bounds — without it, a regression in the
+      # deadlines lands with nothing in CI to catch it.
       - name: Run tests (clean suites)
-        run: bun test src/bus src/adapters src/tuner src/observability src/skills-tuner src/plugins/eval-framework src/__tests__/governance src/__tests__/mcp-multiplexer-integration.test.ts src/__tests__/event-processor.test.ts src/__tests__/pty-boot-dialog.test.ts
+        run: bun test src/bus src/adapters src/tuner src/observability src/skills-tuner src/plugins/eval-framework src/__tests__/governance src/__tests__/mcp-multiplexer-integration.test.ts src/__tests__/event-processor.test.ts src/__tests__/pty-boot-dialog.test.ts src/__tests__/pty-supervisor.test.ts

--- a/src/__tests__/pty-supervisor.test.ts
+++ b/src/__tests__/pty-supervisor.test.ts
@@ -1787,4 +1787,61 @@ describe("pty-supervisor bounded admission (issue #369)", () => {
     });
     expect(third.exitCode).toBe(0);
   });
+
+  it("a caller that abandons the lock wait never lets two turns run on one PTY", async () => {
+    // The regression this guards: releasing the installed lock on the timeout
+    // path hands the chain to the next caller while the predecessor's turn is
+    // still running — two turns interleaved on one PTY. The previous test could
+    // not see it, because it only issued the third call *after* awaiting the
+    // first. This one issues it while the first is still held.
+    let releaseFirstTurn: () => void = () => {};
+    const firstTurnHeld = new Promise<void>((resolve) => {
+      releaseFirstTurn = resolve;
+    });
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let turns = 0;
+
+    const { spawn } = makeSpawnTracker(() =>
+      makeFakePty("serialised", {
+        onTurn: async (prompt: string) => {
+          turns += 1;
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          try {
+            if (turns === 1) await firstTurnHeld;
+            return {
+              text: `echo:${prompt}`,
+              bytesCaptured: prompt.length,
+              cleanBoundary: true,
+              sessionId: "session-serialised",
+            };
+          } finally {
+            inFlight -= 1;
+          }
+        },
+      }),
+    );
+    injectSpawnPty(spawn);
+    await initSupervisor();
+
+    const first = runOnPty("thread:ser", "one", { timeoutMs: 30_000, threadId: "ser" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Gives up on the wait; must not hand the chain on while `first` runs.
+    const second = await runOnPty("thread:ser", "two", { timeoutMs: 60, threadId: "ser" });
+    expect(second.exitCode).toBe(1);
+
+    // Issued while the first turn is STILL held.
+    const third = runOnPty("thread:ser", "three", { timeoutMs: 30_000, threadId: "ser" });
+    await new Promise((r) => setTimeout(r, 150));
+
+    expect(maxInFlight).toBe(1);
+    expect(turns).toBe(1);
+
+    releaseFirstTurn();
+    expect((await first).exitCode).toBe(0);
+    expect((await third).exitCode).toBe(0);
+    expect(maxInFlight).toBe(1);
+  });
 });

--- a/src/__tests__/pty-supervisor.test.ts
+++ b/src/__tests__/pty-supervisor.test.ts
@@ -1844,4 +1844,43 @@ describe("pty-supervisor bounded admission (issue #369)", () => {
     expect((await third).exitCode).toBe(0);
     expect(maxInFlight).toBe(1);
   });
+
+  it("abandoning a slow spawn never spawns a second PTY on the same entry", async () => {
+    // Bounding the spawn must not abandon ownership of it. If the timeout path
+    // let the next caller start its own spawn, both would land and each set
+    // `entry.pty` — orphaning whichever arrived first: a claude process plus its
+    // MCP fleet with no dispose path, since only the entry is tracked.
+    let releaseSpawn: () => void = () => {};
+    const spawnHeld = new Promise<void>((resolve) => {
+      releaseSpawn = resolve;
+    });
+    let spawnCalls = 0;
+
+    const inner = makeSpawnTracker(() => makeFakePty("slow-spawn", {}));
+    const slowSpawn: SpawnPty = async (o) => {
+      spawnCalls += 1;
+      await spawnHeld;
+      return inner.spawn(o);
+    };
+    injectSpawnPty(slowSpawn);
+    await initSupervisor();
+
+    // First caller gives up on the spawn.
+    const first = await runOnPty("thread:spawn1", "one", {
+      timeoutMs: 60,
+      threadId: "spawn1",
+    });
+    expect(first.exitCode).toBe(1);
+    expect(first.stderr).toContain("did not come up");
+
+    // Second caller arrives while that spawn is still in flight. It must join it,
+    // not start another.
+    const second = runOnPty("thread:spawn1", "two", { timeoutMs: 30_000, threadId: "spawn1" });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(spawnCalls).toBe(1);
+
+    releaseSpawn();
+    expect((await second).exitCode).toBe(0);
+    expect(spawnCalls).toBe(1);
+  });
 });

--- a/src/__tests__/pty-supervisor.test.ts
+++ b/src/__tests__/pty-supervisor.test.ts
@@ -1710,3 +1710,81 @@ describe("pty-supervisor housekeeping (issue #65)", () => {
     expect(spawned[1].disposed).toBe(true);
   });
 });
+
+describe("pty-supervisor bounded admission (issue #369)", () => {
+  it("a spawn that never settles fails the call instead of hanging it", async () => {
+    // `timeoutMs` used to bound only the turn. Admission — supervisor init,
+    // the concurrency gate, the spawn itself — ran ahead of it with no
+    // deadline, so a spawn that never returned hung the caller forever: the
+    // caller's own timeout elapsed and nothing fired.
+    const neverSettles: SpawnPty = () => new Promise<never>(() => {});
+    injectSpawnPty(neverSettles);
+    await initSupervisor();
+
+    const started = Date.now();
+    const r = await runOnPty("thread:stuck-spawn", "x", {
+      timeoutMs: 60,
+      threadId: "stuck-spawn",
+    });
+    const elapsed = Date.now() - started;
+
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("PTY spawn for");
+    expect(r.stderr).toContain("did not come up");
+    expect(r.stderr).toContain("thread:stuck-spawn");
+    // Bounded, not hung. Generous ceiling so a loaded runner cannot flake it;
+    // the property under test is "returns at all", not "returns fast".
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  it("a slow turn does not wedge the entry for the calls behind it", async () => {
+    // Turns on one session are serialised through a per-entry lock. A caller
+    // that gave up waiting used to leave the lock it had already installed
+    // unreleased — wedging every later turn on that key. Timing out here must
+    // still release, or the fix reproduces the bug it is fixing.
+    let releaseFirstTurn: () => void = () => {};
+    const firstTurnHeld = new Promise<void>((resolve) => {
+      releaseFirstTurn = resolve;
+    });
+    let turns = 0;
+
+    const { spawn } = makeSpawnTracker(() =>
+      makeFakePty("slow", {
+        onTurn: async (prompt: string) => {
+          turns += 1;
+          if (turns === 1) await firstTurnHeld;
+          return {
+            text: `echo:${prompt}`,
+            bytesCaptured: prompt.length,
+            cleanBoundary: true,
+            sessionId: "session-slow",
+          };
+        },
+      }),
+    );
+    injectSpawnPty(spawn);
+    await initSupervisor();
+
+    const first = runOnPty("thread:slow", "one", { timeoutMs: 30_000, threadId: "slow" });
+    // Let the first call take the lock before the second one asks for it.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const second = await runOnPty("thread:slow", "two", {
+      timeoutMs: 60,
+      threadId: "slow",
+    });
+    expect(second.exitCode).toBe(1);
+    expect(second.stderr).toContain("previous turn");
+
+    releaseFirstTurn();
+    const firstResult = await first;
+    expect(firstResult.exitCode).toBe(0);
+
+    // The entry survived the abandoned wait: a later turn still runs.
+    const third = await runOnPty("thread:slow", "three", {
+      timeoutMs: 30_000,
+      threadId: "slow",
+    });
+    expect(third.exitCode).toBe(0);
+  });
+});

--- a/src/runner/pty-supervisor.ts
+++ b/src/runner/pty-supervisor.ts
@@ -681,8 +681,12 @@ export async function runOnPty(
   // caller's `timeoutMs` elapsed and nothing fired. That is the difference
   // between a job failing cleanly and a job wedging.
   //
-  // Both stages are now bounded by the caller's own `timeoutMs`. Nothing new to
-  // configure, and no caller waits longer than it already asked to.
+  // Each stage is bounded by the caller's own `timeoutMs`. Note this is a
+  // per-stage bound, not a total: admission, the lock wait, the spawn and each
+  // of `maxRetries + 1` turns are each bounded by it, so the worst case is a
+  // multiple of `timeoutMs`, not `timeoutMs`. The retry multiplication predates
+  // this change; what changes here is that the stages ahead of the retry loop
+  // are bounded at all instead of being able to hang forever.
   let entry: PtyEntry;
   let supervisorOpts: ReturnType<typeof readSupervisorOptions>;
   try {
@@ -720,16 +724,25 @@ export async function runOnPty(
   entry.lock = new Promise<void>((resolve) => {
     release = resolve;
   });
+  // The lock is a chain: each caller captures its predecessor, installs its own,
+  // awaits the predecessor, and releases in `finally`. Giving up on the wait is
+  // therefore delicate — releasing immediately would hand the chain to the next
+  // caller while the predecessor's turn is *still running*, putting two turns on
+  // one PTY with interleaved writes and reads. Bounding the wait must not cost
+  // the serialisation it is bounding.
+  //
+  // So on timeout this call abandons its own wait but leaves the chain intact:
+  // its lock is released only once the predecessor actually settles.
+  let releaseOnExit = true;
   try {
-    // The per-entry lock serialises turns on one session. A previous turn that
-    // never settles used to block every later turn on that key forever. Bound
-    // the wait — and note the `finally` below still runs, so timing out here
-    // releases the lock this call installed instead of wedging the entry for
-    // its successors, which would reproduce the very bug being fixed.
     try {
       await withDeadline(previousLock, opts.timeoutMs);
     } catch (err) {
       if (err instanceof DeadlineExceeded) {
+        // Not `release()` — see above. Successors keep waiting behind the
+        // predecessor that is still running, and are unblocked when it ends.
+        releaseOnExit = false;
+        void previousLock.finally(release);
         return errorResult(
           `[pty-supervisor] waited ${opts.timeoutMs}ms for the previous turn on ${sessionKey} to finish; it never did`,
         );
@@ -738,7 +751,7 @@ export async function runOnPty(
     }
     return await runTurnWithRetries(entry, prompt, opts, supervisorOpts);
   } finally {
-    release();
+    if (releaseOnExit) release();
   }
 }
 

--- a/src/runner/pty-supervisor.ts
+++ b/src/runner/pty-supervisor.ts
@@ -601,6 +601,41 @@ export function snapshotSupervisor(): SupervisorSnapshot {
 }
 
 /**
+ * Thrown by `withDeadline` when the wrapped promise does not settle in time.
+ * A distinct type so callers can tell "we gave up waiting" apart from a real
+ * failure the operation itself reported.
+ */
+class DeadlineExceeded extends Error {
+  constructor(ms: number) {
+    super(`deadline of ${ms}ms exceeded`);
+    this.name = "DeadlineExceeded";
+  }
+}
+
+/**
+ * Resolve `p`, or reject with `DeadlineExceeded` after `ms`.
+ *
+ * The loser of the race is not abandoned silently: the timer is always cleared,
+ * and a late rejection from `p` is swallowed so it cannot surface as an
+ * unhandled rejection after we have already returned. `p` itself keeps running —
+ * there is no cancellation to hand it — so this bounds the WAIT, not the work.
+ * That is the right shape here: an admission that eventually completes leaves a
+ * usable entry behind for the next call.
+ */
+function withDeadline<T>(p: Promise<T>, ms: number): Promise<T> {
+  if (!Number.isFinite(ms) || ms <= 0) return p;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return new Promise<T>((resolve, reject) => {
+    timer = setTimeout(() => reject(new DeadlineExceeded(ms)), ms);
+    (timer as { unref?: () => void }).unref?.();
+    p.then(resolve, reject);
+  }).finally(() => {
+    if (timer) clearTimeout(timer);
+    p.catch(() => {});
+  });
+}
+
+/**
  * Run a single turn on the PTY associated with `sessionKey`.
  * See SPEC §3.2 for the contract.
  *
@@ -638,19 +673,47 @@ export async function runOnPty(
   // daemon runtime enters PTY mode through `runOnPty` directly and never
   // calls `initSupervisor`, so without this `settings.pty.idleReapMinutes`
   // would be ignored in production.
-  await ensureSupervisorInitialised();
-
-  const supervisorOpts = readSupervisorOptions();
-
-  // Phase D fix #5: enforce maxConcurrent cap with LRU eviction BEFORE
-  // allocating a new entry. Named agents are exempt — they're always-alive
-  // by design.
+  // Issue #369: `timeoutMs` is consumed inside `runTurnWithRetries`, so it
+  // bounds the TURN. Everything before it — supervisor init, admission (lock
+  // wait, `enforceMaxConcurrent`, spawning claude plus the MCP fleet), and the
+  // wait on the previous turn's lock — ran with no deadline at all. A stall in
+  // any of those was an unbounded hang rather than a recoverable timeout: the
+  // caller's `timeoutMs` elapsed and nothing fired. That is the difference
+  // between a job failing cleanly and a job wedging.
   //
-  // Issue #65 item 2: enforce + create must be a single critical section.
-  // `enforceMaxConcurrent` awaits on `dispose()`, opening a window where two
-  // concurrent admissions can both see "under cap" and both add entries —
-  // exceeding the cap. Serialize through `_admissionLock`.
-  const entry = await admitEntry(sessionKey, opts);
+  // Both stages are now bounded by the caller's own `timeoutMs`. Nothing new to
+  // configure, and no caller waits longer than it already asked to.
+  let entry: PtyEntry;
+  let supervisorOpts: ReturnType<typeof readSupervisorOptions>;
+  try {
+    ({ entry, supervisorOpts } = await withDeadline(
+      (async () => {
+        await ensureSupervisorInitialised();
+        // Read settings before admission, as before: never cached across calls,
+        // so hot-reload keeps working.
+        const so = readSupervisorOptions();
+        // Phase D fix #5: enforce maxConcurrent cap with LRU eviction BEFORE
+        // allocating a new entry. Named agents are exempt — they're always-alive
+        // by design.
+        //
+        // Issue #65 item 2: enforce + create must be a single critical section.
+        // `enforceMaxConcurrent` awaits on `dispose()`, opening a window where two
+        // concurrent admissions can both see "under cap" and both add entries —
+        // exceeding the cap. Serialize through `_admissionLock`.
+        const e = await admitEntry(sessionKey, opts);
+        return { entry: e, supervisorOpts: so };
+      })(),
+      opts.timeoutMs,
+    ));
+  } catch (err) {
+    if (err instanceof DeadlineExceeded) {
+      return errorResult(
+        `[pty-supervisor] admission stage exceeded ${opts.timeoutMs}ms for ${sessionKey} — supervisor init, concurrency admission, or PTY spawn did not settle`,
+      );
+    }
+    throw err;
+  }
+
   entry.lastAccessedAt = _clock();
   const previousLock = entry.lock;
   let release: () => void = () => {};
@@ -658,7 +721,21 @@ export async function runOnPty(
     release = resolve;
   });
   try {
-    await previousLock;
+    // The per-entry lock serialises turns on one session. A previous turn that
+    // never settles used to block every later turn on that key forever. Bound
+    // the wait — and note the `finally` below still runs, so timing out here
+    // releases the lock this call installed instead of wedging the entry for
+    // its successors, which would reproduce the very bug being fixed.
+    try {
+      await withDeadline(previousLock, opts.timeoutMs);
+    } catch (err) {
+      if (err instanceof DeadlineExceeded) {
+        return errorResult(
+          `[pty-supervisor] waited ${opts.timeoutMs}ms for the previous turn on ${sessionKey} to finish; it never did`,
+        );
+      }
+      throw err;
+    }
     return await runTurnWithRetries(entry, prompt, opts, supervisorOpts);
   } finally {
     release();
@@ -1323,16 +1400,35 @@ async function runTurnWithRetries(
   supervisorOpts: SupervisorOptions,
 ): Promise<RunOnPtyResult> {
   // Lazy spawn on first turn for this key.
+  //
+  // Issue #369: this is where the unbounded wait actually lived. `timeoutMs`
+  // is applied inside the retry loop below, so it bounds the TURN — but the
+  // spawn that boots claude and the MCP fleet runs ahead of that loop with no
+  // deadline of its own. A spawn that never settles hung the caller for as long
+  // as the process lived: reported as "given timeoutMs 600_000 it sat the full
+  // 600s", which is exactly this path.
+  //
+  // The issue attributed the stall to `admitEntry` -> `getOrCreateEntry`.
+  // `getOrCreateEntry` does not spawn; the only `spawnEntry` call reachable on
+  // the first-turn path is this one.
   if (!entry.pty) {
     try {
-      await spawnEntry(
-        entry,
-        callOpts.modelOverride,
-        callOpts.api,
-        callOpts.securityArgs,
-        callOpts.appendSystemPrompt,
+      await withDeadline(
+        spawnEntry(
+          entry,
+          callOpts.modelOverride,
+          callOpts.api,
+          callOpts.securityArgs,
+          callOpts.appendSystemPrompt,
+        ),
+        callOpts.timeoutMs,
       );
     } catch (err) {
+      if (err instanceof DeadlineExceeded) {
+        return errorResult(
+          `[pty-supervisor] PTY spawn for ${entry.sessionKey} exceeded ${callOpts.timeoutMs}ms — claude or the MCP fleet did not come up`,
+        );
+      }
       return errorResult(
         `[pty-supervisor] failed to spawn PTY for ${entry.sessionKey}: ${(err as Error).message}`,
       );

--- a/src/runner/pty-supervisor.ts
+++ b/src/runner/pty-supervisor.ts
@@ -414,6 +414,14 @@ interface PtyEntry {
   /** Last time `runOnPty` was called against this key. Drives LRU eviction
    *  when `pty.maxConcurrent` is hit. Adhoc-only — named agents are exempt. */
   lastAccessedAt: number;
+  /** The first-turn spawn while it is still running. A caller that abandons the
+   *  spawn on its own deadline leaves this behind, so the next caller on the key
+   *  awaits the SAME spawn instead of starting a second one. Two spawns on one
+   *  entry would each set `entry.pty`, orphaning whichever landed first — a
+   *  claude process plus its MCP fleet with no path to `dispose()`, since only
+   *  the entry is tracked in `state.ptys`. Cleared once the spawn settles, so a
+   *  failed spawn can be retried by a later turn. */
+  spawnInFlight?: Promise<void>;
   /** Wall-clock at the most recent spawn (or respawn). Used by `reapIdle` to
    *  time out PTYs that never complete a first turn after a (re)spawn
    *  (issue #65 item 6). Reset on every respawn so a healthy long-lived PTY
@@ -1425,17 +1433,26 @@ async function runTurnWithRetries(
   // `getOrCreateEntry` does not spawn; the only `spawnEntry` call reachable on
   // the first-turn path is this one.
   if (!entry.pty) {
+    // Abandoning the wait must not abandon ownership: keep the in-flight spawn
+    // on the entry so the next caller awaits THIS one rather than starting a
+    // second. Cleared on settle so a failed spawn stays retryable.
+    if (!entry.spawnInFlight) {
+      const inFlight = spawnEntry(
+        entry,
+        callOpts.modelOverride,
+        callOpts.api,
+        callOpts.securityArgs,
+        callOpts.appendSystemPrompt,
+      ).finally(() => {
+        if (entry.spawnInFlight === inFlight) entry.spawnInFlight = undefined;
+      });
+      // A caller that walks away leaves nobody awaiting this; keep its rejection
+      // from surfacing unhandled. Real callers still see it through their own await.
+      inFlight.catch(() => {});
+      entry.spawnInFlight = inFlight;
+    }
     try {
-      await withDeadline(
-        spawnEntry(
-          entry,
-          callOpts.modelOverride,
-          callOpts.api,
-          callOpts.securityArgs,
-          callOpts.appendSystemPrompt,
-        ),
-        callOpts.timeoutMs,
-      );
+      await withDeadline(entry.spawnInFlight, callOpts.timeoutMs);
     } catch (err) {
       if (err instanceof DeadlineExceeded) {
         return errorResult(


### PR DESCRIPTION
Closes the second half of #369 — the part that issue calls "separately confirmed"
and "worth fixing on its own merits". The concurrency discriminator
(single/sequential fails, three concurrent pass) is **not** addressed here and
#369 stays open for it.

## What was unbounded

`timeoutMs` is consumed inside `runTurnWithRetries`, so it bounds the **turn**.
Three waits ran ahead of it with no deadline of their own, and a stall in any of
them was an unbounded hang rather than a recoverable timeout — the caller's own
timeout elapsed and nothing fired.

**One correction to the issue's diagnosis.** #369 attributes the stall to
`admitEntry` → `getOrCreateEntry`, "which spawns and boots claude plus the MCP
fleet". `getOrCreateEntry` does not spawn. The only `spawnEntry` call reachable
on the first-turn path is inside `runTurnWithRetries`, ahead of the retry loop
that applies `timeoutMs`. That is the path behind *"given `timeoutMs: 600_000` it
sat the full 600s"*.

Bounded now, each by the caller's own `timeoutMs`:

| Stage | Was |
|---|---|
| supervisor init + admission (lock wait, concurrency gate) | unbounded |
| the wait on the previous turn's per-entry lock | unbounded |
| the lazy PTY spawn that boots claude and the MCP fleet | unbounded |

Each failure returns `errorResult` naming the stage, matching the existing
contract that `execClaude` reads as any other non-zero exit.

## Two ways this went wrong before it went right

Both were caught by adversarial review, and both are now covered by a test that
was **verified to fail without its fix**.

**1. Bounding the lock wait broke the serialisation it was bounding.** Releasing
the installed lock on the timeout path handed the chain to the next caller while
the predecessor's turn was still running — two turns on one PTY, interleaved
writes and reads. On timeout the call now abandons its own wait but leaves the
chain intact (`void previousLock.finally(release)`), so successors keep queueing
behind the turn that is still running. Test asserts max-in-flight turns is 1;
without the fix it reports 2.

**2. Bounding the spawn abandoned ownership of it.** The lock released with
`entry.pty` still null, so the next caller hit `if (!entry.pty)` and started a
**second** spawn. Both land, each sets `entry.pty`, and whichever arrived first
becomes unreachable — a claude process plus its whole MCP fleet with no path to
`dispose()`, since only the entry is tracked in `state.ptys`. Both also share the
pre-allocated session id. The in-flight spawn now lives on the entry so a later
caller awaits **that** spawn; cleared on settle, so a failed spawn stays
retryable. Test asserts a single spawn across a timeout and a following caller;
without the fix it reports 2.

## On the bound itself

`timeoutMs` is a **per-stage** bound, not a total: admission, the lock wait, the
spawn and each of `maxRetries + 1` turns are each bounded by it, so the worst case
is a multiple of `timeoutMs`. The retry multiplication predates this change; what
changes is that the stages ahead of the retry loop are bounded at all. A separate
decision about an overall call deadline would be reasonable.

`withDeadline` bounds the **wait**, not the work — there is no cancellation to
hand the underlying promise, so it keeps running. For admission that is the right
shape: a spawn that eventually completes leaves a usable entry for the next call.
The timer is `unref`'d and cleared, and a late rejection is swallowed so it cannot
surface unhandled after the caller has returned.

## Verification

- `bun run lint` — no errors
- `bun run typecheck` — 153 errors, baseline 153, no regression
- CI suites — **1662 pass / 0 fail**
- Full `bun test` measured against the merge base — **0 new failures, 1 fixed**
- `src/__tests__/pty-supervisor.test.ts` **added to the CI path list**: 51 tests,
  0 fail, verified stable 5/5 across repeat runs in ~1s. It is the suite covering
  the spawn and lock paths this change bounds — without it a regression in the
  deadlines lands with nothing in CI to catch it.

## Follow-up

#385 — `respawnEntryWithRetries` is still unbounded on the crash-recovery path.
Same hang class, one loop later, deliberately out of scope here.
