### PR TITLE
fix(pty): read the turn-summary line and the ✳ title as turn completion — claude ≥ 2.1.246 never repaints the idle footer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.243",
+      "version": "2.2.244",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.243",
+  "version": "2.2.244",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/pty-output-parser.test.ts
+++ b/src/__tests__/pty-output-parser.test.ts
@@ -422,6 +422,160 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     expect(qEvs[0]!.type).toBe("quiet");
   });
 
+  test("issue #369: claude 2.1.269 never repaints the idle footer after a turn — the turn-summary line (`for 1s · done 16:36`) opens the gate instead", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-369-summary";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    let now = 1000;
+    // Boot banner, painted BEFORE the prompt: carries the footer hint. On
+    // 2.1.269 this is the only time the hint is ever painted.
+    feed(
+      parser,
+      enc.encode(
+        "\x1b[2C\x1b[1B⏵⏵\x1b[6Gbypass\x1b[13Gpermissions\x1b[25Gon\x1b[28G(shift+tab\x1b[39Gto\x1b[42Gcycle)",
+      ),
+      now,
+    );
+    startTurn(parser, uuid, sentinelBytes, now); // #316: footerTail emptied here
+
+    // Bytes captured verbatim from a real 2.1.269 PTY (issue #369 repro):
+    // spinner + mid-turn verb — activity gate opens, turn is NOT done.
+    feed(
+      parser,
+      enc.encode(
+        "❯ Reply with exactly the word ACK and nothing else.\n✻ Swooping…\n\n· esc to interrupt",
+      ),
+      now,
+    );
+    feed(
+      parser,
+      enc.encode("\x1b[?25l\x1b[H\n\x1b[2C\x1b[23BGalloping…\x1b[30;1H\x1b[27;3H\x1b[?25h"),
+      now,
+    );
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+    now += 200;
+    expect(tick(parser, now)).toEqual([]); // mid-turn quiet stays withheld (#316)
+
+    // The answer, then the turn-summary line claude paints on completion —
+    // words positioned by CHA, exactly as 2.1.269 emits them. No footer
+    // repaint follows, ever.
+    feed(parser, enc.encode("ACK\n"), now);
+    feed(
+      parser,
+      enc.encode(
+        "\x1b]0;✳ Ack response\x07\x1b[?25l\x1b[H\n\x1b[10B✻\x1b[3GSautéed\x1b[11Gfor\x1b[15G1s\x1b[18G·\x1b[20Gdone\x1b[25G16:36\n\x1b[13B\x1b[K\n\x1b[48C\x1b[6B\x1b[K\x1b[30;1H\x1b[27;3H\x1b[?25h",
+      ),
+      now,
+    );
+    expect(tick(parser, now + 50)).toEqual([]); // still inside the quiet window
+
+    // Pre-fix: withheld forever (no "tab to cycle" since startTurn) → the
+    // turn only died on the 120 s hard timeout, three times over (~369 s).
+    const qEvs = tick(parser, now + 200);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]!.type).toBe("quiet");
+  });
+
+  test("issue #369: the bare word 'done' in prose does NOT open the gate — only the full summary shape does", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-369-prose";
+    startTurn(parser, uuid, encodeSentinel(buildSentinel(uuid)), 1000);
+    feed(parser, enc.encode("✻ Working… esc to interrupt"), 1000);
+    feed(
+      parser,
+      enc.encode("The migration is done. It ran for 3s and is done now at 16:36."),
+      1000,
+    );
+    expect(tick(parser, 1500)).toEqual([]);
+    // `done` next to a clock, and `done` between middle dots — still prose.
+    feed(parser, enc.encode("Ticket marked done 16:36 by the bot. Status · done · next up."), 1000);
+    expect(tick(parser, 1500)).toEqual([]);
+    // A mid-turn status with duration + tokens (tool wait) is not a summary either.
+    feed(parser, enc.encode("✻ Galloping… (12s · ↓ 40 tokens) esc to interrupt"), 1500);
+    expect(tick(parser, 2000)).toEqual([]);
+    // Longer turns and a 12 h clock: `for 1h 5m · done 4:36 PM` is the same
+    // shape and must open it.
+    feed(
+      parser,
+      enc.encode(
+        "✻\x1b[3GBaked\x1b[9Gfor\x1b[13G1h\x1b[16G5m\x1b[19G·\x1b[21Gdone\x1b[26G4:36\x1b[31GPM",
+      ),
+      2000,
+    );
+    const qEvs = tick(parser, 2200);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]!.type).toBe("quiet");
+  });
+
+  test("issue #369: the renderer skipped cells inside 'done' (`do\\x1b[22Ge`) — the ✳ window title still opens the gate", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-369-celldiff";
+    startTurn(parser, uuid, encodeSentinel(buildSentinel(uuid)), 1000);
+    feed(parser, enc.encode("✻ Cooking…\n· esc to interrupt"), 1000);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+    // Captured verbatim (pty-dump-full, second turn of one process): the `n`
+    // of `done` was already on screen, so the renderer did not paint it. The
+    // summary regex cannot match this — and pre-fix nothing else could either.
+    feed(
+      parser,
+      enc.encode(
+        "\x1b]0;✳ Alpha then bravo\x07\x1b[?25l\x1b[H\n\x1b[10B✻\x1b[3GCooked for 4s · do\x1b[22Ge 16:47\n\x1b[?25h",
+      ),
+      1000,
+    );
+    const qEvs = tick(parser, 1200);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]?.type).toBe("quiet");
+  });
+
+  test("issue #369: a ◐/◑ window title (turn running) does NOT open the gate; only the ✳ one does", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-369-title";
+    startTurn(parser, uuid, encodeSentinel(buildSentinel(uuid)), 1000);
+    feed(parser, enc.encode("\x1b]0;◐ Alpha\x07✻ Burrowing… esc to interrupt"), 1000);
+    expect(tick(parser, 1200)).toEqual([]);
+    feed(parser, enc.encode("\x1b]0;◑ Alpha\x07 (3s · ↓ 12 tokens)"), 1200);
+    expect(tick(parser, 1400)).toEqual([]);
+    feed(parser, enc.encode("\x1b]0;✳ Alpha\x07"), 1400);
+    const qEvs = tick(parser, 1600);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]?.type).toBe("quiet");
+  });
+
+  test("issue #369: the classic renderer repaints `(shift+tab to cycle) · esc to interrupt` every frame mid-turn — that line must NOT count as the idle footer", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-369-classic";
+    startTurn(parser, uuid, encodeSentinel(buildSentinel(uuid)), 1000);
+    // First frame after the prompt, captured from a classic-renderer session:
+    // spinner + the footer line carrying BOTH hints. Pre-fix this opened the
+    // gate on the first byte of the turn (the #316 hole, again).
+    feed(
+      parser,
+      enc.encode(
+        "❯ Reply with the single word: alpha\r\n✶ Burrowing…\r\n⏵⏵ bypass permissions on (shift+tab\x1b[39Gto\x1b[42Gcycle)\x1b[49G·\x1b[51Gesc\x1b[55Gto\x1b[58Ginterrupt\r",
+      ),
+      1000,
+    );
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+    expect(tick(parser, 1200)).toEqual([]);
+    expect(tick(parser, 6000)).toEqual([]);
+    // Turn completes: the same line is repainted with the hint alone.
+    feed(
+      parser,
+      enc.encode("alpha\r\n⏵⏵ bypass permissions on (shift+tab\x1b[39Gto\x1b[42Gcycle)\x1b[83G●\r"),
+      6000,
+    );
+    const qEvs = tick(parser, 6200);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]?.type).toBe("quiet");
+  });
+
   test("issue #316: idle footer is detected even when CUF sequences render the inter-word space", () => {
     const enc = new TextEncoder();
     const parser = createParser({ quietWindowMs: 100 });

--- a/src/runner/pty-output-parser.ts
+++ b/src/runner/pty-output-parser.ts
@@ -306,7 +306,85 @@ export function feed(parser: Parser, chunk: Uint8Array, now: number): ParserEven
 function hasIdleReplFooter(parser: Parser): boolean {
   if (parser.footerTail.length === 0) return false;
   const text = stripAnsi(expandCursorForwardToSpaces(_footerDecoder.decode(parser.footerTail)));
-  return text.toLowerCase().includes("tab to cycle");
+  // Issue #369 (adversarial pass): claude's *classic* renderer — the one it
+  // falls back to after a fullscreen boot strike — repaints the footer every
+  // frame, and while a turn runs that line reads
+  // `(shift+tab to cycle) · esc to interrupt`. Taken as the idle hint, that
+  // opened the gate from the first byte of the turn, i.e. the #316 hole again.
+  // The idle line carries the hint alone; the busy line carries both. Judge
+  // per line, not on the whole tail: the fullscreen renderer's prompt-time
+  // `· esc to interrupt` paint is a *different* line that can still sit in
+  // the 2048-byte tail when the turn completes.
+  for (const line of text.split(/[\r\n]+/)) {
+    const lower = line.toLowerCase();
+    if (lower.includes("tab to cycle") && !lower.includes("esc to interrupt")) return true;
+  }
+  return false;
+}
+
+/**
+ * claude's window title (OSC 0, `\x1b]0;<glyph> <summary>\x07`) — the glyph is
+ * ◐/◑ while a turn is running and ✳ once the turn has completed (and once at
+ * boot, which `startTurn` discards with the rest of the pre-turn tail).
+ * Measured on 2.1.269 over 12 real turns: the ✳ title lands in the same chunk
+ * as the turn-summary line, 12/12, and never mid-turn.
+ *
+ * Why a third signal: the renderer paints only the cells that changed, and
+ * one summary out of twelve was emitted as `… · do\x1b[22Ge 16:47` — the
+ * `n` was already on screen — which `TURN_DONE_SUMMARY_RE` cannot see. An
+ * OSC string is emitted whole; it is not subject to cell diffing. The parser
+ * header records that OSC 0 was unreliable as a turn signal on 2.1.89 (#81);
+ * that was re-measured on 2.1.269 for this, not assumed. Raw bytes on purpose:
+ * `stripAnsi` removes OSC sequences, so this looks before normalisation.
+ */
+const IDLE_TITLE_BYTES = new TextEncoder().encode("\x1b]0;✳");
+
+function hasIdleTitle(parser: Parser): boolean {
+  const tail = parser.footerTail;
+  const n = IDLE_TITLE_BYTES.length;
+  if (tail.length < n) return false;
+  outer: for (let i = 0; i <= tail.length - n; i++) {
+    for (let j = 0; j < n; j++) {
+      if (tail[i + j] !== IDLE_TITLE_BYTES[j]) continue outer;
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * The turn-summary line claude paints when a turn genuinely completes —
+ * `✻ Sautéed for 1s · done 16:36` (the verb varies per turn; the shape does
+ * not). Issue #369: claude ≥ 2.1.246 paints the mode-cycler footer ONCE at
+ * boot and never repaints it after a turn — it redraws in place, by absolute
+ * cursor position, touching only the lines that changed. `startTurn` empties
+ * `footerTail` on purpose (#316), so on those CLIs `hasIdleReplFooter` can
+ * never open again: `quiet` never fires, the sentinel is never written, and
+ * the turn only ends on the hard `timeoutMs` — three retries later, ~369 s.
+ * Measured on 2.1.269: the answer lands in ~2 s, the summary line 12/12 turns,
+ * the footer 0/12 after the prompt.
+ *
+ * This summary is the completion signal the modern TUI does emit. It is absent
+ * during a mid-turn tool/sub-agent wait, which paints `<verb>… (Ns · ↓N tokens)
+ * esc to interrupt` instead — so it cannot re-open the #316 hole.
+ *
+ * The match is deliberately the whole shape — duration, the middle dot, `done`
+ * and a clock — not the bare word `done`, which appears in ordinary prose (the
+ * #316 fixture itself contains "done."). Words are separated by CHA/CUF moves
+ * on 2.1.220+, so the tail is normalised the same way the footer gate does it.
+ * Prose can still forge it (`ran for 45s · done 14:02`) — the same class of
+ * risk #316 accepted for "tab to cycle"; the ✳ title below does not share it.
+ */
+// Duration shapes seen or plausible: `1s`, `2.5s`, `1m 20s`, `1h 5m`. The
+// clock may be 24 h (`16:36`) or 12 h (`4:36 PM`); the boundary after the
+// minutes covers both.
+const TURN_DONE_SUMMARY_RE =
+  /\bfor \d+(?:[.,]\d+)?\s?(?:s|m|h|min)(?:\s\d+\s?(?:s|m|min))* · done \d{1,2}:\d{2}\b/;
+
+function hasTurnDoneSummary(parser: Parser): boolean {
+  if (parser.footerTail.length === 0) return false;
+  const text = stripAnsi(expandCursorForwardToSpaces(_footerDecoder.decode(parser.footerTail)));
+  return TURN_DONE_SUMMARY_RE.test(text);
 }
 
 /**
@@ -346,7 +424,12 @@ export function tick(parser: Parser, now: number): ParserEvent[] {
   // treat quiet as turn-completion once the idle REPL footer is showing, so a
   // mid-turn tool-wait quiet no longer completes the turn prematurely. The
   // outer turn timeout remains the backstop if a future CLI renames the hint.
-  if (!hasIdleReplFooter(parser)) return [];
+  // Issue #369: on claude ≥ 2.1.246 the idle footer is never repainted after a
+  // turn; the turn-summary line (`… for 1s · done 16:36`) and the ✳ window
+  // title are the completion signals those CLIs do paint. Any one opens the gate.
+  if (!hasIdleReplFooter(parser) && !hasTurnDoneSummary(parser) && !hasIdleTitle(parser)) {
+    return [];
+  }
   if (now - parser.lastByteAt < parser.quietWindowMs) return [];
   parser.quietEmitted = true;
   return [{ type: "quiet", offset: parser.totalBytes }];

--- a/src/runner/pty-process.ts
+++ b/src/runner/pty-process.ts
@@ -49,6 +49,26 @@ import {
 // pull it from `pty-process` (and through `runner/index`) keep working without
 // loading bun-pty just to get the helper.
 import { sanitizePtyPromptText } from "./pty-prompt-sanitizer";
+import { appendFileSync } from "node:fs";
+
+/**
+ * Raw PTY trace, off unless `CLAUDECLAW_PTY_DUMP=<file>` is set. Every chunk
+ * claude emits and every write we make lands in the file, timestamped, with
+ * the parser state at that instant. Issue #369 was found this way: a
+ * standalone capture harness reproduces claude's boot but not our input
+ * protocol, so its silence says nothing about the daemon (see the issue's
+ * caveat) — this trace is the daemon's own bytes. Best-effort: a failed write
+ * never touches the turn.
+ */
+function dumpPtyTrace(tag: string, payload: string): void {
+  const file = process.env.CLAUDECLAW_PTY_DUMP;
+  if (!file) return;
+  try {
+    appendFileSync(file, `\n@@${new Date().toISOString()} ${tag}\n${payload}`, { mode: 0o600 });
+  } catch {
+    /* diagnostic only */
+  }
+}
 export { sanitizePtyPromptText };
 
 // ─── Public types (FROZEN per SPEC §3.1) ────────────────────────────────────
@@ -506,6 +526,10 @@ class PtyProcessImpl implements PtyProcess {
     // bun-pty delivers strings; re-encode for the byte-level parser.
     const bytes = new TextEncoder().encode(data);
     const now = this._now();
+    dumpPtyTrace(
+      `<< pid=${this._pid} state=${this._parser.state} turn=${this._turnInProgress} n=${bytes.length}`,
+      data,
+    );
     if (this._firstDataAt === 0) this._firstDataAt = now;
 
     // Buffer for the current turn (so idle-fallback can return content).
@@ -629,6 +653,7 @@ class PtyProcessImpl implements PtyProcess {
     // Write prompt + CR (TUI submits on Enter). Sanitize embedded CR/LF so
     // they don't submit mid-prompt.
     try {
+      dumpPtyTrace(`>> pid=${this._pid} write prompt`, `${JSON.stringify(prompt).slice(0, 80)}+CR`);
       this._pty.write(sanitizePtyPromptText(prompt) + "\r");
     } catch (err) {
       this._turnInProgress = false;
@@ -674,6 +699,7 @@ class PtyProcessImpl implements PtyProcess {
     if (!this._turnInProgress || !this._activeSentinelBytes) return;
     if (this._parser.state !== "accumulating") return;
     try {
+      dumpPtyTrace(`>> pid=${this._pid} write sentinel`, "");
       this._pty.write(this._activeSentinelString);
     } catch (err) {
       this._rejectTurn(err instanceof Error ? err : new Error(String(err)));


### PR DESCRIPTION
Second half of #369 — the single/sequential `runOnPty` stall. (#386 bounded the admission stage; this is the turn itself.)

## What was happening

Captured from the daemon's own PTY bytes (new `CLAUDECLAW_PTY_DUMP` trace) on claude 2.1.269: the answer lands in ~2 s, then nothing until the 120 s hard timeout — three times, ~369 s.

The #316 quiet gate needs claude's idle footer (`tab to cycle`) repainted **after** `startTurn`, which empties `footerTail` on purpose. Since 2.1.246 the fullscreen renderer paints that footer once at boot and never again — it redraws in place by absolute cursor position, only the cells that changed. Measured over 14 fullscreen turns: footer after the prompt 0/14, answer 14/14. So `quiet` never fires, the sentinel is never written, and only `timeoutMs` ends the turn.

## The fix

Two completion signals those CLIs do paint, and never mid-turn (mid-turn is `<verb>… (Ns · ↓N tokens) esc to interrupt` with a ◐/◑ title):

1. **Turn-summary line** — `✻ Sautéed for 1s · done 16:36`, matched as the whole shape (duration · done clock), not the word `done`.
2. **Window title** — OSC 0 `\x1b]0;✳ …\x07`. ✳ only once the turn completed; 14/14, same chunk as the summary. This one survives cell diffing: one summary in the captures was painted as `… · do\x1b[22Ge 16:47` (the `n` was already on screen). An OSC string is emitted whole. The parser header says OSC 0 was unreliable on 2.1.89 (#81) — re-measured on 2.1.269 for this.

The gate now opens on the footer, the summary, or the ✳ title.

Also fixed, found by the adversarial pass: the **classic** renderer (fallback after a fullscreen boot strike) repaints the footer every frame as `(shift+tab to cycle) · esc to interrupt` while the turn runs. The old check took it for the idle hint and opened the gate on the first byte — the #316 hole, pre-existing. The hint now only counts on a line without `esc to interrupt`, judged per line.

## Evidence

Real-claude integration suite, 2.1.269, before → after:

| test | before | after |
|---|---|---|
| happy path (single) | 376 881 ms FAIL | 6 649 ms PASS |
| concurrent isolation | 377 615 ms FAIL | 6 969 ms PASS |
| sentinel-echo, two sequential turns | never reached | 11 688 ms PASS (summary 2/2, ✳ 2/2) |

Tests 11/12 of the issue's table — the ones that ran last and still failed — pass. Cold start was never the variable.

Five unit tests pin it with bytes captured verbatim (CHA-positioned words, the cell-skipped `do…e`, the classic busy footer). Each signal and each guard has a mutation that turns exactly one of them red. Full suite: 0 new failures vs `main`.

## Notes

- `CLAUDECLAW_PTY_DUMP=<file>`: timestamped 0600 trace of every chunk claude emits and every write the daemon makes, with parser state. Off unless set. It is what found this — the issue's caveat about standalone harnesses is exactly right.
- Observed, not addressed: on this box 2.1.269 leaves no `~/.claude/projects/<cwd>/<id>.jsonl` for these PTY sessions, so the "resume smoke" test now fails at session discovery instead of at 369 s. Separate question.
- The concurrency discriminator on 2.1.220 is consistent with boot timing (three simultaneous boots are slow enough for the footer paint to land after the prompt write; a lone warm boot is not) — inferred, not measured on that CLI.

Refs #369
